### PR TITLE
refactor: drop formobj, use PageReference for preview Back

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/NanodashSession.java
+++ b/src/main/java/com/knowledgepixels/nanodash/NanodashSession.java
@@ -1,7 +1,6 @@
 package com.knowledgepixels.nanodash;
 
 import com.knowledgepixels.nanodash.component.NanopubResults;
-import com.knowledgepixels.nanodash.component.PublishForm;
 import com.knowledgepixels.nanodash.domain.User;
 import com.knowledgepixels.nanodash.page.OrcidLoginPage;
 import com.knowledgepixels.nanodash.page.ProfilePage;
@@ -9,6 +8,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import jakarta.xml.bind.DatatypeConverter;
 import org.apache.commons.io.FileUtils;
+import org.apache.wicket.PageReference;
 import org.apache.wicket.Session;
 import org.apache.wicket.protocol.http.WebSession;
 import org.apache.wicket.request.Request;
@@ -28,8 +28,6 @@ import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyPair;
 import java.util.Date;
-import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -85,59 +83,6 @@ public class NanodashSession extends WebSession {
     private IntroNanopub localIntro = null;
 
     private Date lastTimeIntroPublished = null;
-
-    // We should store here some sort of form model and not the forms themselves, but I couldn't figure
-    // how to do it, so doing it like this for the moment...
-    private static final int MAX_FORMS = 20;
-    private final Map<String, PublishForm> formMap = Collections.synchronizedMap(new LinkedHashMap<>(16, 0.75f, true) {
-        @Override
-        protected boolean removeEldestEntry(Map.Entry<String, PublishForm> eldest) {
-            boolean evict = size() > MAX_FORMS;
-            if (evict) {
-                logger.info("Evicting form from session LRU (formobj={}, cap={})", eldest.getKey(), MAX_FORMS);
-            }
-            return evict;
-        }
-    });
-
-    /**
-     * Associates a form object with a specific ID.
-     *
-     * @param formObjId The ID of the form object.
-     * @param formObj   The form object to associate.
-     */
-    public void setForm(String formObjId, PublishForm formObj) {
-        formMap.put(formObjId, formObj);
-    }
-
-    /**
-     * Checks if a form object with the given ID exists.
-     *
-     * @param formObjId The ID of the form object.
-     * @return True if the form object exists, false otherwise.
-     */
-    public boolean hasForm(String formObjId) {
-        return formMap.containsKey(formObjId);
-    }
-
-    /**
-     * Retrieves the form object associated with the given ID.
-     *
-     * @param formObjId The ID of the form object.
-     * @return The associated form object, or null if not found.
-     */
-    public PublishForm getForm(String formObjId) {
-        return formMap.get(formObjId);
-    }
-
-    /**
-     * Removes the form object associated with the given ID.
-     *
-     * @param formObjId The ID of the form object to remove.
-     */
-    public void removeForm(String formObjId) {
-        formMap.remove(formObjId);
-    }
 
     /**
      * Loads profile information for the user.
@@ -499,18 +444,21 @@ public class NanodashSession extends WebSession {
         private final PageParameters pageParams;
         private final Class<? extends WebPage> confirmPageClass;
         private final boolean consentChecked;
+        private final PageReference sourcePageRef;
 
-        public PreviewNanopub(Nanopub nanopub, PageParameters pageParams, Class<? extends WebPage> confirmPageClass, boolean consentChecked) {
+        public PreviewNanopub(Nanopub nanopub, PageParameters pageParams, Class<? extends WebPage> confirmPageClass, boolean consentChecked, PageReference sourcePageRef) {
             this.nanopub = nanopub;
             this.pageParams = pageParams;
             this.confirmPageClass = confirmPageClass;
             this.consentChecked = consentChecked;
+            this.sourcePageRef = sourcePageRef;
         }
 
         public Nanopub getNanopub() { return nanopub; }
         public PageParameters getPageParams() { return pageParams; }
         public Class<? extends WebPage> getConfirmPageClass() { return confirmPageClass; }
         public boolean isConsentChecked() { return consentChecked; }
+        public PageReference getSourcePageRef() { return sourcePageRef; }
     }
 
     private ConcurrentMap<String, PreviewNanopub> previewMap = new ConcurrentHashMap<>();

--- a/src/main/java/com/knowledgepixels/nanodash/component/PublishForm.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/PublishForm.java
@@ -305,7 +305,7 @@ public class PublishForm extends Panel {
         if (!assertionContext.getTemplateId().equals(latestAssertionId)) {
             add(new Label("newversion", "There is a new version of this assertion template:"));
             PageParameters params = new PageParameters(pageParams);
-            params.set("template", latestAssertionId).remove("formobj");
+            params.set("template", latestAssertionId);
             add(new BookmarkablePageLink<Void>("newversionlink", publishPageClass, params));
             if ("latest".equals(pageParams.get("template-version").toString())) {
                 throw new RestartResponseException(publishPageClass, params);
@@ -775,7 +775,7 @@ public class PublishForm extends Panel {
                     Nanopub signedNp = SignNanopub.signAndTransform(np, tc);
                     String previewId = signedNp.getUri().stringValue();
                     NanodashSession.get().setPreviewNanopub(previewId,
-                            new NanodashSession.PreviewNanopub(signedNp, pageParams, confirmPageClass, Boolean.TRUE.equals(consentCheck.getModelObject())));
+                            new NanodashSession.PreviewNanopub(signedNp, pageParams, confirmPageClass, Boolean.TRUE.equals(consentCheck.getModelObject()), getPage().getPageReference()));
                     throw new RestartResponseException(PreviewPage.class, new PageParameters().set("id", previewId));
                 } catch (RestartResponseException ex) {
                     throw ex;

--- a/src/main/java/com/knowledgepixels/nanodash/connector/GenPublishPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/connector/GenPublishPage.java
@@ -1,10 +1,8 @@
 package com.knowledgepixels.nanodash.connector;
 
 import com.knowledgepixels.nanodash.NanodashPageRef;
-import com.knowledgepixels.nanodash.NanodashSession;
 import com.knowledgepixels.nanodash.component.PublishForm;
 import com.knowledgepixels.nanodash.component.TitleBar;
-import org.apache.wicket.RestartResponseException;
 import org.apache.wicket.markup.head.IHeaderResponse;
 import org.apache.wicket.markup.head.JavaScriptHeaderItem;
 import org.apache.wicket.markup.html.basic.Label;
@@ -13,17 +11,11 @@ import org.apache.wicket.markup.html.link.BookmarkablePageLink;
 import org.apache.wicket.markup.html.link.ExternalLink;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
 import org.apache.wicket.request.resource.PackageResourceReference;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.Random;
 
 /**
  * Page for publishing a nanopublication.
  */
 public class GenPublishPage extends ConnectorPage {
-
-    private static final Logger logger = LoggerFactory.getLogger(GenPublishPage.class);
 
     /**
      * Mount path for this page.
@@ -47,7 +39,6 @@ public class GenPublishPage extends ConnectorPage {
         super(parameters);
         add(new Label("pagetitle", getConfig().getJournalName() + ": Publish Nanopublication | nanodash"));
 
-        final NanodashSession session = NanodashSession.get();
         PageParameters journalParam = new PageParameters().set("journal", getConnectorId());
         add(new TitleBar("titlebar", this, "connectors",
                 new NanodashPageRef(GenOverviewPage.class, journalParam, getConfig().getJournalName()),
@@ -57,18 +48,8 @@ public class GenPublishPage extends ConnectorPage {
         add(new Image("logo", new PackageResourceReference(getConfig().getClass(), getConfig().getLogoFileName())));
 
         if (parameters.get("template").toString() != null) {
-            if (!parameters.contains("formobj")) {
-                throw new RestartResponseException(getClass(), parameters.set("formobj", Math.abs(new Random().nextLong()) + ""));
-            }
             parameters.set("template-version", "latest");
-            String formObjId = parameters.get("formobj").toString();
-            if (!session.hasForm(formObjId)) {
-                logger.warn("Form object not found in session (formobj={}, template={}); creating new form",
-                        formObjId, parameters.get("template"));
-                PublishForm publishForm = new PublishForm("form", parameters, getClass(), GenConnectPage.class);
-                session.setForm(formObjId, publishForm);
-            }
-            add(session.getForm(formObjId));
+            add(new PublishForm("form", parameters, getClass(), GenConnectPage.class));
         } else {
             throw new RuntimeException("no template parameter");
         }

--- a/src/main/java/com/knowledgepixels/nanodash/page/PreviewPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/PreviewPage.java
@@ -10,6 +10,8 @@ import com.knowledgepixels.nanodash.component.TitleBar;
 import com.knowledgepixels.nanodash.domain.IndividualAgent;
 import com.knowledgepixels.nanodash.repository.MaintainedResourceRepository;
 import com.knowledgepixels.nanodash.repository.SpaceRepository;
+import org.apache.wicket.Page;
+import org.apache.wicket.PageReference;
 import org.apache.wicket.RestartResponseException;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
@@ -72,10 +74,6 @@ public class PreviewPage extends NanodashPage {
                     logger.info("Nanopublication published from preview: {}", npUrl);
                     Utils.cacheNanopub(signedNp);
                     NanodashSession.get().removePreviewNanopub(previewId);
-                    String formObjId = pageParams.get("formobj").toString(null);
-                    if (formObjId != null) {
-                        NanodashSession.get().removeForm(formObjId);
-                    }
 
                     if (!pageParams.get("refresh-upon-publish").isEmpty()) {
                         String toRefresh = pageParams.get("refresh-upon-publish").toString();
@@ -138,7 +136,13 @@ public class PreviewPage extends NanodashPage {
             @Override
             public void onSubmit() {
                 NanodashSession.get().removePreviewNanopub(previewId);
-                throw new RestartResponseException(PublishPage.class, new PageParameters(pageParams));
+                PageReference ref = preview.getSourcePageRef();
+                Page sourcePage = (ref != null) ? ref.getPage() : null;
+                if (sourcePage != null) {
+                    setResponsePage(sourcePage);
+                } else {
+                    throw new RestartResponseException(PublishPage.class, new PageParameters(pageParams));
+                }
             }
         };
         discardButton.setDefaultFormProcessing(false);

--- a/src/main/java/com/knowledgepixels/nanodash/page/PublishPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/PublishPage.java
@@ -5,23 +5,16 @@ import com.knowledgepixels.nanodash.component.DifferentKeyErrorItem;
 import com.knowledgepixels.nanodash.component.PublishForm;
 import com.knowledgepixels.nanodash.component.TemplateList;
 import com.knowledgepixels.nanodash.component.TitleBar;
-import org.apache.wicket.RestartResponseException;
 import org.apache.wicket.markup.head.IHeaderResponse;
 import org.apache.wicket.markup.head.JavaScriptHeaderItem;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.Random;
 
 /**
  * The PublishPage class is responsible for rendering the application's publish page.
  * It allows users to publish content based on templates and manage forms.
  */
 public class PublishPage extends NanodashPage {
-
-    private static final Logger logger = LoggerFactory.getLogger(PublishPage.class);
 
     /**
      * The mount path for the PublishPage.
@@ -41,7 +34,7 @@ public class PublishPage extends NanodashPage {
     /**
      * Constructs a new PublishPage with the given parameters.
      *
-     * @param parameters The parameters for the page, which may include template and form object identifiers.
+     * @param parameters The parameters for the page, which may include a template identifier.
      */
     public PublishPage(final PageParameters parameters) {
         super(parameters);
@@ -53,17 +46,7 @@ public class PublishPage extends NanodashPage {
             if (!parameters.get("sigkey").isNull() && !parameters.get("sigkey").toString().equals(session.getPubkeyString())) {
                 add(new DifferentKeyErrorItem("form", parameters));
             } else {
-                if (!parameters.contains("formobj")) {
-                    throw new RestartResponseException(getClass(), parameters.set("formobj", Math.abs(new Random().nextLong()) + ""));
-                }
-                String formObjId = parameters.get("formobj").toString();
-                if (!session.hasForm(formObjId)) {
-                    logger.warn("Form object not found in session (formobj={}, template={}); creating new form",
-                            formObjId, parameters.get("template"));
-                    PublishForm publishForm = new PublishForm("form", parameters, getClass(), ExplorePage.class);
-                    session.setForm(formObjId, publishForm);
-                }
-                add(session.getForm(formObjId));
+                add(new PublishForm("form", parameters, getClass(), ExplorePage.class));
             }
             add(new Label("templatelist").setVisible(false));
         } else {


### PR DESCRIPTION
## Summary
Replaces the \`formobj\` query-param + session \`formMap\` workaround with Wicket's native \`PageReference\` for the "Back from preview" flow (see #373).

### What changed
- \`NanodashSession.PreviewNanopub\` now holds a \`PageReference\` to the source \`PublishPage\`.
- \`PublishForm\`'s preview button passes \`getPage().getPageReference()\` when storing the preview.
- \`PreviewPage\`'s Back button calls \`setResponsePage(ref.getPage())\` to return to the live page instance; falls back to \`RestartResponseException(PublishPage.class, pageParams)\` if the reference has expired from the page store.
- \`PublishPage\` / \`GenPublishPage\` drop the \`formobj\` redirect and session-cache lookup — just \`new PublishForm(...)\`.
- \`NanodashSession\` drops \`formMap\`, \`MAX_FORMS\`, the LRU eviction + logger, and the \`setForm\`/\`hasForm\`/\`getForm\`/\`removeForm\` helpers (plus the \`removeForm\` call on successful publish).

### Why
- The page store (capped at 100 MB/session) already preserves stateful pages across requests. The formobj layer was a second cache in front of it, solving the same problem less reliably — it never had more guarantees than the page store, only a smaller LRU (20 entries) that caused premature evictions.
- \`PageReference\` is the idiomatic Wicket API for "go back to the page I came from".
- Net: -103 / +19 lines.

## Test plan
- [x] Fill a template form, click "Preview", click "Back" — form values are still populated.
- [x] Fill a template form, click "Preview", click "Publish" — confirm page renders, no errors.
- [x] Fill a template form, fail validation, then preview still works once errors are fixed (sanity check that #445's fix isn't disturbed).
- [x] Same three checks via the connector flow (\`GenPublishPage\` → \`PreviewPage\`).
- [x] Open the browser's network tab and confirm \`/publish\` URLs no longer carry \`&formobj=...\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)