### PR TITLE
Add OLS API concepts/properties resolution in Nanopublications Templates

### DIFF
--- a/src/main/java/org/petapico/nanobench/Template.java
+++ b/src/main/java/org/petapico/nanobench/Template.java
@@ -368,7 +368,7 @@ public class Template implements Serializable {
 				for (int i = 0; i < responseArray.length(); i++) {
 					String uri = responseArray.getJSONObject(i).getString("iri");
 					String label = responseArray.getJSONObject(i).getString("label");
-					if (!values.contains("uri")) {
+					if (!values.contains(uri)) {
 						values.add(uri);
 						labelMap.put(uri, label);
 					}

--- a/src/main/java/org/petapico/nanobench/Template.java
+++ b/src/main/java/org/petapico/nanobench/Template.java
@@ -360,6 +360,19 @@ public class Template implements Serializable {
 
 			if (apiString.startsWith("http://purl.org/nanopub/api/")) {
 				parseNanopubGrlcApi(json, labelMap, values);
+			} else if (apiString.startsWith("https://www.ebi.ac.uk/ols/api/select")) {
+				// Resolve EBI Ontology Lookup Service
+				// e.g. https://www.ebi.ac.uk/ols/api/select?q=interacts%20with 
+				// response.docs.[].iri/label
+				JSONArray responseArray = json.getJSONObject("response").getJSONArray("docs");
+				for (int i = 0; i < responseArray.length(); i++) {
+					String uri = responseArray.getJSONObject(i).getString("iri");
+					String label = responseArray.getJSONObject(i).getString("label");
+					if (!values.contains("uri")) {
+						values.add(uri);
+						labelMap.put(uri, label);
+					}
+				}
 			} else {
 				// TODO: create parseJsonApi() ?
 				boolean foundId = false;
@@ -404,6 +417,7 @@ public class Template implements Serializable {
 				if (foundId == false) {
 					// ID key not found, try to get results for following format
 					// {result1: ["label 1", "label 2"], result2: ["label 3", "label 4"]}
+					// Aims to resolve https://name-resolution-sri.renci.org/docs#
 					for (String key : json.keySet()) {
 						if (!(json.get(key) instanceof JSONArray)) continue;
 						JSONArray labelArray = json.getJSONArray(key);


### PR DESCRIPTION
I added a small block of code to resolve the EBI Ontology Lookup Service API in `Template.java`

It uses a `if` statement to check for OLS API URL, and grab the response to populate the select. So we can easily refactor this code as we wish later, maybe a small list of hadoc functions to resolve different types of APIs):

```java
} else if (apiString.startsWith("https://www.ebi.ac.uk/ols/api/select")) {
    // Resolve EBI Ontology Lookup Service
    // e.g. https://www.ebi.ac.uk/ols/api/select?q=interacts%20with 
    // response.docs.[].iri/label
    JSONArray responseArray = json.getJSONObject("response").getJSONArray("docs");
    for (int i = 0; i < responseArray.length(); i++) {
        String uri = responseArray.getJSONObject(i).getString("iri");
        String label = responseArray.getJSONObject(i).getString("label");
        if (!values.contains(uri)) {
            values.add(uri);
            labelMap.put(uri, label);
        }
    }
}
```

It can be implemented this way in a template:

```turtle
:uri a nt:GuidedChoicePlaceholder ;
    nt:possibleValuesFromApi "https://www.ebi.ac.uk/ols/api/select?q=" . 
```

Or only search in a specific ontology (e.g. the Relation Ontology `ro`): 

```turtle
:uri a nt:GuidedChoicePlaceholder ;
    nt:possibleValuesFromApi "https://www.ebi.ac.uk/ols/api/select?ontology=ro&q=" .
```

See this template as example: http://localhost:37373/publish?1&template=http://purl.org/np/RA8AXz5jnk5caKG-RnOT39_RD_WmPG4chQc2cBoiIzQ_U

The response time of the API is quite good! 

![nanobench_ols_api](https://user-images.githubusercontent.com/3778439/99707565-eaf32480-2a9c-11eb-974f-3579e1451169.png)
