### PR TITLE
Make obsolete Pinned section read-only

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/component/PinGroupList.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/PinGroupList.html
@@ -8,12 +8,13 @@
 
 <wicket:panel>
 
+<div class="row-section">
+<div class="col-12 header">
+<h3>Pinned</h3>
+</div>
 <div wicket:id="pin-groups">
 <div class="col-6" wicket:id="pin-group"></div>
 </div>
-
-<div class="col-6" wicket:id="emptynotice">
-<p class="emptynotice"><em>(nothing has been pinned yet)</em></p>
 </div>
 
 </wicket:panel>

--- a/src/main/java/com/knowledgepixels/nanodash/component/PinGroupList.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/PinGroupList.java
@@ -4,7 +4,6 @@ import com.knowledgepixels.nanodash.GrlcQuery;
 import com.knowledgepixels.nanodash.domain.Space;
 import com.knowledgepixels.nanodash.template.Template;
 import org.apache.commons.lang3.tuple.Pair;
-import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.markup.repeater.Item;
 import org.apache.wicket.markup.repeater.data.DataView;
@@ -74,7 +73,7 @@ public class PinGroupList extends Panel {
             }
         });
 
-        add(new WebMarkupContainer("emptynotice").setVisible(pinnedResourcesList.isEmpty()));
+        setVisible(!pinnedResourcesList.isEmpty());
     }
 
     private static String getName(Serializable s) {

--- a/src/main/java/com/knowledgepixels/nanodash/page/SpacePage.html
+++ b/src/main/java/com/knowledgepixels/nanodash/page/SpacePage.html
@@ -55,15 +55,7 @@
 
   <div wicket:id="views"></div>
 
-  <div class="row-section">
-    <div class="col-12 header">
-      <h3>Pinned</h3>
-    </div>
-    <div wicket:id="pin-groups"></div>
-    <div class="col-12 footer">
-      <div wicket:id="pin-buttons"></div>
-    </div>
-  </div>
+  <div wicket:id="pinned-section"></div>
 
 </wicket:extend>
 </body>

--- a/src/main/java/com/knowledgepixels/nanodash/page/SpacePage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/SpacePage.java
@@ -17,7 +17,6 @@ import org.apache.wicket.Component;
 import org.apache.wicket.RestartResponseException;
 import org.apache.wicket.extensions.ajax.markup.html.AjaxLazyLoadPanel;
 import org.apache.wicket.markup.html.basic.Label;
-import org.apache.wicket.markup.html.link.AbstractLink;
 import org.apache.wicket.markup.html.link.BookmarkablePageLink;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
@@ -27,7 +26,6 @@ import org.nanopub.extra.services.QueryRef;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -122,30 +120,10 @@ public class SpacePage extends NanodashPage {
 
         add(new Label("description", "<span>" + Utils.sanitizeHtml(space.getDescription()) + "</span>").setEscapeModelStrings(false));
 
-        final List<AbstractLink> pinButtons = new ArrayList<>();
-
-        AbstractLink addPinnedTemplateButton = new BookmarkablePageLink<NanodashPage>("button", PublishPage.class, new PageParameters()
-                .set("template", "https://w3id.org/np/RA2YwreWrGW9HkzWls8jgwaIINKUB5ZTli1aFKQt13dUk")
-                .set("template-version", "latest")
-                .set("param_space", space.getId())
-                .set("context", space.getId())
-        );
-        addPinnedTemplateButton.setBody(Model.of("+ template..."));
-        pinButtons.add(addPinnedTemplateButton);
-
-        AbstractLink addPinnedQueryButton = new BookmarkablePageLink<NanodashPage>("button", PublishPage.class, new PageParameters()
-                .set("template", "https://w3id.org/np/RAuLESdeRUlk1GcTwvzVXShiBMI0ntJs2DL2Bm5DzW_ZQ")
-                .set("template-version", "latest")
-                .set("param_space", space.getId())
-        );
-        addPinnedQueryButton.setBody(Model.of("+ query..."));
-        pinButtons.add(addPinnedQueryButton);
-
         if (space.isDataInitialized()) {
-            add(new PinGroupList("pin-groups", space));
-            add(new ButtonList("pin-buttons", space, null, null, pinButtons));
+            add(new PinGroupList("pinned-section", space));
         } else {
-            add(new AjaxLazyLoadPanel<Component>("pin-groups") {
+            add(new AjaxLazyLoadPanel<Component>("pinned-section") {
 
                 @Override
                 public Component getLazyLoadComponent(String markupId) {
@@ -157,19 +135,7 @@ public class SpacePage extends NanodashPage {
                     return space.isDataInitialized();
                 }
 
-            });
-            add(new AjaxLazyLoadPanel<Component>("pin-buttons") {
-
                 @Override
-                public Component getLazyLoadComponent(String markupId) {
-                    return new ButtonList(markupId, space, null, null, pinButtons);
-                }
-
-                @Override
-                protected boolean isContentReady() {
-                    return space.isDataInitialized();
-                }
-
                 public Component getLoadingComponent(String id) {
                     return new Label(id).setVisible(false);
                 }


### PR DESCRIPTION
## Summary
- Remove "+" buttons for adding pinned templates and queries to spaces
- Hide the entire Pinned section when no pinned content exists (instead of showing "(nothing has been pinned yet)")
- Move the Pinned section header/wrapper into `PinGroupList` so it can control its own visibility

Closes #393

## Test plan
- [ ] Visit a space page that has pinned content — verify the Pinned section still displays correctly
- [ ] Visit a space page with no pinned content — verify the Pinned section is completely hidden
- [ ] Verify no "+" buttons appear for adding templates or queries to the Pinned section
- [ ] Test lazy-loading path (clear cache / first load) — section should appear only if pins exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)