### PR TITLE
feat: support multi-value columns in SPARQL query results

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/Utils.java
+++ b/src/main/java/com/knowledgepixels/nanodash/Utils.java
@@ -804,4 +804,30 @@ public class Utils {
         return !uriAsString.isBlank() && uriAsString.startsWith(LocalUri.PREFIX);
     }
 
+    /**
+     * Unescape a multi-value entry where backslashes and newlines are escaped with backslash.
+     *
+     * @param s the escaped string
+     * @return the unescaped string
+     */
+    public static String unescapeMultiValue(String s) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < s.length(); i++) {
+            if (s.charAt(i) == '\\' && i + 1 < s.length()) {
+                char next = s.charAt(i + 1);
+                if (next == 'n') {
+                    sb.append('\n');
+                } else if (next == '\\') {
+                    sb.append('\\');
+                } else {
+                    sb.append(next);
+                }
+                i++;
+            } else {
+                sb.append(s.charAt(i));
+            }
+        }
+        return sb.toString();
+    }
+
 }

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultList.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultList.java
@@ -65,18 +65,46 @@ public class QueryResultList extends QueryResult {
 
                 List<Component> components = new ArrayList<>();
                 for (String key : response.getHeader()) {
-                    if (!key.endsWith("_label")) {
-                        String entryValue = entry.get(key);
-                        if (entryValue != null && !entryValue.isBlank()) {
-                            if (entryValue.matches("https?://.+")) {
-                                String entryLabel = entry.get(key + "_label");
-                                components.add(new NanodashLink("component", entryValue, null, null, entryLabel, contextId));
-                            } else {
-                                if (Utils.looksLikeHtml(entryValue)) {
-                                    entryValue = Utils.sanitizeHtml(entryValue);
-                                }
-                                components.add(new Label("component", entryValue).setEscapeModelStrings(false));
+                    if (key.endsWith("_label") || key.endsWith("_label_multi")) {
+                        continue;
+                    }
+                    String entryValue = entry.get(key);
+                    if (entryValue != null && !entryValue.isBlank()) {
+                        if (key.endsWith("_multi_iri")) {
+                            String[] uris = entryValue.split(" ");
+                            String labelKey = key.substring(0, key.length() - "_multi_iri".length()) + "_label_multi";
+                            String labelValue = entry.get(labelKey);
+                            String[] labels = labelValue != null ? labelValue.split("\n", -1) : null;
+                            List<Component> links = new ArrayList<>();
+                            for (int i = 0; i < uris.length; i++) {
+                                String label = (labels != null && i < labels.length) ? Utils.unescapeMultiValue(labels[i]) : null;
+                                links.add(new NanodashLink("component", uris[i], null, null, label, contextId));
                             }
+                            components.add(new ComponentSequence("component", ", ", links));
+                        } else if (key.endsWith("_multi")) {
+                            String[] parts = entryValue.split("\n", -1);
+                            String labelKey = key.substring(0, key.length() - "_multi".length()) + "_label_multi";
+                            String labelValue = entry.get(labelKey);
+                            String[] labels = labelValue != null ? labelValue.split("\n", -1) : null;
+                            List<Component> multiComponents = new ArrayList<>();
+                            for (int i = 0; i < parts.length; i++) {
+                                String display;
+                                if (labels != null && i < labels.length) {
+                                    display = Utils.unescapeMultiValue(labels[i]);
+                                } else {
+                                    display = Utils.unescapeMultiValue(parts[i]);
+                                }
+                                multiComponents.add(new Label("component", display));
+                            }
+                            components.add(new ComponentSequence("component", ", ", multiComponents));
+                        } else if (entryValue.matches("https?://.+")) {
+                            String entryLabel = entry.get(key + "_label");
+                            components.add(new NanodashLink("component", entryValue, null, null, entryLabel, contextId));
+                        } else {
+                            if (Utils.looksLikeHtml(entryValue)) {
+                                entryValue = Utils.sanitizeHtml(entryValue);
+                            }
+                            components.add(new Label("component", entryValue).setEscapeModelStrings(false));
                         }
                     }
                 }

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultTable.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultTable.java
@@ -97,10 +97,16 @@ public class QueryResultTable extends QueryResult {
         QueryResultDataProvider dataProvider;
         try {
             for (String h : response.getHeader()) {
-                if (h.endsWith("_label")) {
+                if (h.endsWith("_label") || h.endsWith("_label_multi")) {
                     continue;
                 }
-                columns.add(new Column(h.replaceAll("_", " "), h));
+                String displayLabel = h;
+                if (displayLabel.endsWith("_multi_iri")) {
+                    displayLabel = displayLabel.substring(0, displayLabel.length() - "_multi_iri".length());
+                } else if (displayLabel.endsWith("_multi")) {
+                    displayLabel = displayLabel.substring(0, displayLabel.length() - "_multi".length());
+                }
+                columns.add(new Column(displayLabel.replaceAll("_", " "), h));
             }
             if (viewDisplay.getView() != null && !viewDisplay.getView().getViewEntryActionList().isEmpty()) {
                 columns.add(new Column("", Column.ACTIONS));
@@ -175,12 +181,33 @@ public class QueryResultTable extends QueryResult {
                     cellItem.add(new ButtonList(componentId, resourceWithProfile, links, null, null));
                 } else {
                     String value = rowModel.getObject().get(key);
-                    if (value.matches("https?://.+ .+")) {
+                    if (key.endsWith("_multi_iri")) {
+                        String[] uris = value.split(" ");
+                        String labelKey = key.substring(0, key.length() - "_multi_iri".length()) + "_label_multi";
+                        String labelValue = rowModel.getObject().get(labelKey);
+                        String[] labels = labelValue != null ? labelValue.split("\n", -1) : null;
                         List<Component> links = new ArrayList<>();
-                        for (String v : value.split(" ")) {
-                            links.add(new NanodashLink("component", v));
+                        for (int i = 0; i < uris.length; i++) {
+                            String label = (labels != null && i < labels.length) ? Utils.unescapeMultiValue(labels[i]) : null;
+                            links.add(new NanodashLink("component", uris[i], null, null, label, contextId));
                         }
                         cellItem.add(new ComponentSequence(componentId, ", ", links));
+                    } else if (key.endsWith("_multi")) {
+                        String[] parts = value.split("\n", -1);
+                        String labelKey = key.substring(0, key.length() - "_multi".length()) + "_label_multi";
+                        String labelValue = rowModel.getObject().get(labelKey);
+                        String[] labels = labelValue != null ? labelValue.split("\n", -1) : null;
+                        List<Component> components = new ArrayList<>();
+                        for (int i = 0; i < parts.length; i++) {
+                            String display;
+                            if (labels != null && i < labels.length) {
+                                display = Utils.unescapeMultiValue(labels[i]);
+                            } else {
+                                display = Utils.unescapeMultiValue(parts[i]);
+                            }
+                            components.add(new Label("component", display));
+                        }
+                        cellItem.add(new ComponentSequence(componentId, ", ", components));
                     } else if (value.matches("https?://.+")) {
                         String label = rowModel.getObject().get(key + "_label");
                         cellItem.add(new NanodashLink(componentId, value, null, null, label, contextId));

--- a/src/test/java/com/knowledgepixels/nanodash/UtilsTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/UtilsTest.java
@@ -786,4 +786,41 @@ class UtilsTest {
         assertFalse(Utils.isLocalURI((IRI) null));
     }
 
+    @Test
+    void unescapeMultiValueReturnsPlainStringUnchanged() {
+        assertEquals("hello world", Utils.unescapeMultiValue("hello world"));
+    }
+
+    @Test
+    void unescapeMultiValueHandlesEmptyString() {
+        assertEquals("", Utils.unescapeMultiValue(""));
+    }
+
+    @Test
+    void unescapeMultiValueUnescapesNewline() {
+        assertEquals("line1\nline2", Utils.unescapeMultiValue("line1\\nline2"));
+    }
+
+    @Test
+    void unescapeMultiValueUnescapesBackslash() {
+        assertEquals("back\\slash", Utils.unescapeMultiValue("back\\\\slash"));
+    }
+
+    @Test
+    void unescapeMultiValueUnescapesBackslashFollowedByN() {
+        // \\n in input = escaped backslash + literal n → \n (backslash + n, not a newline)
+        assertEquals("\\n", Utils.unescapeMultiValue("\\\\n"));
+    }
+
+    @Test
+    void unescapeMultiValueHandlesMultipleEscapes() {
+        assertEquals("a\nb\\c", Utils.unescapeMultiValue("a\\nb\\\\c"));
+    }
+
+    @Test
+    void unescapeMultiValueHandlesTrailingBackslash() {
+        // Lone trailing backslash with no following character is preserved as-is
+        assertEquals("trailing\\", Utils.unescapeMultiValue("trailing\\"));
+    }
+
 }


### PR DESCRIPTION
## Summary
- Add `_multi_iri` column convention: space-separated URIs rendered as comma-separated links, with optional `_label_multi` labels
- Add `_multi` column convention: newline-separated escaped literals rendered as comma-separated text, with optional `_label_multi` labels
- Replace old heuristic that guessed multi-URI values by checking the value format (`https?://.+ .+`) with explicit `_multi_iri` suffix convention
- Support in both table (`QueryResultTable`) and list (`QueryResultList`) views
- Add `Utils.unescapeMultiValue()` for shared backslash/newline unescaping
- Add unit tests for the unescape utility

Closes #412

## Test plan
- [ ] Verify `_multi_iri` columns render as comma-separated links in table and list views
- [ ] Verify `_label_multi` labels are displayed for `_multi_iri` items
- [ ] Verify `_multi` columns render as comma-separated literals
- [ ] Verify `_label_multi` and `_multi_iri` / `_multi` suffixes are stripped from column headers
- [ ] Verify existing single-value URI columns still render correctly
- [ ] Run `mvn test -Dtest="UtilsTest#unescapeMultiValue*"` — all 7 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)