### PR TITLE
Fix: periodic refresh now triggers recalculation of Space roles and members

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/domain/Space.java
+++ b/src/main/java/com/knowledgepixels/nanodash/domain/Space.java
@@ -37,6 +37,12 @@ public class Space extends AbstractResourceWithProfile {
     }
 
     @Override
+    public void setDataNeedsUpdate() {
+        super.setDataNeedsUpdate();
+        dataNeedsUpdate = true;
+    }
+
+    @Override
     public void forceRefresh(long waitMillis) {
         super.forceRefresh(waitMillis);
         dataNeedsUpdate = true;


### PR DESCRIPTION
## Summary
- Fixes #391
- `Space` declares its own `dataNeedsUpdate` field that shadows the parent `AbstractResourceWithProfile` field, but did not override `setDataNeedsUpdate()`. The periodic background refresh (every 60s via `NanodashPage.ensureRefreshed()`) calls `setDataNeedsUpdate()` through `AbstractResourceWithProfile.refresh()`, which only set the **parent's** flag — leaving Space-specific data (admins, roles, members, pinned resources) permanently stale until an explicit `forceRefresh()` was triggered by another event.
- Adds a `setDataNeedsUpdate()` override in `Space` so the periodic refresh also flags Space's own data for recalculation.

## Test plan
- [ ] Verify that Space roles/members update within ~60 seconds after an external change, without requiring a manual action to trigger refresh
- [ ] Verify that explicit `forceRefresh()` (e.g. after publishing a nanopub) still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)