### PR TITLE
Auto-fill Yasgui placeholders with entered parameter values

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/GrlcQuery.java
+++ b/src/main/java/com/knowledgepixels/nanodash/GrlcQuery.java
@@ -263,4 +263,84 @@ public class GrlcQuery implements Serializable {
         return l;
     }
 
+    // NOTE: The following methods are duplicated from nanopub-query's GrlcSpec.java.
+    // They should eventually be moved to nanopub-java to avoid duplication.
+
+    /**
+     * Expands the SPARQL query by substituting placeholder values from the given param fields.
+     * Unlike the server-side version in nanopub-query, missing mandatory params are simply skipped
+     * (not thrown as errors) to support partial substitution for the Yasgui link.
+     *
+     * @param paramFields the list of query parameter fields with user-entered values
+     * @return the expanded SPARQL query string
+     */
+    public String expandQuery(List<QueryParamField> paramFields) {
+        Map<String, QueryParamField> fieldMap = new HashMap<>();
+        for (QueryParamField f : paramFields) {
+            fieldMap.put(f.getParamName(), f);
+        }
+        String expandedQueryContent = sparql;
+        for (String ph : placeholdersList) {
+            String paramName = QueryParamField.getParamName(ph);
+            QueryParamField field = fieldMap.get(paramName);
+            if (field == null || !field.isSet()) continue;
+            if (QueryParamField.isMultiPlaceholder(ph)) {
+                String[] values = field.getValues();
+                StringBuilder valueList = new StringBuilder();
+                for (String v : values) {
+                    if (isIriPlaceholder(ph)) {
+                        valueList.append(serializeIri(v)).append(" ");
+                    } else {
+                        valueList.append(serializeLiteral(v)).append(" ");
+                    }
+                }
+                expandedQueryContent = expandedQueryContent.replaceAll(
+                    "values\\s*\\?" + ph + "\\s*\\{\\s*\\}",
+                    "values ?" + ph + " { " + escapeSlashes(valueList.toString()) + "}"
+                );
+            } else {
+                String val = field.getValues()[0];
+                if (isIriPlaceholder(ph)) {
+                    expandedQueryContent = expandedQueryContent.replaceAll("\\?" + ph + "(?![A-Za-z0-9_])", escapeSlashes(serializeIri(val)));
+                } else {
+                    expandedQueryContent = expandedQueryContent.replaceAll("\\?" + ph + "(?![A-Za-z0-9_])", escapeSlashes(serializeLiteral(val)));
+                }
+            }
+        }
+        return expandedQueryContent;
+    }
+
+    /**
+     * Returns true if all mandatory (non-optional) param fields have values set.
+     *
+     * @param paramFields the list of query parameter fields
+     * @return true if all mandatory fields are set
+     */
+    public static boolean allMandatoryFieldsSet(List<QueryParamField> paramFields) {
+        for (QueryParamField f : paramFields) {
+            if (!f.isOptional() && !f.isSet()) return false;
+        }
+        return true;
+    }
+
+    private static boolean isIriPlaceholder(String placeholder) {
+        return placeholder.endsWith("_iri");
+    }
+
+    private static String escapeLiteral(String s) {
+        return s.replace("\\", "\\\\").replace("\n", "\\n").replace("\"", "\\\"");
+    }
+
+    private static String serializeIri(String iriString) {
+        return "<" + iriString + ">";
+    }
+
+    private static String serializeLiteral(String literalString) {
+        return "\"" + escapeLiteral(literalString) + "\"";
+    }
+
+    private static String escapeSlashes(String string) {
+        return string.replace("\\", "\\\\");
+    }
+
 }

--- a/src/main/java/com/knowledgepixels/nanodash/page/QueryPage.html
+++ b/src/main/java/com/knowledgepixels/nanodash/page/QueryPage.html
@@ -41,7 +41,7 @@
 
 <p>
 <input type="submit" class="button" value="Run" />
-<a wicket:id="yasgui" href="." class="button light" target="_blank">Open in Yasgui</a>
+<button wicket:id="yasgui" type="submit" class="button light">Open in Yasgui</button>
 </p>
 </form>
 

--- a/src/main/java/com/knowledgepixels/nanodash/page/QueryPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/QueryPage.java
@@ -15,9 +15,12 @@ import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.markup.html.link.BookmarkablePageLink;
+import org.apache.wicket.markup.html.form.Button;
 import org.apache.wicket.markup.html.link.ExternalLink;
 import org.apache.wicket.markup.html.list.ListItem;
 import org.apache.wicket.markup.html.list.ListView;
+import org.apache.wicket.request.IRequestParameters;
+import org.apache.wicket.request.flow.RedirectToUrlException;
 import org.apache.wicket.markup.html.panel.FeedbackPanel;
 import org.apache.wicket.request.mapper.parameter.INamedParameters.NamedPair;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
@@ -124,14 +127,14 @@ public class QueryPage extends NanodashPage {
         WebMarkupContainer paramContainer = new WebMarkupContainer("params");
 
         paramFields = q.createParamFields("paramfield");
+        for (QueryParamField f : paramFields) {
+            for (StringValue parameter : parameters.getValues("queryparam_" + f.getParamName())) {
+                f.putValue(parameter.toString().replaceFirst("\\s*$", ""));
+            }
+        }
         paramContainer.add(new ListView<QueryParamField>("paramfields", paramFields) {
 
             protected void populateItem(ListItem<QueryParamField> item) {
-                QueryParamField f = item.getModelObject();
-                f.clearValue();
-                for (StringValue parameter : parameters.getValues("queryparam_" + f.getParamName())) {
-                    f.putValue(parameter.toString().replaceFirst("\\s*$", ""));
-                }
                 item.add(item.getModelObject());
             }
 
@@ -139,11 +142,29 @@ public class QueryPage extends NanodashPage {
         paramContainer.setVisible(!paramFields.isEmpty());
         form.add(paramContainer);
 
-        // Hack to prevent auto-execution:
-        String sparql = "'auto_execution_blocker: Fill in placeholders below if applicable, then remove this line to run the query'\n\n" + q.getSparql();
-        String editLink = q.getEndpoint().stringValue().replaceFirst("^.*/repo/", Utils.getMainQueryUrl() + "tools/") + "/yasgui.html#query=" + URLEncoder.encode(sparql, Charsets.UTF_8);
-        // TODO We also need to replace the nanopub-query placeholder service URLs in the query above.
-        form.add(new ExternalLink("yasgui", editLink));
+        form.add(new Button("yasgui") {
+
+            @Override
+            public void onSubmit() {
+                IRequestParameters params = getRequest().getPostParameters();
+                for (QueryParamField f : paramFields) {
+                    StringValue input = params.getParameterValue(f.getFormComponent().getInputName());
+                    f.clearValue();
+                    if (!input.isNull() && !input.isEmpty()) {
+                        f.putValue(input.toString());
+                    }
+                }
+                String sparql = q.expandQuery(paramFields);
+                boolean allSet = GrlcQuery.allMandatoryFieldsSet(paramFields);
+                if (!allSet) {
+                    sparql = "'auto_execution_blocker: Fill in placeholders below, then remove this line to run the query'\n\n" + sparql;
+                }
+                String editLink = q.getEndpoint().stringValue().replaceFirst("^.*/repo/", Utils.getMainQueryUrl() + "tools/")
+                    + "/yasgui.html#query=" + URLEncoder.encode(sparql, Charsets.UTF_8);
+                throw new RedirectToUrlException(editLink);
+            }
+
+        }.setDefaultFormProcessing(false));
 
         add(form);
 


### PR DESCRIPTION
## Summary
- When clicking "Open in Yasgui", user-entered parameter values are now substituted into the SPARQL query instead of leaving raw placeholders
- The `auto_execution_blocker` comment is only added when mandatory placeholders remain unfilled
- Changed the Yasgui link from a static `<a>` to a form `<button>` that reads current field values on click

Closes #370

## Test plan
- [ ] Open a query page with placeholders, fill in some values, click "Open in Yasgui" — filled values should appear in the SPARQL
- [ ] Fill in all mandatory values — the `auto_execution_blocker` line should be absent
- [ ] Leave all fields empty — behavior should match the previous static link (blocker + raw placeholders)
- [ ] Test with IRI and multi-value placeholders

🤖 Generated with [Claude Code](https://claude.com/claude-code)