### PR TITLE
fix: use absolute nav links in TitleBar

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/component/TitleBar.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/TitleBar.html
@@ -16,7 +16,7 @@
 <div class="logo-menu">
 <span class="logo" onclick="toggleMobileNav()"></span>
 <div class="logo-dropdown">
-<a href=".">Home</a>
+<a href="/">Home</a>
 <a wicket:id="users" href="./userlist">Users</a>
 <a wicket:id="connectors" href="./spaces">Spaces</a>
 <a wicket:id="query" href="./queries">Query</a>

--- a/src/main/java/com/knowledgepixels/nanodash/component/TitleBar.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/TitleBar.java
@@ -5,6 +5,8 @@ import java.util.List;
 
 import org.apache.wicket.behavior.AttributeAppender;
 import org.apache.wicket.markup.html.WebMarkupContainer;
+import org.apache.wicket.markup.html.WebPage;
+import org.apache.wicket.markup.html.link.BookmarkablePageLink;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.markup.repeater.Item;
 import org.apache.wicket.markup.repeater.data.DataView;
@@ -14,6 +16,10 @@ import com.knowledgepixels.nanodash.NanodashPageRef;
 import com.knowledgepixels.nanodash.NanodashPreferences;
 import com.knowledgepixels.nanodash.Utils;
 import com.knowledgepixels.nanodash.page.NanodashPage;
+import com.knowledgepixels.nanodash.page.PublishPage;
+import com.knowledgepixels.nanodash.page.QueryListPage;
+import com.knowledgepixels.nanodash.page.SpaceListPage;
+import com.knowledgepixels.nanodash.page.UserListPage;
 
 /**
  * TitleBar is the top bar of the Nanodash application, which contains
@@ -38,10 +44,10 @@ public class TitleBar extends Panel {
         this.highlight = highlight;
         add(new ProfileItem("profile", page));
 
-        createContainer("users");
-        createContainer("connectors");
-        createContainer("publish").setVisible(!NanodashPreferences.get().isReadOnlyMode());
-        createContainer("query");
+        createNavLink("users", UserListPage.class);
+        createNavLink("connectors", SpaceListPage.class);
+        createNavLink("publish", PublishPage.class).setVisible(!NanodashPreferences.get().isReadOnlyMode());
+        createNavLink("query", QueryListPage.class);
 
         WebMarkupContainer breadcrumbPath = new WebMarkupContainer("breadcrumbpath");
         breadcrumbPath.setVisible(pathRefs.length > 0);
@@ -125,13 +131,13 @@ public class TitleBar extends Panel {
         return remainder;
     }
 
-    private WebMarkupContainer createContainer(String id) {
-        WebMarkupContainer c = new WebMarkupContainer(id);
+    private BookmarkablePageLink<Void> createNavLink(String id, Class<? extends WebPage> pageClass) {
+        BookmarkablePageLink<Void> link = new BookmarkablePageLink<>(id, pageClass);
         if (id.equals(highlight)) {
-            c.add(new AttributeAppender("class", "selected"));
+            link.add(new AttributeAppender("class", "selected"));
         }
-        add(c);
-        return c;
+        add(link);
+        return link;
     }
 
 }


### PR DESCRIPTION
## Summary
Fixes #450 — from \`/connector/select?journal=...\`, clicking the top-left "Publish" navigated to \`/connector/publish\` (\`GenPublishPage\`) with no \`template\` param and errored out.

Root cause: the nav menu items used \`./publish\`, \`./userlist\`, \`./spaces\`, \`./queries\` as hrefs. Browser URL resolution made them relative to the current page, so from any \`/connector/*\` URL they landed inside the connector tree instead of at the app root.

- Replaced the plain \`WebMarkupContainer\` slots in \`TitleBar\` with \`BookmarkablePageLink\` so Wicket generates absolute, page-class-aware URLs regardless of the current page.
- Changed the static \`Home\` link href from \`.\` to \`/\` for the same reason (it's not Wicket-wired).

## Test plan
- [ ] From \`/connector/select?journal=ios/ds\`, click each top-left menu item (Users, Spaces, Publish, Query, Home) and confirm each lands on the corresponding app-root page.
- [ ] From \`/publish\`, \`/spaces\`, \`/queries\`, \`/userlist\`, the same items keep working as before.
- [ ] In read-only mode, the Publish menu item stays hidden.
- [ ] Highlighted tab (via \`TitleBar\` \`highlight\` argument) still gets the \`selected\` CSS class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)