### PR TITLE
Fix URI and Explore button layout on user page

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/page/UserPage.html
+++ b/src/main/java/com/knowledgepixels/nanodash/page/UserPage.html
@@ -11,7 +11,7 @@
 <body>
 <wicket:extend>
   <div class="row-section">
-    <div class="col-6">
+    <div class="col-12">
       <h2>
         <img class="user-profile-pic" wicket:id="userIcon"/>
         <span wicket:id="username">User Name</span></h2>

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -2234,7 +2234,7 @@ a.source:hover {
 }
 
 .link-actions-panel > a:not(:first-child) {
-  align-self: stretch;
+  align-self: center;
   display: inline-flex;
   align-items: center;
 }


### PR DESCRIPTION
## Summary
- Changed user page header from `col-6` to `col-12` so long URIs have full width and don't wrap unnecessarily
- Changed `.link-actions-panel` action buttons from `align-self: stretch` to `align-self: center` so they never stretch vertically when the URI wraps

Closes #385

## Test plan
- [x] Open a user page with a long URI (e.g. biodiv-bot) and verify the URI section uses full width
- [x] Verify the Explore and copy buttons remain vertically centered, not stretched

🤖 Generated with [Claude Code](https://claude.com/claude-code)