### PR TITLE
Fix issue when building the jar with encode() function

### DIFF
--- a/src/main/java/org/petapico/nanobench/ApiCall.java
+++ b/src/main/java/org/petapico/nanobench/ApiCall.java
@@ -68,8 +68,12 @@ public class ApiCall {
 			paramString = "?";
 			for (String k : params.keySet()) {
 				if (paramString.length() > 1) paramString += "&";
-				paramString += k + "=";
-				paramString += URLEncoder.encode(params.get(k), Charsets.UTF_8);
+				try {
+					paramString += k + "=";
+					paramString += URLEncoder.encode(params.get(k), Charsets.UTF_8.toString());
+				} catch (java.io.UnsupportedEncodingException e) {
+					e.printStackTrace();
+				}
 			}
 		}
 	}

--- a/src/main/java/org/petapico/nanobench/NanobenchLink.java
+++ b/src/main/java/org/petapico/nanobench/NanobenchLink.java
@@ -15,38 +15,42 @@ public class NanobenchLink extends Panel {
 
 	public NanobenchLink(String id, String uri, Nanopub np) {
 		super(id);
-		if (np != null && uri.equals(np.getUri().stringValue())) {
-			ExternalLink link = new ExternalLink("link", "./explore?id=" + URLEncoder.encode(uri, Charsets.UTF_8), "this");
-			link.add(new AttributeAppender("style", "background: #666; color: #fff; padding: 0 5px; border-radius: 7px;"));
-			add(link);
-			add(new Label("iri", uri));
-		} else if (np != null && uri.equals(np.getAssertionUri().stringValue())) {
-			ExternalLink link = new ExternalLink("link", "./explore?id=" + URLEncoder.encode(uri, Charsets.UTF_8), "this assertion");
-			link.add(new AttributeAppender("class", " nanopub-assertion "));
-			link.add(new AttributeAppender("style", "padding: 0 5px; border-radius: 7px; border-width: 1px; border-color: #666; border-style: solid;"));
-			add(link);
-			add(new Label("iri", uri));
-		} else if (uri.equals(Nanopub.HAS_ASSERTION_URI.stringValue())) {
-			ExternalLink link = new ExternalLink("link", "./explore?id=" + URLEncoder.encode(uri, Charsets.UTF_8), "assertion");
-			link.add(new AttributeAppender("class", " nanopub-assertion "));
-			link.add(new AttributeAppender("style", "padding: 0 5px; border-radius: 7px; border-width: 1px; border-color: #666; border-style: solid;"));
-			add(link);
-			add(new Label("iri", uri));
-		} else if (uri.equals(Nanopub.HAS_PROVENANCE_URI.stringValue())) {
-			ExternalLink link = new ExternalLink("link", "./explore?id=" + URLEncoder.encode(uri, Charsets.UTF_8), "provenance");
-			link.add(new AttributeAppender("class", " nanopub-provenance "));
-			link.add(new AttributeAppender("style", "padding: 0 5px; border-radius: 7px; border-width: 1px; border-color: #666; border-style: solid;"));
-			add(link);
-			add(new Label("iri", uri));
-		} else if (uri.equals(Nanopub.HAS_PUBINFO_URI.stringValue())) {
-			ExternalLink link = new ExternalLink("link", "./explore?id=" + URLEncoder.encode(uri, Charsets.UTF_8), "pubinfo");
-			link.add(new AttributeAppender("class", " nanopub-pubinfo "));
-			link.add(new AttributeAppender("style", "padding: 0 5px; border-radius: 7px; border-width: 1px; border-color: #666; border-style: solid;"));
-			add(link);
-			add(new Label("iri", uri));
-		} else {
-			add(new ExternalLink("link", "./explore?id=" + URLEncoder.encode(uri, Charsets.UTF_8), IriItem.getShortNameFromURI(uri)));
-			add(new Label("iri", uri));
+		try {
+			if (np != null && uri.equals(np.getUri().stringValue())) {
+				ExternalLink link = new ExternalLink("link", "./explore?id=" + URLEncoder.encode(uri, Charsets.UTF_8.toString()), "this");
+				link.add(new AttributeAppender("style", "background: #666; color: #fff; padding: 0 5px; border-radius: 7px;"));
+				add(link);
+				add(new Label("iri", uri));
+			} else if (np != null && uri.equals(np.getAssertionUri().stringValue())) {
+				ExternalLink link = new ExternalLink("link", "./explore?id=" + URLEncoder.encode(uri, Charsets.UTF_8.toString()), "this assertion");
+				link.add(new AttributeAppender("class", " nanopub-assertion "));
+				link.add(new AttributeAppender("style", "padding: 0 5px; border-radius: 7px; border-width: 1px; border-color: #666; border-style: solid;"));
+				add(link);
+				add(new Label("iri", uri));
+			} else if (uri.equals(Nanopub.HAS_ASSERTION_URI.stringValue())) {
+				ExternalLink link = new ExternalLink("link", "./explore?id=" + URLEncoder.encode(uri, Charsets.UTF_8.toString()), "assertion");
+				link.add(new AttributeAppender("class", " nanopub-assertion "));
+				link.add(new AttributeAppender("style", "padding: 0 5px; border-radius: 7px; border-width: 1px; border-color: #666; border-style: solid;"));
+				add(link);
+				add(new Label("iri", uri));
+			} else if (uri.equals(Nanopub.HAS_PROVENANCE_URI.stringValue())) {
+				ExternalLink link = new ExternalLink("link", "./explore?id=" + URLEncoder.encode(uri, Charsets.UTF_8.toString()), "provenance");
+				link.add(new AttributeAppender("class", " nanopub-provenance "));
+				link.add(new AttributeAppender("style", "padding: 0 5px; border-radius: 7px; border-width: 1px; border-color: #666; border-style: solid;"));
+				add(link);
+				add(new Label("iri", uri));
+			} else if (uri.equals(Nanopub.HAS_PUBINFO_URI.stringValue())) {
+				ExternalLink link = new ExternalLink("link", "./explore?id=" + URLEncoder.encode(uri, Charsets.UTF_8.toString()), "pubinfo");
+				link.add(new AttributeAppender("class", " nanopub-pubinfo "));
+				link.add(new AttributeAppender("style", "padding: 0 5px; border-radius: 7px; border-width: 1px; border-color: #666; border-style: solid;"));
+				add(link);
+				add(new Label("iri", uri));
+			} else {
+				add(new ExternalLink("link", "./explore?id=" + URLEncoder.encode(uri, Charsets.UTF_8.toString()), IriItem.getShortNameFromURI(uri)));
+				add(new Label("iri", uri));
+			}
+		} catch (java.io.UnsupportedEncodingException e) {
+			e.printStackTrace();
 		}
 	}
 

--- a/src/main/java/org/petapico/nanobench/NanopubItem.java
+++ b/src/main/java/org/petapico/nanobench/NanopubItem.java
@@ -44,21 +44,29 @@ public class NanopubItem extends Panel {
 		}
 		add(new Label("user", userString));
 
-		ExternalLink retractLink = new ExternalLink("retract-link", "./publish?" +
-				"template=http://purl.org/np/RAvySE8-JDPqaPnm_XShAa-aVuDZ2iW2z7Oc1Q9cfvxZE&" +
-				"param_nanopubToBeRetracted=" + URLEncoder.encode(n.getUri(), StandardCharsets.UTF_8));
-		if (ProfilePage.getUserIri() != null && user != null && ProfilePage.getUserIri().equals(user.getId())) {
-			retractLink.add(new Label("retract-label", "retract"));
-		} else {
-			retractLink.add(new Label("retract-label", ""));
+		try {
+			ExternalLink retractLink = new ExternalLink("retract-link", "./publish?" +
+					"template=http://purl.org/np/RAvySE8-JDPqaPnm_XShAa-aVuDZ2iW2z7Oc1Q9cfvxZE&" +
+					"param_nanopubToBeRetracted=" + URLEncoder.encode(n.getUri(), StandardCharsets.UTF_8.toString()));
+			if (ProfilePage.getUserIri() != null && user != null && ProfilePage.getUserIri().equals(user.getId())) {
+				retractLink.add(new Label("retract-label", "retract"));
+			} else {
+				retractLink.add(new Label("retract-label", ""));
+			}
+			add(retractLink);
+		} catch (java.io.UnsupportedEncodingException e) {
+			e.printStackTrace();
 		}
-		add(retractLink);
 
-		ExternalLink commentLink = new ExternalLink("comment-link", "./publish?" +
-				"template=http://purl.org/np/RAqfUmjV05ruLK3Efq2kCODsHfY16LJGO3nAwDi5rmtv0&" +
-				"param_thing=" + URLEncoder.encode(n.getUri(), StandardCharsets.UTF_8));
-//		commentLink.add(new Label("comment-label", "comment"));
-		add(commentLink);
+		try {
+			ExternalLink commentLink = new ExternalLink("comment-link", "./publish?" +
+					"template=http://purl.org/np/RAqfUmjV05ruLK3Efq2kCODsHfY16LJGO3nAwDi5rmtv0&" +
+					"param_thing=" + URLEncoder.encode(n.getUri(), StandardCharsets.UTF_8.toString()));
+	//		commentLink.add(new Label("comment-label", "comment"));
+			add(commentLink);
+		} catch (java.io.UnsupportedEncodingException e) {
+			e.printStackTrace();
+		}
 
 		String positiveNotes = "";
 		String negativeNotes = "";

--- a/src/main/java/org/petapico/nanobench/Template.java
+++ b/src/main/java/org/petapico/nanobench/Template.java
@@ -335,7 +335,7 @@ public class Template implements Serializable {
 
 	private void getPossibleValuesFromApi(String apiString, String searchterm, Map<String,String> labelMap, List<String> values) {
 		try {
-			HttpGet get = new HttpGet(apiString + URLEncoder.encode(searchterm, StandardCharsets.UTF_8));
+			HttpGet get = new HttpGet(apiString + URLEncoder.encode(searchterm, StandardCharsets.UTF_8.toString()));
 			
 			// Quick fix to resolve Nanopubs grlc API as JSON
 			// Otherwise call fails if no ACCEPT header provided
@@ -348,7 +348,7 @@ public class Template implements Serializable {
 
 			if (resp.getStatusLine().getStatusCode() == 405) {
 				// Method not allowed, trying POST
-				HttpPost post = new HttpPost(apiString + URLEncoder.encode(searchterm, StandardCharsets.UTF_8));
+				HttpPost post = new HttpPost(apiString + URLEncoder.encode(searchterm, StandardCharsets.UTF_8.toString()));
 				resp = HttpClientBuilder.create().build().execute(post);
 			}
 			// TODO: support other content types (CSV, XML, ...)


### PR DESCRIPTION
The `encode()` function requires string, not CharSet:
* Added `.toString()`
* Added try catch UnsupportedEncodingException

Issue faced when running the pre-compiled `jar` file with following setup:

```
openjdk version "1.8.0_265"
OpenJDK Runtime Environment (build 1.8.0_265-8u265-b01-0ubuntu2~18.04-b01)
OpenJDK 64-Bit Server VM (build 25.265-b01, mixed mode)
```