### PR TITLE
Fix redirect of resource-part URIs to ResourcePartPage

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/page/SpacePage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/SpacePage.java
@@ -271,7 +271,7 @@ public class SpacePage extends NanodashPage {
      *
      * @param parameters page parameters containing the space {@code id}
      * @return the resolved {@link Space}; never {@code null}
-     * @throws RestartResponseException if the id belongs to a {@link MaintainedResource}
+     * @throws RestartResponseException if the id belongs to a {@link MaintainedResource} or to a part within one
      * @throws IllegalArgumentException if the id cannot be resolved to any known resource
      */
     private Space resolveSpace(PageParameters parameters) {
@@ -280,6 +280,12 @@ public class SpacePage extends NanodashPage {
         if (resolved == null) {
             if (MaintainedResourceRepository.get().findById(id) != null) {
                 throw new RestartResponseException(MaintainedResourcePage.class, parameters);
+            }
+            MaintainedResource containingResource = MaintainedResourceRepository.get().findByNamespace(MaintainedResource.getNamespace(id));
+            if (containingResource != null) {
+                PageParameters partParameters = new PageParameters(parameters);
+                partParameters.set("context", containingResource.getId());
+                throw new RestartResponseException(ResourcePartPage.class, partParameters);
             }
             throw new IllegalArgumentException("No space or resource found for id: " + id);
         }

--- a/src/main/java/com/knowledgepixels/nanodash/repository/MaintainedResourceRepository.java
+++ b/src/main/java/com/knowledgepixels/nanodash/repository/MaintainedResourceRepository.java
@@ -86,6 +86,7 @@ public class MaintainedResourceRepository {
      * @return The MaintainedResource with the given namespace, or null if not found.
      */
     public MaintainedResource findByNamespace(String namespace) {
+        ensureLoaded();
         return resourcesByNamespace.get(namespace);
     }
 


### PR DESCRIPTION
## Summary
- Closes #442
- `w3id.org` forwards every `/spaces/...` URI to `/space?id=<uri>`, so term URIs within a maintained resource's namespace (e.g. `https://w3id.org/spaces/marine-biodiversity/r/ontology/hasWaterbody`) landed on `SpacePage` and returned a 500 because neither `SpaceRepository.findById` nor `MaintainedResourceRepository.findById` matched.
- `SpacePage.resolveSpace` now falls back to `MaintainedResourceRepository.findByNamespace` (using `MaintainedResource.getNamespace(id)`) and, when a containing resource is found, restarts to `ResourcePartPage` with the proper `context`.
- Also adds `ensureLoaded()` to `findByNamespace` for consistency with `findById`.

## Test plan
- [x] Verified locally: the URI from the issue now resolves to the resource-part page.
- [ ] Existing space and maintained-resource URIs still resolve as before (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)