### PR TITLE
fix: skip null queries to prevent NPE on Query page

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryList.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryList.java
@@ -46,7 +46,10 @@ public class QueryList extends Panel {
         List<GrlcQuery> queries = new ArrayList<>();
         for (ApiResponseEntry e : resp.getData()) {
             try {
-                queries.add(GrlcQuery.get(e.get("np")));
+                GrlcQuery q = GrlcQuery.get(e.get("np"));
+                if (q != null) {
+                    queries.add(q);
+                }
             } catch (Exception ex) {
                 logger.error("Error processing query nanopub: {}", ex.getMessage());
             }


### PR DESCRIPTION
## Summary
- `GrlcQuery.get()` can return `null` for unresolvable nanopubs, which was added to the query list and caused a `NullPointerException` in `QueryItem` when rendering
- Added a null check to skip null results before adding to the list

Closes #426

## Test plan
- [ ] Load the Query page and verify it renders without errors
- [ ] Confirm queries still display correctly when all nanopubs resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)