### PR TITLE
feat: implement ItemListView and fix async view rendering

### DIFF
--- a/docker-compose.override.yml.template
+++ b/docker-compose.override.yml.template
@@ -10,6 +10,9 @@ services:
       - NANODASH_MAIN_QUERY=https://query.knowledgepixels.com/
       - NANODASH_UMAMI_SCRIPT_URL=https://your.umami.instance/script.js
       - NANODASH_UMAMI_WEBSITE_ID=your-umami-website-id
+      # The maintained resource whose view displays are shown on the home page.
+      # Default: https://w3id.org/spaces/knowledgepixels/nanodash/r/home
+      #- NANODASH_HOME_RESOURCE=https://w3id.org/spaces/your/resource/r/home
 
   backup-keys:
     build: ./backup-keys

--- a/src/main/java/com/knowledgepixels/nanodash/FilteredQueryResultDataProvider.java
+++ b/src/main/java/com/knowledgepixels/nanodash/FilteredQueryResultDataProvider.java
@@ -8,6 +8,7 @@ import org.nanopub.extra.services.ApiResponse;
 import org.nanopub.extra.services.ApiResponseEntry;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
@@ -70,14 +71,16 @@ public class FilteredQueryResultDataProvider implements ISortableDataProvider<Ap
         SortParam<String> sortParam = baseProvider.getSortParam();
         if (sortParam != null) {
             String prop = sortParam.getProperty();
+            String labelProp = prop + "_label";
+            String sortProp = Arrays.asList(response.getHeader()).contains(labelProp) ? labelProp : prop;
             data.sort((o1, o2) -> {
-                String v1 = o1.get(prop);
-                String v2 = o2.get(prop);
+                String v1 = o1.get(sortProp);
+                String v2 = o2.get(sortProp);
                 int result;
                 if (v1 == null && v2 == null) result = 0;
                 else if (v1 == null) result = 1;
                 else if (v2 == null) result = -1;
-                else result = v1.compareTo(v2);
+                else result = v1.compareToIgnoreCase(v2);
                 if (!sortParam.isAscending()) result = -result;
                 return result;
             });

--- a/src/main/java/com/knowledgepixels/nanodash/FilteredQueryResultDataProvider.java
+++ b/src/main/java/com/knowledgepixels/nanodash/FilteredQueryResultDataProvider.java
@@ -2,6 +2,7 @@ package com.knowledgepixels.nanodash;
 
 import org.apache.wicket.extensions.markup.html.repeater.data.sort.ISortState;
 import org.apache.wicket.extensions.markup.html.repeater.data.table.ISortableDataProvider;
+import org.apache.wicket.extensions.markup.html.repeater.util.SortParam;
 import org.apache.wicket.model.IModel;
 import org.nanopub.extra.services.ApiResponse;
 import org.nanopub.extra.services.ApiResponseEntry;
@@ -65,7 +66,22 @@ public class FilteredQueryResultDataProvider implements ISortableDataProvider<Ap
 
     @Override
     public Iterator<? extends ApiResponseEntry> iterator(long first, long count) {
-        List<ApiResponseEntry> data = getFilteredData();
+        List<ApiResponseEntry> data = new ArrayList<>(getFilteredData());
+        SortParam<String> sortParam = baseProvider.getSortParam();
+        if (sortParam != null) {
+            String prop = sortParam.getProperty();
+            data.sort((o1, o2) -> {
+                String v1 = o1.get(prop);
+                String v2 = o2.get(prop);
+                int result;
+                if (v1 == null && v2 == null) result = 0;
+                else if (v1 == null) result = 1;
+                else if (v2 == null) result = -1;
+                else result = v1.compareTo(v2);
+                if (!sortParam.isAscending()) result = -result;
+                return result;
+            });
+        }
         return Utils.subList(data, first, first + count).iterator();
     }
 

--- a/src/main/java/com/knowledgepixels/nanodash/NanodashPreferences.java
+++ b/src/main/java/com/knowledgepixels/nanodash/NanodashPreferences.java
@@ -51,6 +51,7 @@ public class NanodashPreferences implements Serializable {
     private String settingUri;
     private String umamiScriptUrl;
     private String umamiWebsiteId;
+    private String homeResource = "https://w3id.org/spaces/knowledgepixels/nanodash/r/home";
     public static final String DEFAULT_SETTING_PATH = "/.nanopub/nanodash-preferences.yml";
 
     /**
@@ -250,6 +251,20 @@ public class NanodashPreferences implements Serializable {
      */
     public void setUmamiWebsiteId(String umamiWebsiteId) {
         this.umamiWebsiteId = umamiWebsiteId;
+    }
+
+    public String getHomeResource() {
+        String s = System.getenv("NANODASH_HOME_RESOURCE");
+        if (s != null && !s.isBlank()) {
+            logger.debug("Found environment variable NANODASH_HOME_RESOURCE with value: {}", s);
+            return s;
+        }
+        logger.debug("Environment variable NANODASH_HOME_RESOURCE not set, using default: {}", homeResource);
+        return homeResource;
+    }
+
+    public void setHomeResource(String homeResource) {
+        this.homeResource = homeResource;
     }
 
 }

--- a/src/main/java/com/knowledgepixels/nanodash/QueryResult.java
+++ b/src/main/java/com/knowledgepixels/nanodash/QueryResult.java
@@ -5,7 +5,6 @@ import com.knowledgepixels.nanodash.component.menu.ViewDisplayMenu;
 import com.knowledgepixels.nanodash.domain.AbstractResourceWithProfile;
 import com.knowledgepixels.nanodash.domain.IndividualAgent;
 import com.knowledgepixels.nanodash.page.NanodashPage;
-import org.apache.wicket.behavior.AttributeAppender;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.link.AbstractLink;
 import org.apache.wicket.markup.html.link.BookmarkablePageLink;
@@ -49,8 +48,6 @@ public abstract class QueryResult extends Panel {
         this.viewDisplay = viewDisplay;
         this.response = response;
         this.grlcQuery = GrlcQuery.get(queryRef);
-
-        add(new AttributeAppender("class", " col-" + viewDisplay.getDisplayWidth()));
     }
 
     @Override

--- a/src/main/java/com/knowledgepixels/nanodash/QueryResultDataProvider.java
+++ b/src/main/java/com/knowledgepixels/nanodash/QueryResultDataProvider.java
@@ -3,6 +3,7 @@ package com.knowledgepixels.nanodash;
 import org.apache.wicket.extensions.markup.html.repeater.data.sort.ISortState;
 import org.apache.wicket.extensions.markup.html.repeater.data.table.ISortableDataProvider;
 import org.apache.wicket.extensions.markup.html.repeater.util.SingleSortState;
+import org.apache.wicket.extensions.markup.html.repeater.util.SortParam;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 import org.nanopub.extra.services.ApiResponseEntry;
@@ -53,6 +54,10 @@ public class QueryResultDataProvider implements ISortableDataProvider<ApiRespons
     @Override
     public ISortState<String> getSortState() {
         return sortState;
+    }
+
+    public SortParam<String> getSortParam() {
+        return sortState.getSort();
     }
 
     @Override

--- a/src/main/java/com/knowledgepixels/nanodash/Utils.java
+++ b/src/main/java/com/knowledgepixels/nanodash/Utils.java
@@ -149,6 +149,13 @@ public class Utils {
         return URLEncoder.encode((o == null ? "" : o.toString()), Charsets.UTF_8);
     }
 
+    public static String truncateLabel(String label) {
+        if (label != null && label.length() > 120) {
+            return label.substring(0, 100) + "...";
+        }
+        return label;
+    }
+
     /**
      * URL-decodes the string representation of the given object using UTF-8 encoding.
      *

--- a/src/main/java/com/knowledgepixels/nanodash/ViewDisplay.java
+++ b/src/main/java/com/knowledgepixels/nanodash/ViewDisplay.java
@@ -241,6 +241,11 @@ public class ViewDisplay implements Serializable, Comparable<ViewDisplay> {
         return 12;
     }
 
+    public ViewDisplay withDisplayWidth(int width) {
+        this.displayWidth = width;
+        return this;
+    }
+
     public String getStructuralPosition() {
         if (structuralPosition != null) return structuralPosition;
         if (view == null) return "5.5.default";

--- a/src/main/java/com/knowledgepixels/nanodash/component/NanopubItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/NanopubItem.java
@@ -91,7 +91,7 @@ public class NanopubItem extends Panel {
             add(new Label("header", "").setVisible(false));
         } else {
             WebMarkupContainer header = new WebMarkupContainer("header");
-            String labelString = n.getLabel();
+            String labelString = Utils.truncateLabel(n.getLabel());
             if (labelString == null || labelString.isBlank()) labelString = Utils.getShortNanopubId(n.getUri());
             header.add(NanodashLink.createLink("nanopub-id-link", n.getUri(), labelString, null));
             if (!hideActionMenu && (actions == null || !actions.isEmpty())) {

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultItemList.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultItemList.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html xmlns:wicket="http://wicket.apache.org">
+
+<head>
+  <link rel="stylesheet" href="../../../../../webapp/style.css?for-local-testing-only" type="text/css" media="screen"
+        title="Stylesheet"/>
+</head>
+<body style="margin-left: auto; margin-right: auto; max-width: 1420px">
+
+<wicket:panel>
+  <div class="paneltitlerow listpanel">
+    <h4 wicket:id="label">Query</h4>
+    <input type="text" wicket:id="filter" placeholder="Filter..." style="margin: 5px 10px; padding: 2px 5px; font-size: 12px; width: 150px;"/>
+    <span class="buttons"><wicket:container wicket:id="np">[np]</wicket:container></span>
+    <span wicket:id="buttons" class="buttons"></span>
+  </div>
+
+  <div wicket:id="items-container">
+    <ul wicket:id="items">
+      <li wicket:id="listItem"></li>
+    </ul>
+    <div class="navigation" wicket:id="navigation">
+      <div class="navigatorLabel" wicket:id="navigatorLabel"></div>
+      <div class="navigator" wicket:id="navigator"></div>
+    </div>
+  </div>
+</wicket:panel>
+
+</body>
+
+</html>

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultItemList.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultItemList.java
@@ -1,0 +1,129 @@
+package com.knowledgepixels.nanodash.component;
+
+import com.knowledgepixels.nanodash.*;
+import com.knowledgepixels.nanodash.domain.IndividualAgent;
+import com.knowledgepixels.nanodash.domain.User;
+import com.knowledgepixels.nanodash.page.PublishPage;
+import com.knowledgepixels.nanodash.page.UserPage;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.ajax.form.AjaxFormComponentUpdatingBehavior;
+import org.apache.wicket.ajax.markup.html.navigation.paging.AjaxPagingNavigator;
+import org.apache.wicket.extensions.markup.html.repeater.data.table.NavigatorLabel;
+import org.apache.wicket.markup.html.WebMarkupContainer;
+import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.form.TextField;
+import org.apache.wicket.markup.repeater.Item;
+import org.apache.wicket.markup.repeater.data.DataView;
+import org.apache.wicket.model.Model;
+import org.apache.wicket.request.cycle.RequestCycle;
+import org.apache.wicket.request.resource.ContextRelativeResourceReference;
+import org.apache.wicket.util.string.Strings;
+import org.eclipse.rdf4j.model.IRI;
+import org.nanopub.extra.services.ApiResponse;
+import org.nanopub.extra.services.ApiResponseEntry;
+import org.nanopub.extra.services.QueryRef;
+
+/**
+ * Component for displaying query results as a vertical item list.
+ * Each result row is rendered as a single linked item, with icon handling
+ * for user_iri and template_iri columns.
+ */
+public class QueryResultItemList extends QueryResult {
+
+    private FilteredQueryResultDataProvider filteredDataProvider;
+    private final Model<String> filterModel = Model.of("");
+    private WebMarkupContainer itemsContainer;
+
+    QueryResultItemList(String markupId, QueryRef queryRef, ApiResponse response, ViewDisplay viewDisplay) {
+        super(markupId, queryRef, response, viewDisplay);
+
+        String label = grlcQuery.getLabel();
+        if (viewDisplay.getTitle() != null) {
+            label = viewDisplay.getTitle();
+        }
+        add(new Label("label", label));
+        setOutputMarkupId(true);
+
+        TextField<String> filterField = new TextField<>("filter", filterModel);
+        filterField.setOutputMarkupId(true);
+        filterField.add(new AjaxFormComponentUpdatingBehavior("change") {
+            @Override
+            protected void onUpdate(AjaxRequestTarget target) {
+                if (filteredDataProvider != null && itemsContainer != null) {
+                    filteredDataProvider.setFilterText(filterModel.getObject());
+                    target.add(itemsContainer);
+                }
+            }
+        });
+        add(filterField);
+
+        populateComponent();
+    }
+
+    @Override
+    protected void populateComponent() {
+        QueryResultDataProvider dataProvider = new QueryResultDataProvider(response.getData());
+        filteredDataProvider = new FilteredQueryResultDataProvider(dataProvider, response);
+
+        DataView<ApiResponseEntry> dataView = new DataView<>("items", filteredDataProvider) {
+            @Override
+            protected void populateItem(Item<ApiResponseEntry> item) {
+                ApiResponseEntry entry = item.getModelObject();
+                for (String key : response.getHeader()) {
+                    if (key.endsWith("_label") || key.endsWith("_label_multi")) continue;
+                    String value = entry.get(key);
+                    if (value == null || value.isBlank()) continue;
+                    String entryLabel = entry.get(key + "_label");
+
+                    if (key.endsWith("user_iri")) {
+                        IRI userIri = Utils.vf.createIRI(value);
+                        IRI profilePicIri = User.getProfilePicture(userIri);
+                        String imgSrc;
+                        String iconClass;
+                        if (profilePicIri != null) {
+                            imgSrc = Strings.escapeMarkup(profilePicIri.stringValue()).toString();
+                            iconClass = "user-icon";
+                        } else if (IndividualAgent.isSoftware(userIri)) {
+                            imgSrc = RequestCycle.get().urlFor(new ContextRelativeResourceReference("images/bot-icon.svg", false), null).toString();
+                            iconClass = "bot-icon";
+                        } else {
+                            imgSrc = RequestCycle.get().urlFor(new ContextRelativeResourceReference("images/user-icon.svg", false), null).toString();
+                            iconClass = "user-icon";
+                        }
+                        String displayLabel = (entryLabel != null && !entryLabel.isBlank()) ? entryLabel : User.getShortDisplayName(userIri);
+                        String userUrl = UserPage.MOUNT_PATH + "?id=" + Utils.urlEncode(value);
+                        String html = "<img class=\"" + iconClass + "\" src=\"" + imgSrc + "\" /> <a href=\"" + Strings.escapeMarkup(userUrl) + "\">" + Strings.escapeMarkup(displayLabel) + "</a>";
+                        item.add(new Label("listItem", html).setEscapeModelStrings(false));
+                        return;
+                    } else if (key.endsWith("template_iri")) {
+                        String displayLabel = (entryLabel != null && !entryLabel.isBlank()) ? entryLabel : value;
+                        String templateUrl = PublishPage.MOUNT_PATH + "?template=" + Utils.urlEncode(value) + "&template-version=latest";
+                        String html = "<span class=\"form-icon\"></span> <a href=\"" + Strings.escapeMarkup(templateUrl) + "\">" + Strings.escapeMarkup(displayLabel) + "</a>";
+                        item.add(new Label("listItem", html).setEscapeModelStrings(false));
+                        return;
+                    } else if (value.matches("https?://.*")) {
+                        item.add(new NanodashLink("listItem", value, null, null, entryLabel, contextId));
+                        return;
+                    } else {
+                        item.add(new Label("listItem", value));
+                        return;
+                    }
+                }
+                item.add(new Label("listItem", ""));
+            }
+        };
+        dataView.setItemsPerPage(viewDisplay.getPageSize());
+
+        WebMarkupContainer navigation = new WebMarkupContainer("navigation");
+        navigation.add(new NavigatorLabel("navigatorLabel", dataView));
+        AjaxPagingNavigator pagingNavigator = new AjaxPagingNavigator("navigator", dataView);
+        navigation.setVisible(dataView.getPageCount() > 1);
+        navigation.add(pagingNavigator);
+
+        itemsContainer = new WebMarkupContainer("items-container");
+        itemsContainer.setOutputMarkupId(true);
+        itemsContainer.add(dataView);
+        itemsContainer.add(navigation);
+        add(itemsContainer);
+    }
+}

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultItemListBuilder.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultItemListBuilder.java
@@ -1,0 +1,75 @@
+package com.knowledgepixels.nanodash.component;
+
+import com.knowledgepixels.nanodash.ApiCache;
+import com.knowledgepixels.nanodash.ViewDisplay;
+import org.apache.wicket.behavior.AttributeAppender;
+import com.knowledgepixels.nanodash.domain.AbstractResourceWithProfile;
+import org.apache.wicket.Component;
+import org.nanopub.extra.services.ApiResponse;
+import org.nanopub.extra.services.QueryRef;
+
+import java.io.Serializable;
+
+/**
+ * Builder class for creating QueryResultItemList components.
+ */
+public class QueryResultItemListBuilder implements Serializable {
+
+    private final String markupId;
+    private final ViewDisplay viewDisplay;
+    private String contextId = null;
+    private final QueryRef queryRef;
+    private AbstractResourceWithProfile pageResource = null;
+
+    private QueryResultItemListBuilder(String markupId, QueryRef queryRef, ViewDisplay viewDisplay) {
+        this.markupId = markupId;
+        this.queryRef = queryRef;
+        this.viewDisplay = viewDisplay;
+    }
+
+    public static QueryResultItemListBuilder create(String markupId, QueryRef queryRef, ViewDisplay viewDisplay) {
+        return new QueryResultItemListBuilder(markupId, queryRef, viewDisplay);
+    }
+
+    public QueryResultItemListBuilder contextId(String contextId) {
+        this.contextId = contextId;
+        return this;
+    }
+
+    public QueryResultItemListBuilder resourceWithProfile(AbstractResourceWithProfile resourceWithProfile) {
+        return this;
+    }
+
+    public QueryResultItemListBuilder id(String id) {
+        return this;
+    }
+
+    public QueryResultItemListBuilder pageResource(AbstractResourceWithProfile pageResource) {
+        this.pageResource = pageResource;
+        return this;
+    }
+
+    public Component build() {
+        ApiResponse response = ApiCache.retrieveResponseAsync(queryRef);
+        String colClass = " col-" + viewDisplay.getDisplayWidth();
+        if (response != null) {
+            QueryResultItemList result = new QueryResultItemList(markupId, queryRef, response, viewDisplay);
+            result.setContextId(contextId);
+            result.setPageResource(pageResource);
+            result.add(new AttributeAppender("class", colClass));
+            return result;
+        } else {
+            ApiResultComponent comp = new ApiResultComponent(markupId, queryRef) {
+                @Override
+                public Component getApiResultComponent(String id, ApiResponse r) {
+                    QueryResultItemList result = new QueryResultItemList(id, queryRef, r, viewDisplay);
+                    result.setContextId(contextId);
+                    result.setPageResource(pageResource);
+                    return result;
+                }
+            };
+            comp.add(new AttributeAppender("class", colClass));
+            return comp;
+        }
+    }
+}

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultList.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultList.java
@@ -226,7 +226,7 @@ public class QueryResultList extends QueryResult {
                 item.add(listItem);
             }
         };
-        dataView.setItemsPerPage(10);
+        dataView.setItemsPerPage(viewDisplay.getPageSize());
 
         WebMarkupContainer navigation = new WebMarkupContainer("navigation");
         navigation.add(new NavigatorLabel("navigatorLabel", dataView));

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultListBuilder.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultListBuilder.java
@@ -7,6 +7,7 @@ import com.knowledgepixels.nanodash.page.PublishPage;
 import com.knowledgepixels.nanodash.repository.MaintainedResourceRepository;
 import com.knowledgepixels.nanodash.template.Template;
 import org.apache.wicket.Component;
+import org.apache.wicket.behavior.AttributeAppender;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
 import org.eclipse.rdf4j.model.IRI;
 import org.nanopub.extra.services.ApiResponse;
@@ -78,6 +79,7 @@ public class QueryResultListBuilder implements Serializable {
      */
     public Component build() {
         ApiResponse response = ApiCache.retrieveResponseAsync(queryRef);
+        String colClass = " col-" + viewDisplay.getDisplayWidth();
         if (resourceWithProfile != null) {
             if (response != null) {
                 QueryResultList resultList = new QueryResultList(markupId, queryRef, response, viewDisplay);
@@ -118,9 +120,10 @@ public class QueryResultListBuilder implements Serializable {
                         resultList.addButton(label, PublishPage.class, params);
                     }
                 }
+                resultList.add(new AttributeAppender("class", colClass));
                 return resultList;
             } else {
-                return new ApiResultComponent(markupId, queryRef) {
+                ApiResultComponent comp = new ApiResultComponent(markupId, queryRef) {
                     @Override
                     public Component getApiResultComponent(String markupId, ApiResponse response) {
                         QueryResultList resultList = new QueryResultList(markupId, queryRef, response, viewDisplay);
@@ -163,15 +166,18 @@ public class QueryResultListBuilder implements Serializable {
                         return resultList;
                     }
                 };
+                comp.add(new AttributeAppender("class", colClass));
+                return comp;
             }
         } else {
             if (response != null) {
                 QueryResultList resultList = new QueryResultList(markupId, queryRef, response, viewDisplay);
                 resultList.setPageResource(pageResource);
                 resultList.setContextId(contextId);
+                resultList.add(new AttributeAppender("class", colClass));
                 return resultList;
             } else {
-                return new ApiResultComponent(markupId, queryRef) {
+                ApiResultComponent comp = new ApiResultComponent(markupId, queryRef) {
                     @Override
                     public Component getApiResultComponent(String markupId, ApiResponse response) {
                         QueryResultList resultList = new QueryResultList(markupId, queryRef, response, viewDisplay);
@@ -180,6 +186,8 @@ public class QueryResultListBuilder implements Serializable {
                         return resultList;
                     }
                 };
+                comp.add(new AttributeAppender("class", colClass));
+                return comp;
             }
         }
     }

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultNanopubSetBuilder.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultNanopubSetBuilder.java
@@ -2,6 +2,7 @@ package com.knowledgepixels.nanodash.component;
 
 import com.knowledgepixels.nanodash.ApiCache;
 import com.knowledgepixels.nanodash.ViewDisplay;
+import org.apache.wicket.behavior.AttributeAppender;
 import com.knowledgepixels.nanodash.domain.AbstractResourceWithProfile;
 import org.apache.wicket.Component;
 import org.nanopub.extra.services.ApiResponse;
@@ -20,7 +21,7 @@ public class QueryResultNanopubSetBuilder implements Serializable {
     private final QueryRef queryRef;
     private boolean hasTitle = true;
     private AbstractResourceWithProfile pageResource = null;
-    private long itemsPerPage = 10;
+    private Long itemsPerPage = null;
 
     private QueryResultNanopubSetBuilder(String markupId, QueryRef queryRef, ViewDisplay viewDisplay) {
         this.markupId = markupId;
@@ -78,18 +79,21 @@ public class QueryResultNanopubSetBuilder implements Serializable {
      */
     public Component build() {
         ApiResponse response = ApiCache.retrieveResponseAsync(queryRef);
+        String colClass = " col-" + viewDisplay.getDisplayWidth();
+        long resolvedItemsPerPage = itemsPerPage != null ? itemsPerPage : viewDisplay.getPageSize();
         if (response != null) {
-            QueryResultNanopubSet queryResultNanopubSet = new QueryResultNanopubSet(markupId, queryRef, response, viewDisplay, itemsPerPage);
+            QueryResultNanopubSet queryResultNanopubSet = new QueryResultNanopubSet(markupId, queryRef, response, viewDisplay, resolvedItemsPerPage);
             queryResultNanopubSet.setContextId(contextId);
             queryResultNanopubSet.setPageResource(pageResource);
             queryResultNanopubSet.populateComponent();
             queryResultNanopubSet.setTitleVisible(hasTitle);
+            queryResultNanopubSet.add(new AttributeAppender("class", colClass));
             return queryResultNanopubSet;
         } else {
-            return new ApiResultComponent(markupId, queryRef) {
+            ApiResultComponent comp = new ApiResultComponent(markupId, queryRef) {
                 @Override
                 public Component getApiResultComponent(String markupId, ApiResponse response) {
-                    QueryResultNanopubSet queryResultNanopubSet = new QueryResultNanopubSet(markupId, queryRef, response, viewDisplay, itemsPerPage);
+                    QueryResultNanopubSet queryResultNanopubSet = new QueryResultNanopubSet(markupId, queryRef, response, viewDisplay, resolvedItemsPerPage);
                     queryResultNanopubSet.setContextId(contextId);
                     queryResultNanopubSet.setPageResource(pageResource);
                     queryResultNanopubSet.populateComponent();
@@ -97,6 +101,8 @@ public class QueryResultNanopubSetBuilder implements Serializable {
                     return queryResultNanopubSet;
                 }
             };
+            comp.add(new AttributeAppender("class", colClass));
+            return comp;
         }
     }
 

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultPlainParagraphBuilder.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultPlainParagraphBuilder.java
@@ -10,6 +10,7 @@ import com.knowledgepixels.nanodash.page.PublishPage;
 import com.knowledgepixels.nanodash.repository.MaintainedResourceRepository;
 import com.knowledgepixels.nanodash.template.Template;
 import org.apache.wicket.Component;
+import org.apache.wicket.behavior.AttributeAppender;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
 import org.eclipse.rdf4j.model.IRI;
 import org.nanopub.extra.services.ApiResponse;
@@ -114,6 +115,7 @@ public class QueryResultPlainParagraphBuilder implements Serializable {
      */
     public Component build() {
         ApiResponse response = ApiCache.retrieveResponseAsync(queryRef);
+        String colClass = " col-" + viewDisplay.getDisplayWidth();
         if (space != null) {
             if (response != null) {
                 QueryResultPlainParagraph resultPlainParagraph = new QueryResultPlainParagraph(markupId, queryRef, response, viewDisplay);
@@ -121,9 +123,10 @@ public class QueryResultPlainParagraphBuilder implements Serializable {
                 resultPlainParagraph.setPageResource(pageResource);
                 resultPlainParagraph.setContextId(contextId);
                 addResultButtons(resultPlainParagraph);
+                resultPlainParagraph.add(new AttributeAppender("class", colClass));
                 return resultPlainParagraph;
             } else {
-                return new ApiResultComponent(markupId, queryRef) {
+                ApiResultComponent comp = new ApiResultComponent(markupId, queryRef) {
                     @Override
                     public Component getApiResultComponent(String markupId, ApiResponse response) {
                         QueryResultPlainParagraph resultPlainParagraph = new QueryResultPlainParagraph(markupId, queryRef, response, viewDisplay);
@@ -134,6 +137,8 @@ public class QueryResultPlainParagraphBuilder implements Serializable {
                         return resultPlainParagraph;
                     }
                 };
+                comp.add(new AttributeAppender("class", colClass));
+                return comp;
             }
         } else {
             if (response != null) {
@@ -141,9 +146,10 @@ public class QueryResultPlainParagraphBuilder implements Serializable {
                 resultPlainParagraph.setPageResource(pageResource);
                 resultPlainParagraph.setContextId(contextId);
                 addResultButtons(resultPlainParagraph);
+                resultPlainParagraph.add(new AttributeAppender("class", colClass));
                 return resultPlainParagraph;
             } else {
-                return new ApiResultComponent(markupId, queryRef) {
+                ApiResultComponent comp = new ApiResultComponent(markupId, queryRef) {
                     @Override
                     public Component getApiResultComponent(String markupId, ApiResponse response) {
                         QueryResultPlainParagraph resultPlainParagraph = new QueryResultPlainParagraph(markupId, queryRef, response, viewDisplay);
@@ -153,6 +159,8 @@ public class QueryResultPlainParagraphBuilder implements Serializable {
                         return resultPlainParagraph;
                     }
                 };
+                comp.add(new AttributeAppender("class", colClass));
+                return comp;
             }
         }
     }

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultTable.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultTable.java
@@ -18,6 +18,7 @@ import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.form.TextField;
 import org.apache.wicket.markup.html.link.AbstractLink;
 import org.apache.wicket.markup.html.link.BookmarkablePageLink;
+import org.apache.wicket.util.string.Strings;
 import org.apache.wicket.markup.repeater.Item;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
@@ -243,10 +244,9 @@ public class QueryResultTable extends QueryResult {
                     } else if (key.endsWith("template_iri")) {
                         String label = rowModel.getObject().get(key + "_label");
                         if (label == null || label.isBlank()) label = value;
-                        PageParameters params = new PageParameters()
-                                .set("template", value)
-                                .set("template-version", "latest");
-                        cellItem.add(new BookmarkablePageLink<NanodashPage>(componentId, PublishPage.class, params).setBody(Model.of(label)));
+                        String templateUrl = PublishPage.MOUNT_PATH + "?template=" + Utils.urlEncode(value) + "&template-version=latest";
+                        String html = "<a href=\"" + Strings.escapeMarkup(templateUrl) + "\">" + Strings.escapeMarkup(label) + "</a>";
+                        cellItem.add(new Label(componentId, html).setEscapeModelStrings(false));
                     } else if (value.matches("https?://.+")) {
                         String label = rowModel.getObject().get(key + "_label");
                         cellItem.add(new NanodashLink(componentId, value, null, null, label, contextId));

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultTable.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultTable.java
@@ -276,10 +276,7 @@ public class QueryResultTable extends QueryResult {
     }
 
     private static String truncateLabel(String label) {
-        if (label != null && label.length() > 120) {
-            return label.substring(0, 100) + "...";
-        }
-        return label;
+        return Utils.truncateLabel(label);
     }
 
 }

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultTable.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultTable.java
@@ -240,6 +240,13 @@ public class QueryResultTable extends QueryResult {
                             }
                         }
                         cellItem.add(new ComponentSequence(componentId, ", ", components));
+                    } else if (key.endsWith("template_iri")) {
+                        String label = rowModel.getObject().get(key + "_label");
+                        if (label == null || label.isBlank()) label = value;
+                        PageParameters params = new PageParameters()
+                                .set("template", value)
+                                .set("template-version", "latest");
+                        cellItem.add(new BookmarkablePageLink<NanodashPage>(componentId, PublishPage.class, params).setBody(Model.of(label)));
                     } else if (value.matches("https?://.+")) {
                         String label = rowModel.getObject().get(key + "_label");
                         cellItem.add(new NanodashLink(componentId, value, null, null, label, contextId));

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultTable.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultTable.java
@@ -10,6 +10,7 @@ import org.apache.wicket.Component;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.form.AjaxFormComponentUpdatingBehavior;
 import org.apache.wicket.behavior.AttributeAppender;
+import org.apache.wicket.extensions.ajax.markup.html.repeater.data.table.AjaxFallbackHeadersToolbar;
 import org.apache.wicket.extensions.ajax.markup.html.repeater.data.table.AjaxNavigationToolbar;
 import org.apache.wicket.extensions.markup.html.repeater.data.grid.ICellPopulator;
 import org.apache.wicket.extensions.markup.html.repeater.data.table.*;
@@ -119,7 +120,7 @@ public class QueryResultTable extends QueryResult {
             table.setOutputMarkupId(true);
             table.addBottomToolbar(new AjaxNavigationToolbar(table));
             table.addBottomToolbar(new NoRecordsToolbar(table));
-            table.addTopToolbar(new HeadersToolbar<String>(table, dataProvider));
+            table.addTopToolbar(new AjaxFallbackHeadersToolbar<String>(table, dataProvider));
             add(table);
         } catch (Exception ex) {
             logger.error("Error creating table for query {}", grlcQuery.getQueryId(), ex);
@@ -266,32 +267,5 @@ public class QueryResultTable extends QueryResult {
         }
 
     }
-
-//    private class ApiResponseComparator implements Comparator<ApiResponseEntry>, Serializable {
-//
-//        private SortParam<String> sortParam;
-//
-//        public ApiResponseComparator(SortParam<String> sortParam) {
-//            this.sortParam = sortParam;
-//        }
-//
-//        @Override
-//        public int compare(ApiResponseEntry o1, ApiResponseEntry o2) {
-//            String p = sortParam.getProperty();
-//            int result;
-//            if (o1.get(p) == null && o2.get(p) == null) {
-//                result = 0;
-//            } else if (o1.get(p) == null) {
-//                result = 1;
-//            } else if (o2.get(p) == null) {
-//                result = -1;
-//            } else {
-//                result = o1.get(p).compareTo(o2.get(p));
-//            }
-//            if (!sortParam.isAscending()) result = -result;
-//            return result;
-//        }
-//
-//    }
 
 }

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultTable.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultTable.java
@@ -192,7 +192,7 @@ public class QueryResultTable extends QueryResult {
                         String[] labels = labelValue != null ? labelValue.split("\n", -1) : null;
                         List<Component> links = new ArrayList<>();
                         for (int i = 0; i < uris.length; i++) {
-                            String label = (labels != null && i < labels.length && !labels[i].isBlank()) ? Utils.unescapeMultiValue(labels[i]) : null;
+                            String label = truncateLabel((labels != null && i < labels.length && !labels[i].isBlank()) ? Utils.unescapeMultiValue(labels[i]) : null);
                             links.add(new NanodashLink("component", uris[i], null, null, label, contextId));
                         }
                         cellItem.add(new ComponentSequence(componentId, ", ", links));
@@ -204,7 +204,7 @@ public class QueryResultTable extends QueryResult {
                         List<Component> components = new ArrayList<>();
                         for (int i = 0; i < parts.length; i++) {
                             String part = parts[i];
-                            String label = (labels != null && i < labels.length && !labels[i].isBlank()) ? Utils.unescapeMultiValue(labels[i]) : null;
+                            String label = truncateLabel((labels != null && i < labels.length && !labels[i].isBlank()) ? Utils.unescapeMultiValue(labels[i]) : null);
                             if (part.matches("https?://.+")) {
                                 components.add(new NanodashLink("component", part, null, null, label, contextId));
                             } else {
@@ -242,13 +242,13 @@ public class QueryResultTable extends QueryResult {
                         }
                         cellItem.add(new ComponentSequence(componentId, ", ", components));
                     } else if (key.endsWith("template_iri")) {
-                        String label = rowModel.getObject().get(key + "_label");
-                        if (label == null || label.isBlank()) label = value;
+                        String label = truncateLabel(rowModel.getObject().get(key + "_label"));
+                        if (label == null || label.isBlank()) label = truncateLabel(value);
                         String templateUrl = PublishPage.MOUNT_PATH + "?template=" + Utils.urlEncode(value) + "&template-version=latest";
                         String html = "<a href=\"" + Strings.escapeMarkup(templateUrl) + "\">" + Strings.escapeMarkup(label) + "</a>";
                         cellItem.add(new Label(componentId, html).setEscapeModelStrings(false));
                     } else if (value.matches("https?://.+")) {
-                        String label = rowModel.getObject().get(key + "_label");
+                        String label = truncateLabel(rowModel.getObject().get(key + "_label"));
                         cellItem.add(new NanodashLink(componentId, value, null, null, label, contextId));
                     } else {
                         if (key.startsWith("pubkey")) {
@@ -273,6 +273,13 @@ public class QueryResultTable extends QueryResult {
             }
         }
 
+    }
+
+    private static String truncateLabel(String label) {
+        if (label != null && label.length() > 120) {
+            return label.substring(0, 100) + "...";
+        }
+        return label;
     }
 
 }

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultTableBuilder.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultTableBuilder.java
@@ -9,6 +9,7 @@ import com.knowledgepixels.nanodash.page.PublishPage;
 import com.knowledgepixels.nanodash.repository.MaintainedResourceRepository;
 import com.knowledgepixels.nanodash.template.Template;
 import org.apache.wicket.Component;
+import org.apache.wicket.behavior.AttributeAppender;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
 import org.eclipse.rdf4j.model.IRI;
 import org.nanopub.extra.services.ApiResponse;
@@ -98,6 +99,7 @@ public class QueryResultTableBuilder implements Serializable {
      */
     public Component build() {
         ApiResponse response = ApiCache.retrieveResponseAsync(queryRef);
+        String colClass = " col-" + viewDisplay.getDisplayWidth();
         if (resourceWithProfile != null) {
             if (response != null) {
                 QueryResultTable table = new QueryResultTable(markupId, queryRef, response, viewDisplay, false);
@@ -141,9 +143,10 @@ public class QueryResultTableBuilder implements Serializable {
                         table.addButton(label, PublishPage.class, params);
                     }
                 }
+                table.add(new AttributeAppender("class", colClass));
                 return table;
             } else {
-                return new ApiResultComponent(markupId, queryRef) {
+                ApiResultComponent comp = new ApiResultComponent(markupId, queryRef) {
                     @Override
                     public Component getApiResultComponent(String markupId, ApiResponse response) {
                         QueryResultTable table = new QueryResultTable(markupId, queryRef, response, viewDisplay, false);
@@ -189,14 +192,17 @@ public class QueryResultTableBuilder implements Serializable {
                         return table;
                     }
                 };
+                comp.add(new AttributeAppender("class", colClass));
+                return comp;
             }
         } else {
             if (response != null) {
                 QueryResultTable table = new QueryResultTable(markupId, queryRef, response, viewDisplay, plain);
                 table.setContextId(contextId);
+                table.add(new AttributeAppender("class", colClass));
                 return table;
             } else {
-                return new ApiResultComponent(markupId, queryRef) {
+                ApiResultComponent comp = new ApiResultComponent(markupId, queryRef) {
                     @Override
                     public Component getApiResultComponent(String markupId, ApiResponse response) {
                         QueryResultTable table = new QueryResultTable(markupId, queryRef, response, viewDisplay, plain);
@@ -204,6 +210,8 @@ public class QueryResultTableBuilder implements Serializable {
                         return table;
                     }
                 };
+                comp.add(new AttributeAppender("class", colClass));
+                return comp;
             }
         }
     }

--- a/src/main/java/com/knowledgepixels/nanodash/component/TemplateList.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/TemplateList.html
@@ -14,17 +14,9 @@
 <h2>✏ Publish a new Nanopublication</h2>
 </div>
         
-<div class="col-6">
-
 <div wicket:id="popular-templates" class="forms"></div>
 
-</div>
-
-<div class="col-6">
-
 <div wicket:id="getstarted-templates" class="forms"></div>
-
-</div>
 
 </div>
 

--- a/src/main/java/com/knowledgepixels/nanodash/component/TemplateList.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/TemplateList.java
@@ -35,11 +35,11 @@ public class TemplateList extends Panel {
 
         View popularTemplatesView = View.get("https://w3id.org/np/RAYMZEdmvjIS5QGFASa8L5hygapUlvK3feZBpG6quMYqc/popular-templates");
         QueryRef ptQueryRef = new QueryRef(popularTemplatesView.getQuery().getQueryId());
-        add(QueryResultListBuilder.create("popular-templates", ptQueryRef, new ViewDisplay(popularTemplatesView)).build());
+        add(QueryResultItemListBuilder.create("popular-templates", ptQueryRef, new ViewDisplay(popularTemplatesView).withDisplayWidth(6)).build());
 
         View getStartedView = View.get("https://w3id.org/np/RAeFTjDGTQ-bdulJy4tUlWzRlK8EucXFCxqLrb7Qj35SM/suggested-templates-get-started");
         QueryRef gsQueryRef = new QueryRef(getStartedView.getQuery().getQueryId());
-        add(QueryResultListBuilder.create("getstarted-templates", gsQueryRef, new ViewDisplay(getStartedView)).build());
+        add(QueryResultListBuilder.create("getstarted-templates", gsQueryRef, new ViewDisplay(getStartedView).withDisplayWidth(6)).build());
 
         ArrayList<ApiResponseEntry> templateList = new ArrayList<>(TemplateData.get().getAssertionTemplates());
         templateList.sort((t1, t2) -> {

--- a/src/main/java/com/knowledgepixels/nanodash/component/ViewList.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/ViewList.html
@@ -27,6 +27,8 @@
       <div wicket:id="footer-buttons"></div>
     </div>
   </div>
+
+  <wicket:container wicket:id="page-footer"></wicket:container>
 </wicket:panel>
 
 </body>

--- a/src/main/java/com/knowledgepixels/nanodash/component/ViewList.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/ViewList.java
@@ -8,6 +8,7 @@ import com.knowledgepixels.nanodash.domain.AbstractResourceWithProfile;
 import com.knowledgepixels.nanodash.domain.Space;
 import com.knowledgepixels.nanodash.domain.User;
 import com.knowledgepixels.nanodash.vocabulary.KPXL_TERMS;
+import org.apache.wicket.Component;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.link.AbstractLink;
@@ -184,6 +185,12 @@ public class ViewList extends Panel {
             footerSection.add(new Label("footer-buttons").setVisible(false));
         }
         add(footerSection);
+
+        add(new WebMarkupContainer("page-footer").setVisible(false));
+    }
+
+    public void setPageFooter(Component footer) {
+        replace(footer);
     }
 
 }

--- a/src/main/java/com/knowledgepixels/nanodash/component/ViewList.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/ViewList.java
@@ -152,6 +152,13 @@ public class ViewList extends Panel {
                                         .pageResource(resourceWithProfile)
                                         .contextId(resourceWithProfile.getId())
                                         .build());
+                            } else if (view.getViewType().equals(KPXL_TERMS.ITEM_LIST_VIEW)) {
+                                item.add(QueryResultItemListBuilder.create("view", queryRef, item.getModelObject())
+                                        .resourceWithProfile(resourceWithProfile)
+                                        .pageResource(resourceWithProfile)
+                                        .id(id)
+                                        .contextId(resourceWithProfile.getId())
+                                        .build());
                             } else {
                                 item.add(new Label("view", "<span class=\"negative\">View type \"" + view.getViewType().stringValue() + "\" is supported but its view is not implemented yet</span>").setEscapeModelStrings(false));
                                 logger.error("View type \"{}\" is supported but its view is not implemented yet", view.getViewType().stringValue());

--- a/src/main/java/com/knowledgepixels/nanodash/domain/UserData.java
+++ b/src/main/java/com/knowledgepixels/nanodash/domain/UserData.java
@@ -416,12 +416,12 @@ public class UserData implements Serializable {
         if (ids == null || ids.isEmpty()) {
             ids = unapprovedPubkeyhashIdMap.get(pubkeyHash);
             if (ids == null || ids.isEmpty()) {
-                return getShortName(userIri);
+                return getShortDisplayName(userIri);
             } else if (ids.size() == 1) {
                 return getShortDisplayName(ids.iterator().next());
             } else {
                 // Not showing "contested identity" for now.
-                return getShortName(userIri);  // + " (contested identity)";
+                return getShortDisplayName(userIri);  // + " (contested identity)";
             }
         } else if (ids.size() == 1) {
             return getShortDisplayName(ids.iterator().next());

--- a/src/main/java/com/knowledgepixels/nanodash/page/HomePage.html
+++ b/src/main/java/com/knowledgepixels/nanodash/page/HomePage.html
@@ -16,12 +16,14 @@
 
   <div wicket:id="views"></div>
 
-  <div class="row-section">
-    <div class="col-12 home-footer">
-      <p><a href="https://github.com/knowledgepixels/nanodash">Nanodash on GitHub</a> · by
-        <a href="https://knowledgepixels.com/">Knowledge Pixels</a>.</p>
+  <wicket:fragment wicket:id="homeFooterFragment">
+    <div class="row-section">
+      <div class="col-12 home-footer">
+        <p><a href="https://github.com/knowledgepixels/nanodash">Nanodash on GitHub</a> · by
+          <a href="https://knowledgepixels.com/">Knowledge Pixels</a>.</p>
+      </div>
     </div>
-  </div>
+  </wicket:fragment>
 
 </wicket:extend>
 </body>

--- a/src/main/java/com/knowledgepixels/nanodash/page/HomePage.html
+++ b/src/main/java/com/knowledgepixels/nanodash/page/HomePage.html
@@ -14,17 +14,7 @@
     </div>
   </div>
 
-  <div class="row-section">
-    <div class="col-6">
-      <div wicket:id="mostrecent">...</div>
-      <div wicket:id="upcomingevents">...</div>
-    </div>
-
-    <div class="col-6">
-      <div wicket:id="topCreators">...</div>
-      <div wicket:id="getStartedTemplates">...</div>
-    </div>
-  </div>
+  <div wicket:id="views"></div>
 
   <div class="row-section">
     <div class="col-12 home-footer">

--- a/src/main/java/com/knowledgepixels/nanodash/page/HomePage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/HomePage.java
@@ -6,6 +6,7 @@ import com.knowledgepixels.nanodash.WicketApplication;
 import com.knowledgepixels.nanodash.component.ResultComponent;
 import com.knowledgepixels.nanodash.component.TitleBar;
 import com.knowledgepixels.nanodash.component.ViewList;
+import org.apache.wicket.markup.html.panel.Fragment;
 import com.knowledgepixels.nanodash.domain.MaintainedResource;
 import com.knowledgepixels.nanodash.repository.MaintainedResourceRepository;
 import org.apache.wicket.Component;
@@ -71,13 +72,17 @@ public class HomePage extends NanodashPage {
         homeResource.triggerDataUpdate();
 
         if (homeResource.isDataInitialized()) {
-            add(new ViewList("views", homeResource));
+            ViewList viewList = new ViewList("views", homeResource);
+            viewList.setPageFooter(new Fragment("page-footer", "homeFooterFragment", this));
+            add(viewList);
         } else {
             add(new AjaxLazyLoadPanel<Component>("views") {
 
                 @Override
                 public Component getLazyLoadComponent(String markupId) {
-                    return new ViewList(markupId, homeResource);
+                    ViewList viewList = new ViewList(markupId, homeResource);
+                    viewList.setPageFooter(new Fragment("page-footer", "homeFooterFragment", HomePage.this));
+                    return viewList;
                 }
 
                 @Override

--- a/src/main/java/com/knowledgepixels/nanodash/page/HomePage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/HomePage.java
@@ -1,15 +1,20 @@
 package com.knowledgepixels.nanodash.page;
 
-import com.knowledgepixels.nanodash.*;
-import com.knowledgepixels.nanodash.component.*;
-import org.apache.wicket.AttributeModifier;
+import com.knowledgepixels.nanodash.NanodashPreferences;
+import com.knowledgepixels.nanodash.NanodashSession;
+import com.knowledgepixels.nanodash.WicketApplication;
+import com.knowledgepixels.nanodash.component.ResultComponent;
+import com.knowledgepixels.nanodash.component.TitleBar;
+import com.knowledgepixels.nanodash.component.ViewList;
+import com.knowledgepixels.nanodash.domain.MaintainedResource;
+import com.knowledgepixels.nanodash.repository.MaintainedResourceRepository;
+import org.apache.wicket.Component;
+import org.apache.wicket.extensions.ajax.markup.html.AjaxLazyLoadPanel;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
-import org.nanopub.extra.services.QueryRef;
 
 /**
- * The home page of Nanodash, which shows the most recent nanopublications
- * and the latest accepted nanopublications.
+ * The home page of Nanodash, showing the views defined for the configured home resource.
  */
 public class HomePage extends NanodashPage {
 
@@ -62,35 +67,40 @@ public class HomePage extends NanodashPage {
 
         setOutputMarkupId(true);
 
-        View mostRecentNanopubsView = View.get("https://w3id.org/np/RAawFcLhQOJfA9Ke1spCNkXWA68J1O-wOJrSmBdNFsAtI/most-recent-nanopubs");
-        QueryRef rQueryRef = new QueryRef(mostRecentNanopubsView.getQuery().getQueryId());
-        add(QueryResultNanopubSetBuilder.create("mostrecent", rQueryRef, new ViewDisplay(mostRecentNanopubsView))
-                .setItemsPerPage(5)
-                .build()
-                .add(AttributeModifier.remove("class"))
-        );
+        MaintainedResource homeResource = MaintainedResourceRepository.get().findById(NanodashPreferences.get().getHomeResource());
+        homeResource.triggerDataUpdate();
 
-        View upcomingEventsView = View.get("https://w3id.org/np/RAq5EwXCcCUsBEc7bMUgrT5oeLvX7khfqhA4hKzCjjBwk/upcoming-events-view");
-        QueryRef eQueryRef = new QueryRef(upcomingEventsView.getQuery().getQueryId());
-        add(QueryResultTableBuilder.create("upcomingevents", eQueryRef, new ViewDisplay(upcomingEventsView))
-                .build()
-                .add(AttributeModifier.remove("class"))
-        );
+        if (homeResource.isDataInitialized()) {
+            add(new ViewList("views", homeResource));
+        } else {
+            add(new AjaxLazyLoadPanel<Component>("views") {
 
-        View topCreatorsView = View.get("https://w3id.org/np/RACcywnbkn6OAd_6E25qZL9-vdO-UwmpO1vXVWzNWJYLo/top-creators-last-30days");
-        QueryRef cQueryRef = new QueryRef(topCreatorsView.getQuery().getQueryId());
-        add(QueryResultListBuilder.create("topCreators", cQueryRef, new ViewDisplay(topCreatorsView))
-                .build()
-                .add(AttributeModifier.remove("class"))
-        );
+                @Override
+                public Component getLazyLoadComponent(String markupId) {
+                    return new ViewList(markupId, homeResource);
+                }
 
-        View getStartedView = View.get("https://w3id.org/np/RAeFTjDGTQ-bdulJy4tUlWzRlK8EucXFCxqLrb7Qj35SM/suggested-templates-get-started");
-        QueryRef gQueryRef = new QueryRef(getStartedView.getQuery().getQueryId());
-        add(QueryResultListBuilder.create("getStartedTemplates", gQueryRef, new ViewDisplay(getStartedView))
-                .build()
-                .add(AttributeModifier.remove("class"))
-        );
+                @Override
+                protected boolean isContentReady() {
+                    return homeResource.isDataInitialized();
+                }
 
+                @Override
+                public Component getLoadingComponent(String id) {
+                    return new Label(id, "<div class=\"row-section\"><div class=\"col-12\">" + ResultComponent.getWaitIconHtml() + "</div></div>").setEscapeModelStrings(false);
+                }
+
+            });
+        }
+    }
+
+    /**
+     * <p>hasAutoRefreshEnabled.</p>
+     *
+     * @return a boolean
+     */
+    protected boolean hasAutoRefreshEnabled() {
+        return true;
     }
 
 }

--- a/src/main/java/com/knowledgepixels/nanodash/page/UserListPage.html
+++ b/src/main/java/com/knowledgepixels/nanodash/page/UserListPage.html
@@ -17,17 +17,9 @@
       <h2>👥 Users</h2>
     </div>
 
-    <div class="col-6">
+    <div wicket:id="topcreators" class="users"></div>
 
-      <div wicket:id="topcreators" class="users"></div>
-
-    </div>
-
-    <div class="col-6">
-
-      <div wicket:id="latestusers" class="users"></div>
-
-    </div>
+    <div wicket:id="latestusers" class="users"></div>
 
   </div>
 

--- a/src/main/java/com/knowledgepixels/nanodash/page/UserListPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/UserListPage.java
@@ -61,11 +61,11 @@ public class UserListPage extends NanodashPage {
 
         View topCreatorsView = View.get("https://w3id.org/np/RACcywnbkn6OAd_6E25qZL9-vdO-UwmpO1vXVWzNWJYLo/top-creators-last-30days");
         QueryRef tcQueryRef = new QueryRef(topCreatorsView.getQuery().getQueryId());
-        add(QueryResultListBuilder.create("topcreators", tcQueryRef, new ViewDisplay(topCreatorsView)).build());
+        add(QueryResultListBuilder.create("topcreators", tcQueryRef, new ViewDisplay(topCreatorsView).withDisplayWidth(6)).build());
 
         View latestUsersView = View.get("https://w3id.org/np/RAtwNLvsJbz3pk_UxdKSydsghbX6D_60ivTZpDQhK-9zA/latest-users");
         QueryRef luQueryRef = new QueryRef(latestUsersView.getQuery().getQueryId());
-        add(QueryResultListBuilder.create("latestusers", luQueryRef, new ViewDisplay(latestUsersView)).build());
+        add(QueryResultListBuilder.create("latestusers", luQueryRef, new ViewDisplay(latestUsersView).withDisplayWidth(6)).build());
 
         add(new ItemListPanel<IRI>(
                 "approved-human-users",

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -543,8 +543,15 @@ img.thirdparty {
   margin-top: 0;
   margin-right: 0.3em;
   width: 1.5em;
-  border: 1px solid lightblue;
-  border-radius: 50px;
+  height: 1.5em;
+  object-fit: cover;
+  background-color: lightgray;
+  mask-image: url("images/mask.svg");
+  mask-repeat: no-repeat;
+  mask-size: contain;
+  -webkit-mask-image: url("images/mask.svg");
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-size: contain;
 }
 
 .user-profile-pic {
@@ -610,12 +617,14 @@ li:has(.templateref) {
 }
 
 li:has(.user-icon),
+li:has(.bot-icon),
 li:has(.form-icon) {
   list-style: none;
   margin-left: -1em;
 }
 
 .users li:has(.user-icon),
+.users li:has(.bot-icon),
 .users li:has(.form-icon) {
   margin-left: -0.5em;
 }
@@ -1878,7 +1887,7 @@ p.waiting {
   color: #ccc;
 }
 
-.listview img { /* for wait icon */
+.listview img:not(.user-icon):not(.bot-icon) { /* for wait icon */
   padding: 15px;
 }
 


### PR DESCRIPTION
## Summary

- Implements the `ItemListView` view type (`QueryResultItemList` + builder + HTML), with special handling for `user_iri` and `template_iri` columns, filter field, and pagination
- Dispatches `ITEM_LIST_VIEW` in `ViewList` so it no longer throws an error on pages that use it
- Fixes `col-X` class not being applied to the `ApiResultComponent` wrapper in the async loading path — it was only on the inner `QueryResult`, causing floated elements to escape their containers
- Fixes page size being ignored when views are loaded via `ViewList`: `QueryResultList`, `QueryResultItemList`, and `QueryResultNanopubSetBuilder` now read from `viewDisplay.getPageSize()`
- Fixes `.listview img` padding rule accidentally applying to `user-icon`/`bot-icon` images
- Fixes bullet point not hidden for `li` containing a `bot-icon`
- Makes `bot-icon` use the same tilted-square mask shape and gray background as `user-icon`

## Test plan

- [x] Visit a page that uses `ItemListView` (e.g. `/resource?id=.../r/home`) and verify items render as a vertical list with correct icons and links
- [x] On first page load (cold cache), verify async-loaded views maintain correct column widths and don't appear side-by-side unexpectedly
- [x] Verify page size from view definition is respected (e.g. a view configured with page size 5 shows 5 items)
- [x] Verify bot icons appear with tilted-square shape (same as user icons) and no bullet point in lists

🤖 Generated with [Claude Code](https://claude.com/claude-code)