### PR TITLE
feat: convert home page fixed lists to proper views with dropdown menus

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/ViewDisplay.java
+++ b/src/main/java/com/knowledgepixels/nanodash/ViewDisplay.java
@@ -43,7 +43,7 @@ public class ViewDisplay implements Serializable, Comparable<ViewDisplay> {
      */
     public ViewDisplay(View view) {
         this.id = null;
-        this.nanopub = null;
+        this.nanopub = view.getNanopub();
         this.view = view;
     }
 

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultList.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultList.java
@@ -6,6 +6,7 @@ import com.knowledgepixels.nanodash.domain.MaintainedResource;
 import com.knowledgepixels.nanodash.domain.User;
 import com.knowledgepixels.nanodash.page.NanodashPage;
 import com.knowledgepixels.nanodash.page.PublishPage;
+import com.knowledgepixels.nanodash.page.UserPage;
 import com.knowledgepixels.nanodash.repository.MaintainedResourceRepository;
 import com.knowledgepixels.nanodash.template.Template;
 import org.apache.wicket.Component;
@@ -86,9 +87,13 @@ public class QueryResultList extends QueryResult {
                             } else {
                                 imgSrc = RequestCycle.get().urlFor(new ContextRelativeResourceReference("images/user-icon.svg", false), null).toString();
                             }
+                            String userLabel = entry.get(key + "_label");
+                            String displayLabel = userLabel != null && !userLabel.isBlank() ? userLabel : User.getShortDisplayName(userIri);
+                            String userUrl = UserPage.MOUNT_PATH + "?id=" + Utils.urlEncode(entryValue);
+                            String linkHtml = "<a href=\"" + Strings.escapeMarkup(userUrl) + "\">" + Strings.escapeMarkup(displayLabel) + "</a>";
                             components.add(new ComponentSequence("component", " ", List.of(
                                     new Label("component", "<img class=\"user-icon\" src=\"" + imgSrc + "\" />").setEscapeModelStrings(false),
-                                    new NanodashLink("component", entryValue, null, null, entry.get(key + "_label"), contextId))));
+                                    new Label("component", linkHtml).setEscapeModelStrings(false))));
                         } else if (key.endsWith("template_iri")) {
                             String templateLabel = entry.get(key + "_label");
                             String displayLabel = templateLabel != null && !templateLabel.isBlank() ? templateLabel : entryValue;

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultList.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultList.java
@@ -90,9 +90,15 @@ public class QueryResultList extends QueryResult {
                                     new Label("component", "<img class=\"user-icon\" src=\"" + imgSrc + "\" />").setEscapeModelStrings(false),
                                     new NanodashLink("component", entryValue, null, null, entry.get(key + "_label"), contextId))));
                         } else if (key.endsWith("template_iri")) {
+                            String templateLabel = entry.get(key + "_label");
+                            PageParameters tParams = new PageParameters()
+                                    .set("template", entryValue)
+                                    .set("template-version", "latest");
+                            BookmarkablePageLink<NanodashPage> templateLink = new BookmarkablePageLink<>("component", PublishPage.class, tParams);
+                            templateLink.setBody(Model.of(templateLabel != null ? templateLabel : entryValue));
                             components.add(new ComponentSequence("component", " ", List.of(
                                     new Label("component", "<span class=\"form-icon\"></span>").setEscapeModelStrings(false),
-                                    new NanodashLink("component", entryValue, null, null, entry.get(key + "_label"), contextId))));
+                                    templateLink)));
                         } else if (key.endsWith("_multi_iri")) {
                             String[] uris = entryValue.split("\\s+");
                             String labelKey = key.substring(0, key.length() - "_multi_iri".length()) + "_label_multi";

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultList.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultList.java
@@ -1,7 +1,9 @@
 package com.knowledgepixels.nanodash.component;
 
 import com.knowledgepixels.nanodash.*;
+import com.knowledgepixels.nanodash.domain.IndividualAgent;
 import com.knowledgepixels.nanodash.domain.MaintainedResource;
+import com.knowledgepixels.nanodash.domain.User;
 import com.knowledgepixels.nanodash.page.NanodashPage;
 import com.knowledgepixels.nanodash.page.PublishPage;
 import com.knowledgepixels.nanodash.repository.MaintainedResourceRepository;
@@ -17,7 +19,10 @@ import org.apache.wicket.markup.repeater.Item;
 import org.apache.wicket.markup.repeater.RepeatingView;
 import org.apache.wicket.markup.repeater.data.DataView;
 import org.apache.wicket.model.Model;
+import org.apache.wicket.request.cycle.RequestCycle;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
+import org.apache.wicket.request.resource.ContextRelativeResourceReference;
+import org.apache.wicket.util.string.Strings;
 import org.eclipse.rdf4j.model.IRI;
 import org.nanopub.extra.services.ApiResponse;
 import org.nanopub.extra.services.ApiResponseEntry;
@@ -70,7 +75,25 @@ public class QueryResultList extends QueryResult {
                     }
                     String entryValue = entry.get(key);
                     if (entryValue != null && !entryValue.isBlank()) {
-                        if (key.endsWith("_multi_iri")) {
+                        if (key.endsWith("user_iri")) {
+                            IRI userIri = Utils.vf.createIRI(entryValue);
+                            IRI profilePicIri = User.getProfilePicture(userIri);
+                            String imgSrc;
+                            if (profilePicIri != null) {
+                                imgSrc = Strings.escapeMarkup(profilePicIri.stringValue()).toString();
+                            } else if (IndividualAgent.isSoftware(userIri)) {
+                                imgSrc = RequestCycle.get().urlFor(new ContextRelativeResourceReference("images/bot-icon.svg", false), null).toString();
+                            } else {
+                                imgSrc = RequestCycle.get().urlFor(new ContextRelativeResourceReference("images/user-icon.svg", false), null).toString();
+                            }
+                            components.add(new ComponentSequence("component", " ", List.of(
+                                    new Label("component", "<img class=\"user-icon\" src=\"" + imgSrc + "\" />").setEscapeModelStrings(false),
+                                    new NanodashLink("component", entryValue, null, null, entry.get(key + "_label"), contextId))));
+                        } else if (key.endsWith("template_iri")) {
+                            components.add(new ComponentSequence("component", " ", List.of(
+                                    new Label("component", "<span class=\"form-icon\"></span>").setEscapeModelStrings(false),
+                                    new NanodashLink("component", entryValue, null, null, entry.get(key + "_label"), contextId))));
+                        } else if (key.endsWith("_multi_iri")) {
                             String[] uris = entryValue.split("\\s+");
                             String labelKey = key.substring(0, key.length() - "_multi_iri".length()) + "_label_multi";
                             String labelValue = entry.get(labelKey);

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultList.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultList.java
@@ -15,6 +15,7 @@ import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.link.AbstractLink;
 import org.apache.wicket.markup.html.link.BookmarkablePageLink;
+import org.apache.wicket.markup.html.link.ExternalLink;
 import org.apache.wicket.markup.repeater.Item;
 import org.apache.wicket.markup.repeater.RepeatingView;
 import org.apache.wicket.markup.repeater.data.DataView;
@@ -91,11 +92,9 @@ public class QueryResultList extends QueryResult {
                                     new NanodashLink("component", entryValue, null, null, entry.get(key + "_label"), contextId))));
                         } else if (key.endsWith("template_iri")) {
                             String templateLabel = entry.get(key + "_label");
-                            PageParameters tParams = new PageParameters()
-                                    .set("template", entryValue)
-                                    .set("template-version", "latest");
-                            BookmarkablePageLink<NanodashPage> templateLink = new BookmarkablePageLink<>("component", PublishPage.class, tParams);
-                            templateLink.setBody(Model.of(templateLabel != null ? templateLabel : entryValue));
+                            String displayLabel = templateLabel != null && !templateLabel.isBlank() ? templateLabel : entryValue;
+                            String templateUrl = PublishPage.MOUNT_PATH + "?template=" + Utils.urlEncode(entryValue) + "&template-version=latest";
+                            ExternalLink templateLink = new ExternalLink("component", templateUrl, displayLabel);
                             components.add(new ComponentSequence("component", " ", List.of(
                                     new Label("component", "<span class=\"form-icon\"></span>").setEscapeModelStrings(false),
                                     templateLink)));

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultList.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultList.java
@@ -15,7 +15,6 @@ import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.link.AbstractLink;
 import org.apache.wicket.markup.html.link.BookmarkablePageLink;
-import org.apache.wicket.markup.html.link.ExternalLink;
 import org.apache.wicket.markup.repeater.Item;
 import org.apache.wicket.markup.repeater.RepeatingView;
 import org.apache.wicket.markup.repeater.data.DataView;
@@ -94,10 +93,10 @@ public class QueryResultList extends QueryResult {
                             String templateLabel = entry.get(key + "_label");
                             String displayLabel = templateLabel != null && !templateLabel.isBlank() ? templateLabel : entryValue;
                             String templateUrl = PublishPage.MOUNT_PATH + "?template=" + Utils.urlEncode(entryValue) + "&template-version=latest";
-                            ExternalLink templateLink = new ExternalLink("component", templateUrl, displayLabel);
+                            String linkHtml = "<a href=\"" + Strings.escapeMarkup(templateUrl) + "\">" + Strings.escapeMarkup(displayLabel) + "</a>";
                             components.add(new ComponentSequence("component", " ", List.of(
                                     new Label("component", "<span class=\"form-icon\"></span>").setEscapeModelStrings(false),
-                                    templateLink)));
+                                    new Label("component", linkHtml).setEscapeModelStrings(false))));
                         } else if (key.endsWith("_multi_iri")) {
                             String[] uris = entryValue.split("\\s+");
                             String labelKey = key.substring(0, key.length() - "_multi_iri".length()) + "_label_multi";

--- a/src/main/java/com/knowledgepixels/nanodash/component/menu/ViewDisplayMenu.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/menu/ViewDisplayMenu.html
@@ -9,6 +9,7 @@
 
 <wicket:extend>
   <a wicket:id="showQuery">show query</a>
+  <a wicket:id="showView">show view</a>
   <a wicket:id="adjust">edit view display...</a>
   <a wicket:id="deactivate">deactivate view display...</a>
   <a wicket:id="addToOwn">add to my own profile...</a>

--- a/src/main/java/com/knowledgepixels/nanodash/component/menu/ViewDisplayMenu.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/menu/ViewDisplayMenu.java
@@ -43,6 +43,9 @@ public class ViewDisplayMenu extends BaseDisplayMenu {
         }
         addEntry("showQuery", new BookmarkablePageLink<Void>("showQuery", QueryPage.class, showQueryParams));
 
+        addEntry("showView", new BookmarkablePageLink<Void>("showView", ExplorePage.class,
+                new PageParameters().set("id", viewDisplay.getView().getNanopub().getUri())));
+
         IRI nanopubId = viewDisplay.getNanopubId();
 
         // Determine whether "adjust" should be visible for this user on this page
@@ -61,19 +64,23 @@ public class ViewDisplayMenu extends BaseDisplayMenu {
             }
         }
 
-        // Determine supersede vs derive based on whether this user's pubkey matches the nanopub's
-        String nanopubPubkey = NanopubElement.get(viewDisplay.getNanopub()).getPubkey();
-        String sessionPubkey = session.getPubkeyString();
-        String adjustParam = (nanopubPubkey != null && nanopubPubkey.equals(sessionPubkey))
-                ? "supersede" : "derive";
-
-        IRI templateId = TemplateData.get().getTemplateId(viewDisplay.getNanopub());
-        String templateUri = templateId != null ? templateId.stringValue()
-                : "http://purl.org/np/RACyK2NjqFgezYLiE8FQu7JI0xY1M1aNQbykeCW8oqXkA";
-        String adjustUrl = PublishPage.MOUNT_PATH + "?template=" + Utils.urlEncode(templateUri)
-                + "&" + adjustParam + "=" + Utils.urlEncode(nanopubId.stringValue())
-                + "&template-version=latest"
-                + "&context=" + Utils.urlEncode(pageResource.getId());
+        // Determine supersede vs derive based on whether this user's pubkey matches the nanopub's.
+        // These are only needed when showAdjust is true (i.e. pageResource is non-null).
+        String adjustUrl = "";
+        String pageResourceId = pageResource != null ? pageResource.getId() : "";
+        if (showAdjust) {
+            String nanopubPubkey = NanopubElement.get(viewDisplay.getNanopub()).getPubkey();
+            String sessionPubkey = session.getPubkeyString();
+            String adjustParam = (nanopubPubkey != null && nanopubPubkey.equals(sessionPubkey))
+                    ? "supersede" : "derive";
+            IRI templateId = TemplateData.get().getTemplateId(viewDisplay.getNanopub());
+            String templateUri = templateId != null ? templateId.stringValue()
+                    : "http://purl.org/np/RACyK2NjqFgezYLiE8FQu7JI0xY1M1aNQbykeCW8oqXkA";
+            adjustUrl = PublishPage.MOUNT_PATH + "?template=" + Utils.urlEncode(templateUri)
+                    + "&" + adjustParam + "=" + Utils.urlEncode(nanopubId.stringValue())
+                    + "&template-version=latest"
+                    + "&context=" + Utils.urlEncode(pageResourceId);
+        }
         ExternalLink adjustLink = new ExternalLink("adjust", adjustUrl, "edit view display...");
         adjustLink.setVisible(showAdjust);
         addEntry("adjust", adjustLink);
@@ -82,10 +89,10 @@ public class ViewDisplayMenu extends BaseDisplayMenu {
                 new PageParameters()
                         .set("template", "https://w3id.org/np/RAZ47_4JquvEXk30HYnVeSgFRcQqHtpdibcfBOeqHI2j4")
                         .set("template-version", "latest")
-                        .set("param_resource", pageResource.getId())
+                        .set("param_resource", pageResourceId)
                         .set("param_view", viewDisplay.getViewIri() != null ? viewDisplay.getViewIri().stringValue() : viewDisplay.getView().getId())
-                        .set("context", pageResource.getId())
-                        .set("refresh-upon-publish", pageResource.getId()));
+                        .set("context", pageResourceId)
+                        .set("refresh-upon-publish", pageResourceId));
         deactivateLink.setVisible(showAdjust);
         addEntry("deactivate", deactivateLink);
 
@@ -120,8 +127,10 @@ public class ViewDisplayMenu extends BaseDisplayMenu {
         refreshLink.setVisible(session.getUserIri() != null);
         addEntry("refreshNow", refreshLink);
 
-        addEntry("viewDeclaration", new BookmarkablePageLink<Void>("viewDeclaration", ExplorePage.class,
-                new PageParameters().set("id", nanopubId)));
+        BookmarkablePageLink<Void> viewDeclarationLink = new BookmarkablePageLink<>("viewDeclaration", ExplorePage.class,
+                new PageParameters().set("id", nanopubId));
+        viewDeclarationLink.setVisible(viewDisplay.getId() != null);
+        addEntry("viewDeclaration", viewDeclarationLink);
     }
 
 }

--- a/src/main/java/com/knowledgepixels/nanodash/component/menu/ViewDisplayMenu.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/menu/ViewDisplayMenu.java
@@ -97,6 +97,7 @@ public class ViewDisplayMenu extends BaseDisplayMenu {
         addEntry("deactivate", deactivateLink);
 
         boolean showAddToOwn = session.getUserIri() != null
+                && viewDisplay.getViewIri() != null
                 && pageResource instanceof IndividualAgent ia && !ia.isCurrentUser();
         String addToOwnUrl = "";
         if (showAddToOwn) {

--- a/src/main/java/com/knowledgepixels/nanodash/page/HomePage.html
+++ b/src/main/java/com/knowledgepixels/nanodash/page/HomePage.html
@@ -21,12 +21,8 @@
     </div>
 
     <div class="col-6">
-      <div wicket:id="topCreators" class="users">
-        <div wicket:id="creatorsView">...</div>
-      </div>
-      <div wicket:id="getStartedTemplates" class="forms">
-        <div wicket:id="getStartedTemplatesView">...</div>
-      </div>
+      <div wicket:id="topCreators">...</div>
+      <div wicket:id="getStartedTemplates">...</div>
     </div>
   </div>
 

--- a/src/main/java/com/knowledgepixels/nanodash/page/HomePage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/HomePage.java
@@ -84,7 +84,7 @@ public class HomePage extends NanodashPage {
                 .add(AttributeModifier.remove("class"))
         );
 
-        View getStartedView = View.get("https://w3id.org/np/RARrw7fbTehd1bzIGQY-C9iEIFpL-0t7iURZx1whcgiGU/suggested-templates-get-started");
+        View getStartedView = View.get("https://w3id.org/np/RAeFTjDGTQ-bdulJy4tUlWzRlK8EucXFCxqLrb7Qj35SM/suggested-templates-get-started");
         QueryRef gQueryRef = new QueryRef(getStartedView.getQuery().getQueryId());
         add(QueryResultListBuilder.create("getStartedTemplates", gQueryRef, new ViewDisplay(getStartedView))
                 .build()

--- a/src/main/java/com/knowledgepixels/nanodash/page/HomePage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/HomePage.java
@@ -2,21 +2,10 @@ package com.knowledgepixels.nanodash.page;
 
 import com.knowledgepixels.nanodash.*;
 import com.knowledgepixels.nanodash.component.*;
-import com.knowledgepixels.nanodash.domain.User;
-import com.knowledgepixels.nanodash.template.Template;
-import com.knowledgepixels.nanodash.template.TemplateData;
 import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.markup.html.basic.Label;
-import org.apache.wicket.markup.repeater.Item;
-import org.apache.wicket.markup.repeater.data.DataView;
-import org.apache.wicket.markup.repeater.data.ListDataProvider;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
-import org.eclipse.rdf4j.model.IRI;
-import org.nanopub.extra.services.ApiResponseEntry;
 import org.nanopub.extra.services.QueryRef;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * The home page of Nanodash, which shows the most recent nanopublications
@@ -88,41 +77,19 @@ public class HomePage extends NanodashPage {
                 .add(AttributeModifier.remove("class"))
         );
 
-        View topCreatorsView = View.get("https://w3id.org/np/RAuv15ISgaPadgIj_LCSQNd2QRKmMcPulun6NyiblzEOs/top-creators-last-30days");
-        add(new DataView<ViewDisplay>("topCreators", new ListDataProvider<ViewDisplay>(List.of(new ViewDisplay(topCreatorsView)))) {
+        View topCreatorsView = View.get("https://w3id.org/np/RACcywnbkn6OAd_6E25qZL9-vdO-UwmpO1vXVWzNWJYLo/top-creators-last-30days");
+        QueryRef cQueryRef = new QueryRef(topCreatorsView.getQuery().getQueryId());
+        add(QueryResultListBuilder.create("topCreators", cQueryRef, new ViewDisplay(topCreatorsView))
+                .build()
+                .add(AttributeModifier.remove("class"))
+        );
 
-            @Override
-            protected void populateItem(Item<ViewDisplay> item) {
-                item.add(new ItemListPanel<IRI>(
-                        "creatorsView",
-                        topCreatorsView.getTitle(),
-                        new QueryRef(topCreatorsView.getQuery().getQueryId()),
-                        (apiResponse) -> {
-                            List<IRI> users = new ArrayList<>();
-                            for (ApiResponseEntry e : apiResponse.getData()) {
-                                users.add(Utils.vf.createIRI(e.get("userid")));
-                            }
-                            return users;
-                        },
-                        (userIri) -> new ItemListElement("item", UserPage.class, new PageParameters().set("id", userIri), User.getShortDisplayName(userIri))
-                ));
-            }
-        });
-
-        View getStartedView = View.get("https://w3id.org/np/RAx2ljM4FrwsW9evtQj5LJWlL21tJR3Z-b__PdOpws2lY/suggested-templates-get-started");
-        add(new DataView<ViewDisplay>("getStartedTemplates", new ListDataProvider<ViewDisplay>(List.of(new ViewDisplay(topCreatorsView)))) {
-
-            @Override
-            protected void populateItem(Item<ViewDisplay> item) {
-                item.add(new ItemListPanel<Template>(
-                        "getStartedTemplatesView",
-                        getStartedView.getTitle(),
-                        new QueryRef(getStartedView.getQuery().getQueryId()),
-                        TemplateData::getTemplateList,
-                        (template) -> new TemplateItem("item", template)
-                ));
-            }
-        });
+        View getStartedView = View.get("https://w3id.org/np/RAxs0UPoSkbNM-BZg15PeqClvXDFYOFFA4uCTUmoJR04U/suggested-templates-get-started");
+        QueryRef gQueryRef = new QueryRef(getStartedView.getQuery().getQueryId());
+        add(QueryResultListBuilder.create("getStartedTemplates", gQueryRef, new ViewDisplay(getStartedView))
+                .build()
+                .add(AttributeModifier.remove("class"))
+        );
 
     }
 

--- a/src/main/java/com/knowledgepixels/nanodash/page/HomePage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/HomePage.java
@@ -84,7 +84,7 @@ public class HomePage extends NanodashPage {
                 .add(AttributeModifier.remove("class"))
         );
 
-        View getStartedView = View.get("https://w3id.org/np/RAxs0UPoSkbNM-BZg15PeqClvXDFYOFFA4uCTUmoJR04U/suggested-templates-get-started");
+        View getStartedView = View.get("https://w3id.org/np/RARrw7fbTehd1bzIGQY-C9iEIFpL-0t7iURZx1whcgiGU/suggested-templates-get-started");
         QueryRef gQueryRef = new QueryRef(getStartedView.getQuery().getQueryId());
         add(QueryResultListBuilder.create("getStartedTemplates", gQueryRef, new ViewDisplay(getStartedView))
                 .build()

--- a/src/main/java/com/knowledgepixels/nanodash/page/UserListPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/UserListPage.java
@@ -1,19 +1,18 @@
 package com.knowledgepixels.nanodash.page;
 
-import com.knowledgepixels.nanodash.QueryApiAccess;
-import com.knowledgepixels.nanodash.Utils;
+import com.knowledgepixels.nanodash.View;
+import com.knowledgepixels.nanodash.ViewDisplay;
 import com.knowledgepixels.nanodash.component.ItemListElement;
 import com.knowledgepixels.nanodash.component.ItemListPanel;
+import com.knowledgepixels.nanodash.component.QueryResultListBuilder;
 import com.knowledgepixels.nanodash.component.TitleBar;
 import com.knowledgepixels.nanodash.domain.IndividualAgent;
 import com.knowledgepixels.nanodash.domain.User;
 import org.apache.wicket.markup.html.link.ExternalLink;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
 import org.eclipse.rdf4j.model.IRI;
-import org.nanopub.extra.services.ApiResponseEntry;
 import org.nanopub.extra.services.QueryRef;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -60,34 +59,13 @@ public class UserListPage extends NanodashPage {
 //
 //		});
 
-        add(new ItemListPanel<IRI>(
-                "topcreators",
-                "🔥 Most Active Nanopublishers Last Month",
-                new QueryRef(QueryApiAccess.GET_TOP_CREATORS_LAST30D),
-                (apiResponse) -> {
-                    List<IRI> users = new ArrayList<>();
-                    for (ApiResponseEntry e : apiResponse.getData()) {
-                        users.add(Utils.vf.createIRI(e.get("userid")));
-                    }
-                    return users;
-                },
-                (userIri) -> new ItemListElement("item", UserPage.class, new PageParameters().set("id", userIri), User.getShortDisplayName(userIri))
-        ));
+        View topCreatorsView = View.get("https://w3id.org/np/RACcywnbkn6OAd_6E25qZL9-vdO-UwmpO1vXVWzNWJYLo/top-creators-last-30days");
+        QueryRef tcQueryRef = new QueryRef(topCreatorsView.getQuery().getQueryId());
+        add(QueryResultListBuilder.create("topcreators", tcQueryRef, new ViewDisplay(topCreatorsView)).build());
 
-        add(new ItemListPanel<IRI>(
-                "latestusers",
-                "🆕 Latest New Users",
-                new QueryRef(QueryApiAccess.GET_LATEST_USERS),
-                (apiResponse) -> {
-                    List<IRI> users = new ArrayList<>();
-                    for (ApiResponseEntry e : apiResponse.getData()) {
-                        users.add(Utils.vf.createIRI(e.get("user")));
-                    }
-                    return users;
-                },
-                (userIri) -> new ItemListElement("item", UserPage.class, new PageParameters().set("id", userIri), User.getShortDisplayName(userIri)),
-                User::getShortDisplayName
-        ));
+        View latestUsersView = View.get("https://w3id.org/np/RAVWBxoYLQk7sa-STHN63vqUSMVZ9oiwEy6ye5rlbXGwU/latest-users");
+        QueryRef luQueryRef = new QueryRef(latestUsersView.getQuery().getQueryId());
+        add(QueryResultListBuilder.create("latestusers", luQueryRef, new ViewDisplay(latestUsersView)).build());
 
         add(new ItemListPanel<IRI>(
                 "approved-human-users",

--- a/src/main/java/com/knowledgepixels/nanodash/page/UserListPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/UserListPage.java
@@ -63,7 +63,7 @@ public class UserListPage extends NanodashPage {
         QueryRef tcQueryRef = new QueryRef(topCreatorsView.getQuery().getQueryId());
         add(QueryResultListBuilder.create("topcreators", tcQueryRef, new ViewDisplay(topCreatorsView)).build());
 
-        View latestUsersView = View.get("https://w3id.org/np/RAVWBxoYLQk7sa-STHN63vqUSMVZ9oiwEy6ye5rlbXGwU/latest-users");
+        View latestUsersView = View.get("https://w3id.org/np/RAYTXpoo3YtYYzzJn56fdS0g1odA7zLtwpuY8-GSncklA/latest-users");
         QueryRef luQueryRef = new QueryRef(latestUsersView.getQuery().getQueryId());
         add(QueryResultListBuilder.create("latestusers", luQueryRef, new ViewDisplay(latestUsersView)).build());
 

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -609,6 +609,11 @@ li:has(.templateref) {
   list-style-image: url('images/form-icon.svg');
 }
 
+li:has(.user-icon),
+li:has(.form-icon) {
+  list-style: none;
+}
+
 .sidelogo {
   margin-bottom: 50px;
 }

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -612,7 +612,12 @@ li:has(.templateref) {
 li:has(.user-icon),
 li:has(.form-icon) {
   list-style: none;
-  margin-left: -1.3em;
+  margin-left: -1em;
+}
+
+.users li:has(.user-icon),
+.users li:has(.form-icon) {
+  margin-left: -0.5em;
 }
 
 .sidelogo {

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -612,6 +612,7 @@ li:has(.templateref) {
 li:has(.user-icon),
 li:has(.form-icon) {
   list-style: none;
+  margin-left: -1.3em;
 }
 
 .sidelogo {


### PR DESCRIPTION
Closes #435

## Summary

- Convert the top-creators and get-started-templates sections on the home page from hard-coded `ItemListPanel` blocks to `View.get()` + `QueryResultListBuilder`, so they behave like proper views with dropdown menus
- Fix `ViewDisplay(View)` constructor to carry the view's nanopub, enabling dropdown menus on view displays that don't have a backing ViewDisplay nanopub
- Fix `ViewDisplayMenu` NPE when `pageResource` is null; guard adjust/deactivate actions inside `showAdjust` check
- Add "show view" entry to `ViewDisplayMenu` linking to the View definition nanopub
- Hide "show nanopub" in `ViewDisplayMenu` when no ViewDisplay nanopub exists (only show it when a real ViewDisplay nanopub backs the display)
- Add user icon and template icon rendering for `_user_iri` / `_template_iri` columns in `QueryResultList`: icon and name rendered together as a unit without an intermediate separator
- Publish new top-creators-last-30days query nanopub (`?user_iri` column, no count column) and matching view nanopub; update home page to reference new view

## Test plan

- [x] Home page loads without errors
- [x] Top creators section shows user icons alongside names, no count column
- [x] Dropdown menus (⋮) appear on home page view sections
- [x] "show query" and "show view" entries work in dropdown
- [x] "show nanopub" is hidden for home page views (no backing ViewDisplay nanopub), visible on resource page views that have one
- [ ] Adjust/deactivate entries only appear for logged-in users with edit rights
- [x] No regression on existing resource page view displays

🤖 Generated with [Claude Code](https://claude.com/claude-code)