### PR TITLE
fix: ensure space admin data is loaded before filtering view displays

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/domain/Space.java
+++ b/src/main/java/com/knowledgepixels/nanodash/domain/Space.java
@@ -122,6 +122,7 @@ public class Space extends AbstractResourceWithProfile {
 
     private volatile boolean dataInitialized = false;
     private volatile boolean dataNeedsUpdate = true;
+    private transient volatile Future<?> spaceDataFuture = null;
 
     Space(ApiResponseEntry resp) {
         super(resp.get("space"));
@@ -363,15 +364,15 @@ public class Space extends AbstractResourceWithProfile {
     }
 
     private synchronized void ensureInitialized() {
-        Future<?> future = triggerSpaceDataUpdate();
-        if (!dataInitialized && future != null) {
+        triggerSpaceDataUpdate();
+        if (!dataInitialized && spaceDataFuture != null) {
             try {
-                future.get(30, TimeUnit.SECONDS);
+                spaceDataFuture.get(30, TimeUnit.SECONDS);
             } catch (Exception ex) {
                 logger.error("failed to await space data update", ex);
             }
         }
-        future = super.triggerDataUpdate();
+        Future<?> future = super.triggerDataUpdate();
         if (!dataInitialized && future != null) {
             try {
                 future.get(30, TimeUnit.SECONDS);
@@ -391,7 +392,7 @@ public class Space extends AbstractResourceWithProfile {
         if (dataNeedsUpdate) {
             logger.info("Data needs update for space {} core data, starting update thread", getId());
             dataNeedsUpdate = false;
-            return NanodashThreadPool.submit(() -> {
+            spaceDataFuture = NanodashThreadPool.submit(() -> {
                 try {
                     if (getRunUpdateAfter() != null) {
                         while (System.currentTimeMillis() < getRunUpdateAfter()) {
@@ -480,8 +481,9 @@ public class Space extends AbstractResourceWithProfile {
                     dataNeedsUpdate = true;
                 }
             });
+            return spaceDataFuture;
         }
-        return null;
+        return spaceDataFuture;
     }
 
     private void setCoreData(SpaceData data) {


### PR DESCRIPTION
## Summary
- When a Space page loads for the first time, two background tasks run in parallel: one loading space admin data (`adminPubkeyMap`) and one loading view displays. The view display task filters entries by admin pubkey via `isAdminPubkey()` → `ensureInitialized()`, but the `Future` from the space data task was discarded by `triggerSpaceDataUpdate()`, so `ensureInitialized()` could never wait on it. This caused view displays from API-discovered admins to be silently filtered out on first load.
- Store the space data `Future` in a `transient volatile` field so `ensureInitialized()` can always block until admin data is ready, even when the task was already submitted by an earlier `triggerDataUpdate()` call.

Fixes #418

## Test plan
- [x] Load `/space?id=https://w3id.org/spaces/knowledgepixels` fresh (clear cache or use incognito) and verify all view displays (e.g. "Our news" and "Messages") appear on first load
- [x] Verify no serialization errors in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)