### PR TITLE
Show start and end time for single-day Spaces

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/page/SpacePage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/SpacePage.java
@@ -24,8 +24,8 @@ import org.apache.wicket.request.mapper.parameter.PageParameters;
 import org.nanopub.Nanopub;
 import org.nanopub.extra.services.QueryRef;
 
-import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
@@ -53,6 +53,7 @@ public class SpacePage extends NanodashPage {
      */
     private final Space space;
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+    private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
 
     /**
      * Constructor for the SpacePage.
@@ -105,14 +106,18 @@ public class SpacePage extends NanodashPage {
         ));
 
         if (space.getStartDate() != null) {
-            String dateString;
-            LocalDateTime dt = LocalDateTime.ofInstant(space.getStartDate().toInstant(), ZoneId.systemDefault());
-            dateString = DATE_FORMATTER.format(dt);
+            ZoneId startZone = space.getStartDate().getTimeZone().toZoneId();
+            ZonedDateTime startDt = ZonedDateTime.ofInstant(space.getStartDate().toInstant(), startZone);
+            String dateString = DATE_FORMATTER.format(startDt);
             if (space.getEndDate() != null) {
-                dt = LocalDateTime.ofInstant(space.getEndDate().toInstant(), ZoneId.systemDefault());
-                String endDate = DATE_FORMATTER.format(dt);
-                if (!dateString.equals(endDate)) {
-                    dateString += " - " + endDate;
+                ZoneId endZone = space.getEndDate().getTimeZone().toZoneId();
+                ZonedDateTime endDt = ZonedDateTime.ofInstant(space.getEndDate().toInstant(), endZone);
+                String endDateStr = DATE_FORMATTER.format(endDt);
+                if (dateString.equals(endDateStr)) {
+                    String tzAbbr = startDt.getZone().getDisplayName(java.time.format.TextStyle.SHORT, java.util.Locale.ENGLISH);
+                    dateString += " " + TIME_FORMATTER.format(startDt) + " - " + TIME_FORMATTER.format(endDt) + " " + tzAbbr;
+                } else {
+                    dateString += " - " + endDateStr;
                 }
             }
             add(new Label("date", dateString));


### PR DESCRIPTION
## Summary
- For Spaces where start and end fall on the same day, display start/end times and timezone abbreviation instead of just the date (e.g. `2024-03-13 09:00 - 17:00 CET`)
- Uses the timezone from the parsed RDF date value rather than system default
- Multi-day and date-only displays remain unchanged

Closes #390

## Test plan
- [ ] Verify a single-day Space shows times and timezone (e.g. `2024-03-13 09:00 - 17:00 CET`)
- [ ] Verify a multi-day Space still shows date range (e.g. `2024-03-13 - 2024-03-15`)
- [ ] Verify a Space with only a start date (no end date) shows just the date
- [ ] Verify a Space with no dates hides the date section

🤖 Generated with [Claude Code](https://claude.com/claude-code)