### PR TITLE
Add a checkbox in the Search page to filter results of logged users

### DIFF
--- a/src/main/java/org/petapico/nanobench/SearchPage.html
+++ b/src/main/java/org/petapico/nanobench/SearchPage.html
@@ -20,6 +20,7 @@
 
 <form wicket:id="form">
 <input wicket:id="search" type="text" class="textfield" size="100" required />
+<label><input type="checkbox" wicket:id="filter" />Only show my nanopubs</label>
 </form>
 
 <h2>Results</h2>


### PR DESCRIPTION
When the box is checked, the results only show the nanopubs published by the logged user 

It could be extended to filtering based on a specific ORCID given by the user in a new input TextField

The feature has been discussed with @tkuhn and requested in this issue: https://github.com/peta-pico/nanobench/issues/54