### PR TITLE
Fix connection pool exhaustion errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,17 +98,17 @@
       <artifactId>owasp-java-html-sanitizer</artifactId>
       <version>20260102.1</version>
     </dependency>
-    <dependency>
+    <!-- <dependency>
       <groupId>org.nanopub</groupId>
       <artifactId>nanopub</artifactId>
       <version>1.86.2</version>
-    </dependency>
+    </dependency> -->
     <!-- Temporary: dependency on Jitpack for snapshot builds -->
-    <!-- <dependency>
+    <dependency>
       <groupId>com.github.Nanopublication</groupId>
       <artifactId>nanopub-java</artifactId>
-      <version>-SNAPSHOT</version>
-    </dependency> -->
+      <version>b80512b</version>
+    </dependency>
     <dependency>
       <groupId>jakarta.servlet</groupId>
       <artifactId>jakarta.servlet-api</artifactId>


### PR DESCRIPTION
## Summary
- Switches nanopub-java dependency from Maven Central 1.86.2 to JitPack snapshot (`b80512b`) which fixes "Timeout waiting for connection from pool" errors

## Upstream fix (Nanopublication/nanopub-java@b80512b)
- Increases `connectionRequestTimeout` from 500ms to 10s — 500ms was too aggressive for a shared pool under concurrent load
- Fixes connection leak in `QueryCall.getApiInstances()` where health-check responses were never consumed
- Fixes connection leak in `QueryAccess.call()` RDF path by using try-with-resources and a finally block to guarantee connection release

## Test plan
- [ ] Verify nanodash compiles and starts correctly with the JitPack dependency
- [ ] Monitor logs for "Timeout waiting for connection from pool" errors under load
- [ ] Switch back to Maven Central release once nanopub-java 1.86.3 is published

Fixes #416

🤖 Generated with [Claude Code](https://claude.com/claude-code)