### PR TITLE
chore: log form-object loss and LRU eviction

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/NanodashSession.java
+++ b/src/main/java/com/knowledgepixels/nanodash/NanodashSession.java
@@ -92,7 +92,11 @@ public class NanodashSession extends WebSession {
     private final Map<String, PublishForm> formMap = Collections.synchronizedMap(new LinkedHashMap<>(16, 0.75f, true) {
         @Override
         protected boolean removeEldestEntry(Map.Entry<String, PublishForm> eldest) {
-            return size() > MAX_FORMS;
+            boolean evict = size() > MAX_FORMS;
+            if (evict) {
+                logger.info("Evicting form from session LRU (formobj={}, cap={})", eldest.getKey(), MAX_FORMS);
+            }
+            return evict;
         }
     });
 

--- a/src/main/java/com/knowledgepixels/nanodash/connector/GenPublishPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/connector/GenPublishPage.java
@@ -13,6 +13,8 @@ import org.apache.wicket.markup.html.link.BookmarkablePageLink;
 import org.apache.wicket.markup.html.link.ExternalLink;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
 import org.apache.wicket.request.resource.PackageResourceReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Random;
 
@@ -20,6 +22,8 @@ import java.util.Random;
  * Page for publishing a nanopublication.
  */
 public class GenPublishPage extends ConnectorPage {
+
+    private static final Logger logger = LoggerFactory.getLogger(GenPublishPage.class);
 
     /**
      * Mount path for this page.
@@ -59,6 +63,8 @@ public class GenPublishPage extends ConnectorPage {
             parameters.set("template-version", "latest");
             String formObjId = parameters.get("formobj").toString();
             if (!session.hasForm(formObjId)) {
+                logger.warn("Form object not found in session (formobj={}, template={}); creating new form",
+                        formObjId, parameters.get("template"));
                 PublishForm publishForm = new PublishForm("form", parameters, getClass(), GenConnectPage.class);
                 session.setForm(formObjId, publishForm);
             }

--- a/src/main/java/com/knowledgepixels/nanodash/page/PublishPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/PublishPage.java
@@ -10,6 +10,8 @@ import org.apache.wicket.markup.head.IHeaderResponse;
 import org.apache.wicket.markup.head.JavaScriptHeaderItem;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Random;
 
@@ -18,6 +20,8 @@ import java.util.Random;
  * It allows users to publish content based on templates and manage forms.
  */
 public class PublishPage extends NanodashPage {
+
+    private static final Logger logger = LoggerFactory.getLogger(PublishPage.class);
 
     /**
      * The mount path for the PublishPage.
@@ -54,6 +58,8 @@ public class PublishPage extends NanodashPage {
                 }
                 String formObjId = parameters.get("formobj").toString();
                 if (!session.hasForm(formObjId)) {
+                    logger.warn("Form object not found in session (formobj={}, template={}); creating new form",
+                            formObjId, parameters.get("template"));
                     PublishForm publishForm = new PublishForm("form", parameters, getClass(), ExplorePage.class);
                     session.setForm(formObjId, publishForm);
                 }


### PR DESCRIPTION
## Summary
Instrument the \`formobj\` caching path so we can tell from prod logs whether the workaround is still needed (context: #373). Three log sites added:

- \`PublishPage\` / \`GenPublishPage\`: \`WARN\` when \`formobj\` is in the URL but the session has no matching \`PublishForm\` — the definitive "form was lost" signal.
- \`NanodashSession\`: \`INFO\` on LRU eviction when \`MAX_FORMS = 20\` is exceeded, so we can distinguish eviction-caused losses from session-expiry / restart losses.

All log lines include the \`formobj\` ID (and template, where available) so entries can be correlated across the lifecycle.

Once we have a few days of prod logs, filtering for \`"Form object not found"\` will tell us whether the \`formobj\` hack is still load-bearing; if the rate is ~0 outside of expected session-expiry windows, we can drop it.

## Test plan
- [ ] Deploy and confirm logs appear when visiting \`/publish?template=...\` for the first time (no warning) and when visiting with a stale \`formobj\` (warning).
- [ ] Confirm LRU eviction log fires when more than 20 distinct templates are opened in a single session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)