### PR TITLE
fix: Fix race conditions in repository refresh and Space field visibility

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/domain/Space.java
+++ b/src/main/java/com/knowledgepixels/nanodash/domain/Space.java
@@ -84,8 +84,8 @@ public class Space extends AbstractResourceWithProfile {
         return id + " " + rootNanopubId;
     }
 
-    private boolean dataInitialized = false;
-    private boolean dataNeedsUpdate = true;
+    private volatile boolean dataInitialized = false;
+    private volatile boolean dataNeedsUpdate = true;
 
     Space(ApiResponseEntry resp) {
         super(resp.get("space"));

--- a/src/main/java/com/knowledgepixels/nanodash/repository/MaintainedResourceRepository.java
+++ b/src/main/java/com/knowledgepixels/nanodash/repository/MaintainedResourceRepository.java
@@ -48,29 +48,33 @@ public class MaintainedResourceRepository {
      * @param resp The API response containing maintained resource data.
      */
     public synchronized void refresh(ApiResponse resp) {
-        resourceList = new ArrayList<>();
-        resourcesById = new HashMap<>();
-        resourcesBySpace = new HashMap<>();
-        resourcesByNamespace = new HashMap<>();
+        List<MaintainedResource> newResourceList = new ArrayList<>();
+        Map<String, MaintainedResource> newResourcesById = new HashMap<>();
+        Map<Space, List<MaintainedResource>> newResourcesBySpace = new HashMap<>();
+        Map<String, MaintainedResource> newResourcesByNamespace = new HashMap<>();
         for (ApiResponseEntry entry : resp.getData()) {
             Space space = SpaceRepository.get().findById(entry.get("space"));
             if (space == null) {
                 continue;
             }
             MaintainedResource resource = MaintainedResourceFactory.getOrCreate(entry, space);
-            if (resourcesById.containsKey(resource.getId())) {
+            if (newResourcesById.containsKey(resource.getId())) {
                 continue;
             }
-            resourceList.add(resource);
-            resourcesById.put(resource.getId(), resource);
-            resourcesBySpace.computeIfAbsent(space, k -> new ArrayList<>()).add(resource);
+            newResourceList.add(resource);
+            newResourcesById.put(resource.getId(), resource);
+            newResourcesBySpace.computeIfAbsent(space, k -> new ArrayList<>()).add(resource);
             if (resource.getNamespace() != null) {
                 // TODO Handle conflicts when two resources claim the same namespace:
-                resourcesByNamespace.put(resource.getNamespace(), resource);
+                newResourcesByNamespace.put(resource.getNamespace(), resource);
             }
         }
-        MaintainedResourceFactory.removeStale(resourcesById.keySet());
+        MaintainedResourceFactory.removeStale(newResourcesById.keySet());
+        resourcesById = newResourcesById;
+        resourcesBySpace = newResourcesBySpace;
+        resourcesByNamespace = newResourcesByNamespace;
         loaded = true;
+        resourceList = newResourceList; // volatile write last — establishes happens-before for all above
     }
 
     /**
@@ -121,7 +125,9 @@ public class MaintainedResourceRepository {
             } catch (InterruptedException ex) {
                 logger.error("Interrupted", ex);
             }
-            refresh(ApiCache.retrieveResponseSync(new QueryRef(QueryApiAccess.GET_MAINTAINED_RESOURCES), true));
+            if (resourceList == null) { // double-check after potential wait
+                refresh(ApiCache.retrieveResponseSync(new QueryRef(QueryApiAccess.GET_MAINTAINED_RESOURCES), true));
+            }
         }
     }
 

--- a/src/main/java/com/knowledgepixels/nanodash/repository/SpaceRepository.java
+++ b/src/main/java/com/knowledgepixels/nanodash/repository/SpaceRepository.java
@@ -37,7 +37,7 @@ public class SpaceRepository {
     private Map<Space, Set<Space>> subspaceMap;
     private Map<Space, Set<Space>> superspaceMap;
     private boolean loaded = false;
-    private Long runRootUpdateAfter = null;
+    private volatile Long runRootUpdateAfter = null;
 
     private final Object loadLock = new Object();
 
@@ -51,27 +51,35 @@ public class SpaceRepository {
      */
     public synchronized void refresh(ApiResponse resp) {
         logger.info("Refreshing spaces from API response with {} entries", resp.getData().size());
-        spaceList = new ArrayList<>();
-        spaceListByType = new HashMap<>();
-        spacesById = new HashMap<>();
-        subspaceMap = new HashMap<>();
-        superspaceMap = new HashMap<>();
+        List<Space> newSpaceList = new ArrayList<>();
+        Map<String, List<Space>> newSpaceListByType = new HashMap<>();
+        Map<String, Space> newSpacesById = new HashMap<>();
+        Map<Space, Set<Space>> newSubspaceMap = new HashMap<>();
+        Map<Space, Set<Space>> newSuperspaceMap = new HashMap<>();
         for (ApiResponseEntry entry : resp.getData()) {
             Space space;
             space = SpaceFactory.getOrCreate(entry);
-            spaceList.add(space);
-            spaceListByType.computeIfAbsent(space.getType(), k -> new ArrayList<>()).add(space);
-            spacesById.put(space.getId(), space);
+            newSpaceList.add(space);
+            newSpaceListByType.computeIfAbsent(space.getType(), k -> new ArrayList<>()).add(space);
+            newSpacesById.put(space.getId(), space);
         }
-        SpaceFactory.removeStale(spacesById.keySet());
-        for (Space space : spaceList) {
-            Space superSpace = this.getIdSuperspace(space);
+        SpaceFactory.removeStale(newSpacesById.keySet());
+        for (Space space : newSpaceList) {
+            String id = space.getId();
+            if (!id.matches("https?://[^/]+/.*/[^/]*/?")) continue;
+            String superId = id.replaceFirst("(https?://[^/]+/.*)/[^/]*/?", "$1");
+            Space superSpace = newSpacesById.get(superId);
             if (superSpace == null) continue;
-            subspaceMap.computeIfAbsent(superSpace, k -> new HashSet<>()).add(space);
-            superspaceMap.computeIfAbsent(space, k -> new HashSet<>()).add(superSpace);
+            newSubspaceMap.computeIfAbsent(superSpace, k -> new HashSet<>()).add(space);
+            newSuperspaceMap.computeIfAbsent(space, k -> new HashSet<>()).add(superSpace);
             space.setDataNeedsUpdate();
         }
+        spacesById = newSpacesById;
+        spaceListByType = newSpaceListByType;
+        subspaceMap = newSubspaceMap;
+        superspaceMap = newSuperspaceMap;
         loaded = true;
+        spaceList = newSpaceList; // volatile write last — establishes happens-before for all above
     }
 
     /**
@@ -101,7 +109,9 @@ public class SpaceRepository {
             } catch (InterruptedException ex) {
                 logger.error("Interrupted", ex);
             }
-            refresh(ApiCache.retrieveResponseSync(new QueryRef(QueryApiAccess.GET_SPACES), true));
+            if (spaceList == null) { // double-check after potential wait
+                refresh(ApiCache.retrieveResponseSync(new QueryRef(QueryApiAccess.GET_SPACES), true));
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes two related race conditions that caused maintained resources to fail loading on live instances:

- **Repository refresh race condition**: In `MaintainedResourceRepository` and `SpaceRepository`, the volatile sentinel field (`resourceList`/`spaceList`) was assigned at the *start* of `refresh()`, before the lookup maps were populated. Concurrent readers could see the non-null sentinel, skip `ensureLoaded()`, and then access null/empty/partially-populated maps — causing NPEs or missing data. Fixed by building all data structures with local variables and assigning the volatile field *last*, establishing a happens-before guarantee for all prior writes. Also added double-check in `ensureLoaded()` to prevent redundant refreshes, and made `SpaceRepository.runRootUpdateAfter` volatile.

- **Space field visibility**: `Space.dataInitialized` and `Space.dataNeedsUpdate` were non-volatile shadow fields written by background threads and read by the AjaxLazyLoadPanel polling thread without synchronization. Under the Java Memory Model, the polling thread could cache the stale `false` value indefinitely, causing `isDataInitialized()` to never return `true`. This was previously masked by the first bug (pages would crash before reaching the polling stage). Fixed by making both fields `volatile`.

## Test plan

- [ ] Verify maintained resource pages load correctly (e.g. `/resource?id=https://w3id.org/fair/fip/terms/FIP-Ontology`)
- [ ] Verify space pages load correctly under concurrent access
- [ ] Verify no "stuck" loading spinners on initial page loads

Closes #374

🤖 Generated with [Claude Code](https://claude.com/claude-code)