### PR TITLE
feat: add filter field to all view types and convert publish page panels to proper views

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/FilteredQueryResultDataProvider.java
+++ b/src/main/java/com/knowledgepixels/nanodash/FilteredQueryResultDataProvider.java
@@ -35,7 +35,7 @@ public class FilteredQueryResultDataProvider implements ISortableDataProvider<Ap
         }
     }
 
-    private List<ApiResponseEntry> getFilteredData() {
+    public List<ApiResponseEntry> getFilteredData() {
         if (filteredData != null) {
             return filteredData;
         }

--- a/src/main/java/com/knowledgepixels/nanodash/component/NanopubResults.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/NanopubResults.java
@@ -58,8 +58,12 @@ public class NanopubResults extends Panel {
      * @return a new NanopubResults panel
      */
     public static NanopubResults fromApiResponse(String id, ApiResponse apiResponse, long itemPerPage) {
+        return fromApiResponse(id, apiResponse.getData(), itemPerPage);
+    }
+
+    public static NanopubResults fromApiResponse(String id, List<ApiResponseEntry> data, long itemPerPage) {
         NanopubResults r = new NanopubResults(id);
-        DataView<ApiResponseEntry> dataView = new DataView<ApiResponseEntry>("nanopubs", new ListDataProvider<ApiResponseEntry>(apiResponse.getData())) {
+        DataView<ApiResponseEntry> dataView = new DataView<ApiResponseEntry>("nanopubs", new ListDataProvider<ApiResponseEntry>(data)) {
 
             @Override
             protected void populateItem(Item<ApiResponseEntry> item) {

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultList.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultList.html
@@ -10,16 +10,19 @@
 <wicket:panel>
   <div class="paneltitlerow listpanel">
     <h4 wicket:id="label">Query</h4>
+    <input type="text" wicket:id="filter" placeholder="Filter..." style="margin: 5px 10px; padding: 2px 5px; font-size: 12px; width: 150px;"/>
     <span class="buttons"><wicket:container wicket:id="np">[np]</wicket:container></span>
     <span wicket:id="buttons" class="buttons"></span>
   </div>
 
-  <ul wicket:id="items" class="inline-list">
-    <li wicket:id="listItem"></li>
-  </ul>
-  <div class="navigation" wicket:id="navigation">
-    <div class="navigatorLabel" wicket:id="navigatorLabel"></div>
-    <div class="navigator" wicket:id="navigator"></div>
+  <div wicket:id="items-container">
+    <ul wicket:id="items" class="inline-list">
+      <li wicket:id="listItem"></li>
+    </ul>
+    <div class="navigation" wicket:id="navigation">
+      <div class="navigatorLabel" wicket:id="navigatorLabel"></div>
+      <div class="navigator" wicket:id="navigator"></div>
+    </div>
   </div>
 </wicket:panel>
 

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultList.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultList.java
@@ -10,7 +10,10 @@ import com.knowledgepixels.nanodash.page.UserPage;
 import com.knowledgepixels.nanodash.repository.MaintainedResourceRepository;
 import com.knowledgepixels.nanodash.template.Template;
 import org.apache.wicket.Component;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.ajax.form.AjaxFormComponentUpdatingBehavior;
 import org.apache.wicket.ajax.markup.html.navigation.paging.AjaxPagingNavigator;
+import org.apache.wicket.markup.html.form.TextField;
 import org.apache.wicket.extensions.markup.html.repeater.data.table.NavigatorLabel;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
@@ -39,6 +42,10 @@ public class QueryResultList extends QueryResult {
 
     private static final String SEPARATOR = " · ";
 
+    private FilteredQueryResultDataProvider filteredDataProvider;
+    private Model<String> filterModel = Model.of("");
+    private WebMarkupContainer itemsContainer;
+
     /**
      * Constructor for QueryResultList.
      *
@@ -56,13 +63,28 @@ public class QueryResultList extends QueryResult {
         }
         add(new Label("label", label));
         setOutputMarkupId(true);
+
+        TextField<String> filterField = new TextField<>("filter", filterModel);
+        filterField.setOutputMarkupId(true);
+        filterField.add(new AjaxFormComponentUpdatingBehavior("change") {
+            @Override
+            protected void onUpdate(AjaxRequestTarget target) {
+                if (filteredDataProvider != null && itemsContainer != null) {
+                    filteredDataProvider.setFilterText(filterModel.getObject());
+                    target.add(itemsContainer);
+                }
+            }
+        });
+        add(filterField);
+
         populateComponent();
     }
 
     @Override
     protected void populateComponent() {
         QueryResultDataProvider dataProvider = new QueryResultDataProvider(response.getData());
-        DataView<ApiResponseEntry> dataView = new DataView<>("items", dataProvider) {
+        filteredDataProvider = new FilteredQueryResultDataProvider(dataProvider, response);
+        DataView<ApiResponseEntry> dataView = new DataView<>("items", filteredDataProvider) {
 
             @Override
             protected void populateItem(Item<ApiResponseEntry> item) {
@@ -205,7 +227,6 @@ public class QueryResultList extends QueryResult {
             }
         };
         dataView.setItemsPerPage(10);
-        dataView.setOutputMarkupId(true);
 
         WebMarkupContainer navigation = new WebMarkupContainer("navigation");
         navigation.add(new NavigatorLabel("navigatorLabel", dataView));
@@ -213,8 +234,11 @@ public class QueryResultList extends QueryResult {
         navigation.setVisible(dataView.getPageCount() > 1);
         navigation.add(pagingNavigator);
 
-        add(navigation);
-        add(dataView);
+        itemsContainer = new WebMarkupContainer("items-container");
+        itemsContainer.setOutputMarkupId(true);
+        itemsContainer.add(dataView);
+        itemsContainer.add(navigation);
+        add(itemsContainer);
     }
 
 }

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultNanopubSet.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultNanopubSet.html
@@ -6,6 +6,7 @@
   <div class="paneltitlerow listpanel">
     <h4 wicket:id="title">[View Title]</h4>
     <div wicket:id="viewSelector" class="view-selector with-source">
+      <input type="text" wicket:id="filter" placeholder="Filter..." style="margin: 2px 10px; padding: 2px 5px; font-size: 12px; width: 150px;"/>
       <span wicket:id="listEnabler" class="list" onclick="toggleView();"></span>
       <span wicket:id="gridEnabler" class="grid" onclick="toggleView();"></span>
       <span class="buttons">
@@ -13,7 +14,9 @@
       </span>
     </div>
   </div>
-  <div class="flex-container" wicket:id="nanopubs"></div>
+  <div wicket:id="nanopubs-container">
+    <div class="flex-container" wicket:id="nanopubs"></div>
+  </div>
 </wicket:panel>
 
 </body>

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultNanopubSet.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultNanopubSet.java
@@ -1,14 +1,19 @@
 package com.knowledgepixels.nanodash.component;
 
+import com.knowledgepixels.nanodash.FilteredQueryResultDataProvider;
 import com.knowledgepixels.nanodash.NanodashSession;
 import com.knowledgepixels.nanodash.QueryResult;
+import com.knowledgepixels.nanodash.QueryResultDataProvider;
 import com.knowledgepixels.nanodash.ViewDisplay;
 import com.knowledgepixels.nanodash.component.menu.ViewDisplayMenu;
 import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.ajax.form.AjaxFormComponentUpdatingBehavior;
 import org.apache.wicket.ajax.markup.html.AjaxLink;
 import org.apache.wicket.behavior.AttributeAppender;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.form.TextField;
+import org.apache.wicket.model.Model;
 import org.nanopub.extra.services.ApiResponse;
 import org.nanopub.extra.services.QueryRef;
 import org.slf4j.Logger;
@@ -22,6 +27,9 @@ public class QueryResultNanopubSet extends QueryResult {
     private static final Logger logger = LoggerFactory.getLogger(QueryResultNanopubSet.class);
     private final WebMarkupContainer viewSelector;
     private final long itemsPerPage;
+    private FilteredQueryResultDataProvider filteredDataProvider;
+    private Model<String> filterModel = Model.of("");
+    private WebMarkupContainer nanopubsContainer;
 
     /**
      * Constructor for QueryResultList.
@@ -65,21 +73,45 @@ public class QueryResultNanopubSet extends QueryResult {
             titleLabel = viewDisplay.getTitle();
         }
         add(new Label("title", titleLabel));
+
+        TextField<String> filterField = new TextField<>("filter", filterModel);
+        filterField.setOutputMarkupId(true);
+        filterField.add(new AjaxFormComponentUpdatingBehavior("change") {
+            @Override
+            protected void onUpdate(AjaxRequestTarget target) {
+                if (filteredDataProvider != null && nanopubsContainer != null) {
+                    filteredDataProvider.setFilterText(filterModel.getObject());
+                    nanopubsContainer.addOrReplace(buildNanopubResults());
+                    target.add(nanopubsContainer);
+                }
+            }
+        });
+        viewSelector.add(filterField);
+
         setOutputMarkupId(true);
     }
 
     @Override
     protected void populateComponent() {
         logger.info("Populating the component with nanopub results.");
-        NanopubResults nanopubResults = NanopubResults.fromApiResponse("nanopubs", response, itemsPerPage);
-        nanopubResults.add(AttributeAppender.append("class", NanodashSession.get().getNanopubResultsViewMode().getValue()));
-        add(nanopubResults);
+        filteredDataProvider = new FilteredQueryResultDataProvider(new QueryResultDataProvider(response.getData()), response);
+
+        nanopubsContainer = new WebMarkupContainer("nanopubs-container");
+        nanopubsContainer.setOutputMarkupId(true);
+        nanopubsContainer.add(buildNanopubResults());
+        add(nanopubsContainer);
 
         if (viewDisplay.getNanopubId() != null) {
             viewSelector.addOrReplace(new ViewDisplayMenu("np", viewDisplay, queryRef, pageResource));
         } else {
             viewSelector.addOrReplace(new Label("np").setVisible(false));
         }
+    }
+
+    private NanopubResults buildNanopubResults() {
+        NanopubResults nanopubResults = NanopubResults.fromApiResponse("nanopubs", filteredDataProvider.getFilteredData(), itemsPerPage);
+        nanopubResults.add(AttributeAppender.append("class", NanodashSession.get().getNanopubResultsViewMode().getValue()));
+        return nanopubResults;
     }
 
     /**

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultPlainParagraph.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultPlainParagraph.html
@@ -10,15 +10,18 @@
 <wicket:panel>
   <div class="paneltitlerow listpanel">
     <h4 wicket:id="label">Paragraph</h4>
+    <input type="text" wicket:id="filter" placeholder="Filter..." style="margin: 5px 10px; padding: 2px 5px; font-size: 12px; width: 150px;"/>
     <span class="buttons"><wicket:container wicket:id="np">[np]</wicket:container></span>
     <span wicket:id="buttons" class="buttons"></span>
   </div>
-  <div wicket:id="paragraphs">
-    <div class="paragraph-header">
-      <h5 wicket:id="title">[title]</h5>
-      <span class="buttons"><a href="." wicket:id="pnp" class="smallbutton source">^</a></span>
+  <div wicket:id="paragraphs-container">
+    <div wicket:id="paragraphs">
+      <div class="paragraph-header">
+        <h5 wicket:id="title">[title]</h5>
+        <span class="buttons"><a href="." wicket:id="pnp" class="smallbutton source">^</a></span>
+      </div>
+      <p wicket:id="content">[content]</p>
     </div>
-    <p wicket:id="content">[content]</p>
   </div>
 </wicket:panel>
 

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultPlainParagraph.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultPlainParagraph.java
@@ -1,12 +1,19 @@
 package com.knowledgepixels.nanodash.component;
 
+import com.knowledgepixels.nanodash.FilteredQueryResultDataProvider;
 import com.knowledgepixels.nanodash.QueryResult;
+import com.knowledgepixels.nanodash.QueryResultDataProvider;
 import com.knowledgepixels.nanodash.ViewDisplay;
 import com.knowledgepixels.nanodash.page.ExplorePage;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.ajax.form.AjaxFormComponentUpdatingBehavior;
+import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.form.TextField;
 import org.apache.wicket.markup.html.link.BookmarkablePageLink;
 import org.apache.wicket.markup.html.list.ListItem;
 import org.apache.wicket.markup.html.list.ListView;
+import org.apache.wicket.model.Model;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
 import org.nanopub.extra.services.ApiResponse;
 import org.nanopub.extra.services.ApiResponseEntry;
@@ -16,6 +23,10 @@ import org.nanopub.extra.services.QueryRef;
  * Component for displaying query results in a list format.
  */
 public class QueryResultPlainParagraph extends QueryResult {
+
+    private FilteredQueryResultDataProvider filteredDataProvider;
+    private Model<String> filterModel = Model.of("");
+    private WebMarkupContainer paragraphsContainer;
 
     /**
      * Constructor for QueryResultList.
@@ -34,12 +45,36 @@ public class QueryResultPlainParagraph extends QueryResult {
         }
         add(new Label("label", label));
         setOutputMarkupId(true);
+
+        TextField<String> filterField = new TextField<>("filter", filterModel);
+        filterField.setOutputMarkupId(true);
+        filterField.add(new AjaxFormComponentUpdatingBehavior("change") {
+            @Override
+            protected void onUpdate(AjaxRequestTarget target) {
+                if (filteredDataProvider != null && paragraphsContainer != null) {
+                    filteredDataProvider.setFilterText(filterModel.getObject());
+                    paragraphsContainer.addOrReplace(buildParagraphsView());
+                    target.add(paragraphsContainer);
+                }
+            }
+        });
+        add(filterField);
+
         populateComponent();
     }
 
     @Override
     protected void populateComponent() {
-        add(new ListView<>("paragraphs", response.getData()) {
+        filteredDataProvider = new FilteredQueryResultDataProvider(new QueryResultDataProvider(response.getData()), response);
+
+        paragraphsContainer = new WebMarkupContainer("paragraphs-container");
+        paragraphsContainer.setOutputMarkupId(true);
+        paragraphsContainer.add(buildParagraphsView());
+        add(paragraphsContainer);
+    }
+
+    private ListView<ApiResponseEntry> buildParagraphsView() {
+        return new ListView<>("paragraphs", filteredDataProvider.getFilteredData()) {
             @Override
             protected void populateItem(ListItem<ApiResponseEntry> item) {
                 item.add(new Label("title", item.getModelObject().get("title")));
@@ -51,7 +86,7 @@ public class QueryResultPlainParagraph extends QueryResult {
                 }
                 item.add(new Label("content", item.getModelObject().get("content")).setEscapeModelStrings(false));
             }
-        });
+        };
     }
 
 }

--- a/src/main/java/com/knowledgepixels/nanodash/component/TemplateList.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/TemplateList.java
@@ -13,8 +13,8 @@ import org.apache.wicket.markup.repeater.data.ListDataProvider;
 import org.nanopub.extra.services.ApiResponseEntry;
 import org.nanopub.extra.services.QueryRef;
 
-import com.knowledgepixels.nanodash.QueryApiAccess;
-import com.knowledgepixels.nanodash.template.Template;
+import com.knowledgepixels.nanodash.View;
+import com.knowledgepixels.nanodash.ViewDisplay;
 import com.knowledgepixels.nanodash.template.TemplateData;
 
 import jakarta.xml.bind.DatatypeConverter;
@@ -33,21 +33,13 @@ public class TemplateList extends Panel {
         super(id);
         setOutputMarkupId(true);
 
-        add(new ItemListPanel<Template>(
-                "popular-templates",
-                "⭐ Popular Templates",
-                new QueryRef(QueryApiAccess.GET_MOST_USED_TEMPLATES_LAST30D),
-                TemplateData::getTemplateList,
-                (template) -> new TemplateItem("item", template)
-        ));
+        View popularTemplatesView = View.get("https://w3id.org/np/RAYMZEdmvjIS5QGFASa8L5hygapUlvK3feZBpG6quMYqc/popular-templates");
+        QueryRef ptQueryRef = new QueryRef(popularTemplatesView.getQuery().getQueryId());
+        add(QueryResultListBuilder.create("popular-templates", ptQueryRef, new ViewDisplay(popularTemplatesView)).build());
 
-        add(new ItemListPanel<Template>(
-                "getstarted-templates",
-                "🚀 Suggested Templates to Get Started",
-                new QueryRef(QueryApiAccess.GET_SUGGESTED_TEMPLATES_TO_GET_STARTED),
-                TemplateData::getTemplateList,
-                (template) -> new TemplateItem("item", template)
-        ));
+        View getStartedView = View.get("https://w3id.org/np/RAeFTjDGTQ-bdulJy4tUlWzRlK8EucXFCxqLrb7Qj35SM/suggested-templates-get-started");
+        QueryRef gsQueryRef = new QueryRef(getStartedView.getQuery().getQueryId());
+        add(QueryResultListBuilder.create("getstarted-templates", gsQueryRef, new ViewDisplay(getStartedView)).build());
 
         ArrayList<ApiResponseEntry> templateList = new ArrayList<>(TemplateData.get().getAssertionTemplates());
         templateList.sort((t1, t2) -> {

--- a/src/main/java/com/knowledgepixels/nanodash/page/HomePage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/HomePage.java
@@ -62,7 +62,7 @@ public class HomePage extends NanodashPage {
 
         setOutputMarkupId(true);
 
-        View mostRecentNanopubsView = View.get("https://w3id.org/np/RA85WirEeiXnxKdoL5IJMgnz9J5KcQLivapXLzTrupT6k/most-recent-nanopubs");
+        View mostRecentNanopubsView = View.get("https://w3id.org/np/RAawFcLhQOJfA9Ke1spCNkXWA68J1O-wOJrSmBdNFsAtI/most-recent-nanopubs");
         QueryRef rQueryRef = new QueryRef(mostRecentNanopubsView.getQuery().getQueryId());
         add(QueryResultNanopubSetBuilder.create("mostrecent", rQueryRef, new ViewDisplay(mostRecentNanopubsView))
                 .setItemsPerPage(5)

--- a/src/main/java/com/knowledgepixels/nanodash/page/UserListPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/UserListPage.java
@@ -63,7 +63,7 @@ public class UserListPage extends NanodashPage {
         QueryRef tcQueryRef = new QueryRef(topCreatorsView.getQuery().getQueryId());
         add(QueryResultListBuilder.create("topcreators", tcQueryRef, new ViewDisplay(topCreatorsView)).build());
 
-        View latestUsersView = View.get("https://w3id.org/np/RAYTXpoo3YtYYzzJn56fdS0g1odA7zLtwpuY8-GSncklA/latest-users");
+        View latestUsersView = View.get("https://w3id.org/np/RAtwNLvsJbz3pk_UxdKSydsghbX6D_60ivTZpDQhK-9zA/latest-users");
         QueryRef luQueryRef = new QueryRef(latestUsersView.getQuery().getQueryId());
         add(QueryResultListBuilder.create("latestusers", luQueryRef, new ViewDisplay(latestUsersView)).build());
 


### PR DESCRIPTION
## Summary
- Add text filter field to list views, nanopub set views, and plain paragraph views (matching the existing table view filter behavior)
- Fix Wicket repeater AJAX issue in `QueryResultList` by wrapping `DataView` in a `WebMarkupContainer`
- Convert Popular Templates and Get Started panels on `/publish` page to proper views via `QueryResultListBuilder`
- Update `HomePage` and `UserListPage` to reference latest view nanopub URIs directly (🆕 Latest Nanopublications, 🌱 Latest New Users)

## Test plan
- [ ] Filter field appears and works in list views (e.g. top creators, latest users on `/userlist`)
- [ ] Filter field appears and works in nanopub set views (e.g. latest nanopubs on home page)
- [ ] Filter field appears and works in plain paragraph views
- [ ] Filter field in nanopub set is accessible (inside view selector, not hidden behind it)
- [ ] Popular Templates and Get Started on `/publish` render with view title and dropdown menu
- [ ] Home page shows 🆕 Latest Nanopublications title
- [ ] `/userlist` shows 🌱 Latest New Users title

🤖 Generated with [Claude Code](https://claude.com/claude-code)