### PR TITLE
Fix: disable Publish button after click to prevent double submissions

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/component/PublishForm.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/PublishForm.html
@@ -134,7 +134,7 @@ I understand that published data cannot be fully removed (only retracted or supe
 </p>
 
 <p class="center">
-<input type="submit" class="button" value="Publish" />
+<input type="submit" class="button" value="Publish" onclick="this.value='Publishing\u2026'; this.disabled=true; this.form.submit();" />
 <button wicket:id="preview-button" type="submit" class="button light">Preview</button>
 </p>
 

--- a/src/main/java/com/knowledgepixels/nanodash/page/PreviewPage.html
+++ b/src/main/java/com/knowledgepixels/nanodash/page/PreviewPage.html
@@ -26,7 +26,7 @@
         </p>
 
         <p class="center">
-          <input type="submit" class="button" value="Publish"/>
+          <input type="submit" class="button" value="Publish" onclick="this.value='Publishing\u2026'; this.disabled=true; this.form.submit();"/>
           <button wicket:id="discard-button" type="submit" class="button light">Back</button>
         </p>
       </form>


### PR DESCRIPTION
## Summary
- Disable the Publish button immediately on click and change its label to "Publishing…" to prevent duplicate submissions
- Applied to both `PublishForm.html` (main publish flow) and `PreviewPage.html` (preview publish flow)

## Root cause
`PublishNanopub.publish()` is a blocking network call. While the server is busy publishing, the browser shows no feedback — the button stays clickable. Users click again, causing a second form POST that publishes the same nanopub again.

## Test plan
- [x] Click Publish — button should disable and show "Publishing…"
- [x] Verify the nanopub is published exactly once
- [ ] If publishing fails (server error), reload the page and verify the button is active again

Closes #419

🤖 Generated with [Claude Code](https://claude.com/claude-code)