### PR TITLE
fix: clear rawInput when removing repetition groups

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/component/StatementItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/StatementItem.java
@@ -5,11 +5,13 @@ import com.knowledgepixels.nanodash.template.Template;
 import com.knowledgepixels.nanodash.template.TemplateContext;
 import com.knowledgepixels.nanodash.template.UnificationException;
 import org.apache.wicket.AttributeModifier;
+import org.apache.wicket.Component;
 import org.apache.wicket.ajax.AjaxEventBehavior;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.behavior.AttributeAppender;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.form.FormComponent;
 import org.apache.wicket.markup.html.list.ListItem;
 import org.apache.wicket.markup.html.list.ListView;
 import org.apache.wicket.markup.html.panel.Panel;
@@ -465,15 +467,16 @@ public class StatementItem extends Panel {
                     for (int i = getRepeatIndex() + 1; i < repetitionGroups.size(); i++) {
                         IModel swapModel2 = (IModel) context.getComponentModels().get(vf.createIRI(iriBase + getRepeatSuffix(i)));
                         if (swapModel1 != null && swapModel2 != null) {
-                            // TODO check how to fix this -- maybe a function that does the swap?
                             swapModel1.setObject(swapModel2.getObject());
                         }
+                        // Drop any retained rawInput so the shifted model value is rendered
+                        // instead of the user's previous (post-validation-error) entry.
+                        clearInputForModel(swapModel1);
                         swapModel1 = swapModel2;
                     }
-                    // Clear last object:
                     if (swapModel1 != null) {
-                        // FIXME check if this is fine now
                         swapModel1.setObject(null);
+                        clearInputForModel(swapModel1);
                     }
                 }
             }
@@ -483,6 +486,15 @@ public class StatementItem extends Panel {
                 vi.removeFromContext();
             }
             repetitionGroupsChanged = true;
+        }
+
+        private void clearInputForModel(IModel<?> model) {
+            if (model == null) return;
+            for (Component c : context.getComponents()) {
+                if (c instanceof FormComponent && c.getDefaultModel() == model) {
+                    ((FormComponent<?>) c).clearInput();
+                }
+            }
         }
 
         private String getRepeatSuffix() {


### PR DESCRIPTION
## Summary
- Fixes #445: after a template form fails validation, removing a repetition group left the removed statement's placeholder value visible at the slot that took its place.
- Root cause: Wicket retains each `FormComponent`'s `rawInput` after a failed validation and uses it for rendering instead of the model value. `RepetitionGroup.remove()` shifted model values down but didn't clear the stale `rawInput`, so the shifted-in value was masked.
- Fix: after each value swap (and the final clear) in `remove()`, walk `context.getComponents()` and call `clearInput()` on any `FormComponent` bound to the affected model.

## Test plan
- [x] Fill a template with a repeatable statement, create 3+ repetitions with distinct values
- [x] Submit to trigger a validation error
- [x] Click "−" on the first or middle repetition
- [x] Confirm the values in the remaining slots correspond to the post-shift state (not the removed entry's value)
- [x] Re-submit and verify nanopub contents match what is displayed

🤖 Generated with [Claude Code](https://claude.com/claude-code)