### PR TITLE
fix: use ExternalLinkWithActionsPanel for alternative ID links

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/page/SpacePage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/SpacePage.java
@@ -100,7 +100,7 @@ public class SpacePage extends NanodashPage {
                 "altids",
                 "Alternative IDs:",
                 space.getAltIDs(),
-                i -> new ItemListElement("item", ExplorePage.class, new PageParameters().set("id", i), i)
+                i -> new ExternalLinkWithActionsPanel("item", Model.of(i), Model.of(i))
         ));
 
         if (space.getStartDate() != null) {


### PR DESCRIPTION
## Summary
- Alternative ID links now use `ExternalLinkWithActionsPanel` instead of `ItemListElement`, giving them the same copy icon, explore option, and direct external link as the main ID link.

Fixes #407

## Test plan
- [x] Open a space page that has alternative IDs
- [x] Verify each alternative ID shows a direct external link, copy icon, and explore button
- [x] Verify the main ID link still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)