### PR TITLE
fix: apply user's default license per-request instead of caching globally

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/component/PublishForm.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/PublishForm.java
@@ -207,6 +207,12 @@ public class PublishForm extends Panel {
             pubInfoContexts.add(c);
             pubInfoContextMap.put(c.getTemplate().getId(), c);
             requiredPubInfoContexts.add(c);
+            if (t.equals(LICENSE_PUB_INFO_TEMPLATE)) {
+                IRI defaultLicense = User.getDefaultLicense(NanodashSession.get().getUserIri());
+                if (defaultLicense != null) {
+                    c.setParam("license", defaultLicense.stringValue());
+                }
+            }
         }
         if (fillMode == FillMode.SUPERSEDE) {
             TemplateContext c = new TemplateContext(ContextType.PUBINFO, supersedesPubInfoTemplateId, "pi-statement", targetNamespace);

--- a/src/main/java/com/knowledgepixels/nanodash/component/TemplateFormPreview.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/TemplateFormPreview.java
@@ -1,5 +1,7 @@
 package com.knowledgepixels.nanodash.component;
 
+import com.knowledgepixels.nanodash.NanodashSession;
+import com.knowledgepixels.nanodash.domain.User;
 import com.knowledgepixels.nanodash.page.ExplorePage;
 import com.knowledgepixels.nanodash.template.ContextType;
 import com.knowledgepixels.nanodash.template.Template;
@@ -64,7 +66,12 @@ public class TemplateFormPreview extends Panel {
         // Pubinfo contexts
         List<TemplateContext> pubInfoContexts = new ArrayList<>();
         pubInfoContexts.add(new TemplateContext(ContextType.PUBINFO, PublishForm.CREATOR_PUB_INFO_TEMPLATE, "pi-statement", targetNamespace));
-        pubInfoContexts.add(new TemplateContext(ContextType.PUBINFO, PublishForm.LICENSE_PUB_INFO_TEMPLATE, "pi-statement", targetNamespace));
+        TemplateContext licenseContext = new TemplateContext(ContextType.PUBINFO, PublishForm.LICENSE_PUB_INFO_TEMPLATE, "pi-statement", targetNamespace);
+        IRI defaultLicense = User.getDefaultLicense(NanodashSession.get().getUserIri());
+        if (defaultLicense != null) {
+            licenseContext.setParam("license", defaultLicense.stringValue());
+        }
+        pubInfoContexts.add(licenseContext);
         for (IRI r : template.getRequiredPubInfoElements()) {
             String rId = r.stringValue();
             boolean alreadyAdded = false;

--- a/src/main/java/com/knowledgepixels/nanodash/template/Template.java
+++ b/src/main/java/com/knowledgepixels/nanodash/template/Template.java
@@ -1,10 +1,7 @@
 package com.knowledgepixels.nanodash.template;
 
 import com.knowledgepixels.nanodash.LookupApis;
-import com.knowledgepixels.nanodash.NanodashSession;
 import com.knowledgepixels.nanodash.Utils;
-import com.knowledgepixels.nanodash.component.PublishForm;
-import com.knowledgepixels.nanodash.domain.User;
 import net.trustyuri.TrustyUriUtils;
 import org.eclipse.rdf4j.common.exception.RDF4JException;
 import org.eclipse.rdf4j.model.*;
@@ -758,9 +755,6 @@ public class Template implements Serializable {
                     statementOrder.put(subj, Integer.valueOf(objS));
                 }
             }
-            if (subj.equals(vf.createIRI(PublishForm.LICENSE_PUB_INFO_TEMPLATE + "/license"))) {
-                processDefaultLicense();
-            }
         }
 //		List<IRI> assertionTypes = typeMap.get(templateIri);
 //		if (assertionTypes == null || (!assertionTypes.contains(NTEMPLATE.ASSERTION_TEMPLATE) &&
@@ -776,16 +770,6 @@ public class Template implements Serializable {
         }
         for (List<IRI> l : statementMap.values()) {
             l.sort(statementComparator);
-        }
-    }
-
-    /**
-     * Processes the default license for the template by retrieving it from the user's profile and adding it to the default values if it exists.
-     */
-    private void processDefaultLicense() {
-        IRI licenseUrl = User.getDefaultLicense(NanodashSession.get().getUserIri());
-        if (licenseUrl != null) {
-            defaultValues.put(vf.createIRI(PublishForm.LICENSE_PUB_INFO_TEMPLATE + "/license"), licenseUrl);
         }
     }
 


### PR DESCRIPTION
## Summary
- `processDefaultLicense()` in `Template.java` stored the current session user's default license in `Template.defaultValues`, but `Template` objects are cached globally in the `TemplateData` singleton — so the first user to load the license template had their preference baked into the cache for all subsequent users
- Moved default license handling to `PublishForm` and `TemplateFormPreview` where it runs per-request via `setParam` on the license `TemplateContext`
- Removed the now-unused `processDefaultLicense()` method and its imports from `Template.java`

## Test plan
- [ ] Set a default license in user profile (e.g. CC-BY 4.0)
- [ ] Go to another user's profile page and click "add to my own profile..." on a View
- [ ] Verify the default license is pre-selected in the publish form
- [ ] Verify supersede/derive flows still carry over the license from the original nanopub
- [ ] Verify publishing without a default license set still shows no pre-selection

Closes #429

🤖 Generated with [Claude Code](https://claude.com/claude-code)