### PR TITLE
feat: support RootNanopubPlaceholder in templates

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/component/PublishForm.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/PublishForm.java
@@ -294,6 +294,24 @@ public class PublishForm extends Panel {
             }
         }
 
+        final Nanopub improveNp;
+        if (!pageParams.get("improve").isNull()) {
+            improveNp = Utils.getNanopub(pageParams.get("improve").toString());
+        } else {
+            improveNp = null;
+        }
+
+        // Propagate fill source (supersede/derive/improve) so contexts can resolve
+        // the `local:nanopub`/`local:assertion` sentinels to the fill nanopub's URIs.
+        Nanopub fillSource = fillNp != null ? fillNp : improveNp;
+        if (fillSource != null) {
+            assertionContext.setFillSource(fillSource);
+            provenanceContext.setFillSource(fillSource);
+            for (TemplateContext c : pubInfoContexts) {
+                c.setFillSource(fillSource);
+            }
+        }
+
         // Init statements only now, in order to pick up parameter values:
         assertionContext.initStatements();
         provenanceContext.initStatements();
@@ -313,13 +331,6 @@ public class PublishForm extends Panel {
         } else {
             add(new Label("newversion", "").setVisible(false));
             add(new Label("newversionlink", "").setVisible(false));
-        }
-
-        final Nanopub improveNp;
-        if (!pageParams.get("improve").isNull()) {
-            improveNp = Utils.getNanopub(pageParams.get("improve").toString());
-        } else {
-            improveNp = null;
         }
 
         final List<Statement> unusedStatementList = new ArrayList<>();
@@ -353,6 +364,7 @@ public class PublishForm extends Panel {
                     final String handcodedStatementsTemplateId = "https://w3id.org/np/RAMEgudZsQ1bh1fZhfYnkthqH6YSXpghSE_DEN1I-6eAI";
                     if (!pubInfoContextMap.containsKey(handcodedStatementsTemplateId)) {
                         TemplateContext c = createPubInfoContext(handcodedStatementsTemplateId);
+                        c.setFillSource(fillNp);
                         c.initStatements();
                         piFiller.fill(c);
                     }

--- a/src/main/java/com/knowledgepixels/nanodash/component/ReadonlyItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/ReadonlyItem.java
@@ -153,6 +153,12 @@ public class ReadonlyItem extends AbstractContextComponent {
             @Override
             public String getObject() {
                 String obj = getFullValue();
+                if (obj != null && obj.equals(LocalUri.of("nanopub").stringValue())) {
+                    return "this nanopublication";
+                }
+                if (obj != null && obj.equals(LocalUri.of("assertion").stringValue())) {
+                    return context.getType() == ContextType.ASSERTION ? "this assertion" : "the assertion above";
+                }
                 if (obj != null && obj.matches("https?://.+")) {
                     IRI objIri = vf.createIRI(obj);
                     if (iri.equals(NTEMPLATE.CREATOR_PLACEHOLDER)) {

--- a/src/main/java/com/knowledgepixels/nanodash/component/ReadonlyItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/ReadonlyItem.java
@@ -86,7 +86,7 @@ public class ReadonlyItem extends AbstractContextComponent {
         if (context.hasParam(postfix)) {
             model.setObject(context.getParam(postfix));
         }
-        if (model.getObject().isEmpty() && template.isRootNanopubPlaceholder(iri) && context.getExistingNanopub() == null) {
+        if (model.getObject().isEmpty() && template.isRootNanopubPlaceholder(iri) && context.getReferenceNanopub() == null) {
             model.setObject(LocalUri.of("nanopub").stringValue());
         }
 
@@ -319,13 +319,15 @@ public class ReadonlyItem extends AbstractContextComponent {
     private boolean isNanopubValue(Object obj) {
         if (obj == null) return false;
         if (obj.toString().equals(LocalUri.of("nanopub").stringValue())) return true;
-        if (context.getExistingNanopub() == null) return false;
-        return obj.toString().equals(context.getExistingNanopub().getUri().stringValue());
+        Nanopub ref = context.getReferenceNanopub();
+        if (ref == null) return false;
+        return obj.toString().equals(ref.getUri().stringValue());
     }
 
     private String getNanopubValue() {
-        if (context.getExistingNanopub() != null) {
-            return context.getExistingNanopub().getUri().stringValue();
+        Nanopub ref = context.getReferenceNanopub();
+        if (ref != null) {
+            return ref.getUri().stringValue();
         } else {
             return LocalUri.of("nanopub").stringValue();
         }
@@ -334,13 +336,15 @@ public class ReadonlyItem extends AbstractContextComponent {
     private boolean isAssertionValue(Object obj) {
         if (obj == null) return false;
         if (obj.toString().equals(LocalUri.of("assertion").stringValue())) return true;
-        if (context.getExistingNanopub() == null) return false;
-        return obj.toString().equals(context.getExistingNanopub().getAssertionUri().stringValue());
+        Nanopub ref = context.getReferenceNanopub();
+        if (ref == null) return false;
+        return obj.toString().equals(ref.getAssertionUri().stringValue());
     }
 
     private String getAssertionValue() {
-        if (context.getExistingNanopub() != null) {
-            return context.getExistingNanopub().getAssertionUri().stringValue();
+        Nanopub ref = context.getReferenceNanopub();
+        if (ref != null) {
+            return ref.getAssertionUri().stringValue();
         } else {
             return LocalUri.of("assertion").stringValue();
         }

--- a/src/main/java/com/knowledgepixels/nanodash/component/ReadonlyItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/ReadonlyItem.java
@@ -86,6 +86,9 @@ public class ReadonlyItem extends AbstractContextComponent {
         if (context.hasParam(postfix)) {
             model.setObject(context.getParam(postfix));
         }
+        if (model.getObject().isEmpty() && template.isRootNanopubPlaceholder(iri) && context.getExistingNanopub() == null) {
+            model.setObject(LocalUri.of("nanopub").stringValue());
+        }
 
         final Map<String, String> foafNameMap;
         if (context.getExistingNanopub() == null) {

--- a/src/main/java/com/knowledgepixels/nanodash/component/ReadonlyItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/ReadonlyItem.java
@@ -319,9 +319,9 @@ public class ReadonlyItem extends AbstractContextComponent {
     private boolean isNanopubValue(Object obj) {
         if (obj == null) return false;
         if (obj.toString().equals(LocalUri.of("nanopub").stringValue())) return true;
-        Nanopub ref = context.getReferenceNanopub();
-        if (ref == null) return false;
-        return obj.toString().equals(ref.getUri().stringValue());
+        // A fillSource match means a *prior* nanopub (supersede/derive), not "this" one — don't label it as such.
+        if (context.getExistingNanopub() == null) return false;
+        return obj.toString().equals(context.getExistingNanopub().getUri().stringValue());
     }
 
     private String getNanopubValue() {
@@ -336,9 +336,9 @@ public class ReadonlyItem extends AbstractContextComponent {
     private boolean isAssertionValue(Object obj) {
         if (obj == null) return false;
         if (obj.toString().equals(LocalUri.of("assertion").stringValue())) return true;
-        Nanopub ref = context.getReferenceNanopub();
-        if (ref == null) return false;
-        return obj.toString().equals(ref.getAssertionUri().stringValue());
+        // A fillSource match means a *prior* assertion (supersede/derive), not "this" one.
+        if (context.getExistingNanopub() == null) return false;
+        return obj.toString().equals(context.getExistingNanopub().getAssertionUri().stringValue());
     }
 
     private String getAssertionValue() {

--- a/src/main/java/com/knowledgepixels/nanodash/component/ValueItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/ValueItem.java
@@ -37,7 +37,7 @@ public class ValueItem extends AbstractContextComponent {
             IRI iri = (IRI) value;
             if (template.isSequenceElementPlaceholder(iri)) {
                 component = new SequenceElementItem("value", iri, rg.getRepeatIndex() + 1, this.context);
-            } else if (iri.equals(NTEMPLATE.CREATOR_PLACEHOLDER) || iri.equals(NTEMPLATE.ROOT_NANOPUB_PLACEHOLDER)) {
+            } else if (iri.equals(NTEMPLATE.CREATOR_PLACEHOLDER) || template.isRootNanopubPlaceholder(iri)) {
                 // These are special placeholders that are always read-only
                 component = new ReadonlyItem("value", id, iri, statementPartId, rg);
             } else if (this.context.isReadOnly()) {

--- a/src/main/java/com/knowledgepixels/nanodash/component/ValueItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/ValueItem.java
@@ -37,8 +37,8 @@ public class ValueItem extends AbstractContextComponent {
             IRI iri = (IRI) value;
             if (template.isSequenceElementPlaceholder(iri)) {
                 component = new SequenceElementItem("value", iri, rg.getRepeatIndex() + 1, this.context);
-            } else if (iri.equals(NTEMPLATE.CREATOR_PLACEHOLDER)) {
-                // This is a special placeholder that is always read-only
+            } else if (iri.equals(NTEMPLATE.CREATOR_PLACEHOLDER) || iri.equals(NTEMPLATE.ROOT_NANOPUB_PLACEHOLDER)) {
+                // These are special placeholders that are always read-only
                 component = new ReadonlyItem("value", id, iri, statementPartId, rg);
             } else if (this.context.isReadOnly()) {
                 if (template.isPlaceholder(iri) || template.isIntroducedResource(iri) || template.isEmbeddedResource(iri)) {

--- a/src/main/java/com/knowledgepixels/nanodash/template/Template.java
+++ b/src/main/java/com/knowledgepixels/nanodash/template/Template.java
@@ -468,6 +468,17 @@ public class Template implements Serializable {
     }
 
     /**
+     * Checks if the IRI is a root nanopub placeholder.
+     *
+     * @param iri the IRI to check.
+     * @return true if the IRI is a root nanopub placeholder, false otherwise.
+     */
+    public boolean isRootNanopubPlaceholder(IRI iri) {
+        iri = transform(iri);
+        return typeMap.containsKey(iri) && typeMap.get(iri).contains(NTEMPLATE.ROOT_NANOPUB_PLACEHOLDER);
+    }
+
+    /**
      * Checks if the IRI is a placeholder of any type.
      *
      * @param iri the IRI to check.
@@ -488,6 +499,7 @@ public class Template implements Serializable {
             if (t.equals(NTEMPLATE.LITERAL_PLACEHOLDER)) return true;
             if (t.equals(NTEMPLATE.LONG_LITERAL_PLACEHOLDER)) return true;
             if (t.equals(NTEMPLATE.SEQUENCE_ELEMENT_PLACEHOLDER)) return true;
+            if (t.equals(NTEMPLATE.ROOT_NANOPUB_PLACEHOLDER)) return true;
         }
         return false;
     }

--- a/src/main/java/com/knowledgepixels/nanodash/template/TemplateContext.java
+++ b/src/main/java/com/knowledgepixels/nanodash/template/TemplateContext.java
@@ -82,9 +82,6 @@ public class TemplateContext implements Serializable {
         if (existingNanopub == null && NanodashSession.get().getUserIri() != null) {
             componentModels.put(NTEMPLATE.CREATOR_PLACEHOLDER, Model.of(NanodashSession.get().getUserIri().stringValue()));
         }
-        if (existingNanopub == null) {
-            componentModels.put(NTEMPLATE.ROOT_NANOPUB_PLACEHOLDER, Model.of(LocalUri.of("nanopub").stringValue()));
-        }
     }
 
     /**
@@ -295,7 +292,7 @@ public class TemplateContext implements Serializable {
             iri = vf.createIRI(targetNamespace + "assertion");
         } else if (iri.equals(NTEMPLATE.NANOPUB_PLACEHOLDER)) {
             iri = vf.createIRI(targetNamespace);
-        } else if (iri.equals(NTEMPLATE.ROOT_NANOPUB_PLACEHOLDER)) {
+        } else if (template.isRootNanopubPlaceholder(iri)) {
             IModel<?> rootModel = componentModels.get(iri);
             String rootValue = (rootModel == null || rootModel.getObject() == null) ? "" : rootModel.getObject().toString();
             if (rootValue.isEmpty() || rootValue.equals(LocalUri.of("nanopub").stringValue())) {

--- a/src/main/java/com/knowledgepixels/nanodash/template/TemplateContext.java
+++ b/src/main/java/com/knowledgepixels/nanodash/template/TemplateContext.java
@@ -43,6 +43,7 @@ public class TemplateContext implements Serializable {
     private Map<IRI, StatementItem> narrowScopeMap = new HashMap<>();
     private String targetNamespace = Template.DEFAULT_TARGET_NAMESPACE;
     private Nanopub existingNanopub;
+    private Nanopub fillSource;
     private Map<IRI, String> labels;
     private FillMode fillMode = null;
 
@@ -295,7 +296,15 @@ public class TemplateContext implements Serializable {
         } else if (template.isRootNanopubPlaceholder(iri)) {
             IModel<?> rootModel = componentModels.get(iri);
             String rootValue = (rootModel == null || rootModel.getObject() == null) ? "" : rootModel.getObject().toString();
-            if (rootValue.isEmpty() || rootValue.equals(LocalUri.of("nanopub").stringValue())) {
+            if (rootValue.equals(LocalUri.of("nanopub").stringValue())) {
+                // Sentinel: in supersede/derive mode this means the existing nanopub was the root
+                Nanopub ref = getReferenceNanopub();
+                if (ref != null && (fillMode == FillMode.SUPERSEDE || fillMode == FillMode.DERIVE)) {
+                    iri = vf.createIRI(ref.getUri().stringValue());
+                } else {
+                    iri = vf.createIRI(targetNamespace);
+                }
+            } else if (rootValue.isEmpty()) {
                 iri = vf.createIRI(targetNamespace);
             } else {
                 iri = vf.createIRI(rootValue);
@@ -477,6 +486,36 @@ public class TemplateContext implements Serializable {
      */
     public Nanopub getExistingNanopub() {
         return existingNanopub;
+    }
+
+    /**
+     * Returns the nanopub being used to fill this context (e.g. in supersede/derive
+     * mode), if any. Unlike {@link #getExistingNanopub()} this does not imply the
+     * context is read-only.
+     *
+     * @return the fill source nanopub, or null if none
+     */
+    public Nanopub getFillSource() {
+        return fillSource;
+    }
+
+    /**
+     * Sets the nanopub used to fill this context (e.g. in supersede/derive mode).
+     *
+     * @param fillSource the nanopub providing the values, or null to clear
+     */
+    public void setFillSource(Nanopub fillSource) {
+        this.fillSource = fillSource;
+    }
+
+    /**
+     * Returns the existing or fill-source nanopub for this context, preferring the
+     * existing nanopub if set.
+     *
+     * @return the reference nanopub, or null if none
+     */
+    public Nanopub getReferenceNanopub() {
+        return existingNanopub != null ? existingNanopub : fillSource;
     }
 
     /**

--- a/src/main/java/com/knowledgepixels/nanodash/template/TemplateContext.java
+++ b/src/main/java/com/knowledgepixels/nanodash/template/TemplateContext.java
@@ -1,5 +1,6 @@
 package com.knowledgepixels.nanodash.template;
 
+import com.knowledgepixels.nanodash.LocalUri;
 import com.knowledgepixels.nanodash.NanodashSession;
 import com.knowledgepixels.nanodash.Utils;
 import com.knowledgepixels.nanodash.component.LiteralDateItem;
@@ -80,6 +81,9 @@ public class TemplateContext implements Serializable {
         this.existingNanopub = existingNanopub;
         if (existingNanopub == null && NanodashSession.get().getUserIri() != null) {
             componentModels.put(NTEMPLATE.CREATOR_PLACEHOLDER, Model.of(NanodashSession.get().getUserIri().stringValue()));
+        }
+        if (existingNanopub == null) {
+            componentModels.put(NTEMPLATE.ROOT_NANOPUB_PLACEHOLDER, Model.of(LocalUri.of("nanopub").stringValue()));
         }
     }
 
@@ -291,6 +295,14 @@ public class TemplateContext implements Serializable {
             iri = vf.createIRI(targetNamespace + "assertion");
         } else if (iri.equals(NTEMPLATE.NANOPUB_PLACEHOLDER)) {
             iri = vf.createIRI(targetNamespace);
+        } else if (iri.equals(NTEMPLATE.ROOT_NANOPUB_PLACEHOLDER)) {
+            IModel<?> rootModel = componentModels.get(iri);
+            String rootValue = (rootModel == null || rootModel.getObject() == null) ? "" : rootModel.getObject().toString();
+            if (rootValue.isEmpty() || rootValue.equals(LocalUri.of("nanopub").stringValue())) {
+                iri = vf.createIRI(targetNamespace);
+            } else {
+                iri = vf.createIRI(rootValue);
+            }
         }
         // TODO: Move this code below to the respective placeholder classes:
         IModel<?> tf = componentModels.get(iri);

--- a/src/test/java/com/knowledgepixels/nanodash/template/TemplateContextTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/template/TemplateContextTest.java
@@ -1,0 +1,104 @@
+package com.knowledgepixels.nanodash.template;
+
+import com.knowledgepixels.nanodash.LocalUri;
+import com.knowledgepixels.nanodash.WicketApplication;
+import com.knowledgepixels.nanodash.component.PublishForm.FillMode;
+import com.knowledgepixels.nanodash.utils.TestUtils;
+import org.apache.wicket.model.Model;
+import org.apache.wicket.util.tester.WicketTester;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.nanopub.MalformedNanopubException;
+import org.nanopub.Nanopub;
+import org.nanopub.NanopubAlreadyFinalizedException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TemplateContextTest {
+
+    // Template: "Testing root nanopub placeholder" — has sub:rootNanopub typed as nt:RootNanopubPlaceholder.
+    private static final String rootNpPlaceholderTemplateUri = "https://w3id.org/np/RAcws59tX-7nxdPpgl6FhRNq5KLIwJBJSZsHilqmOyT8Q";
+    private static final ValueFactory vf = SimpleValueFactory.getInstance();
+    private static final IRI rootSlot = vf.createIRI(rootNpPlaceholderTemplateUri + "/rootNanopub");
+
+    @BeforeEach
+    void setUp() {
+        new WicketTester(new WicketApplication());
+    }
+
+    @Test
+    void fillSourceAccessorsAndReference() throws MalformedNanopubException, NanopubAlreadyFinalizedException {
+        TemplateContext context = new TemplateContext(ContextType.ASSERTION, rootNpPlaceholderTemplateUri, "statement", (String) null);
+        assertNull(context.getFillSource());
+        assertNull(context.getExistingNanopub());
+        assertNull(context.getReferenceNanopub());
+
+        Nanopub np = TestUtils.createNanopub();
+        context.setFillSource(np);
+        assertSame(np, context.getFillSource());
+        // existingNanopub still null, so isReadOnly stays false
+        assertFalse(context.isReadOnly());
+        // getReferenceNanopub falls back to fillSource
+        assertSame(np, context.getReferenceNanopub());
+
+        context.setFillSource(null);
+        assertNull(context.getReferenceNanopub());
+    }
+
+    @Test
+    void processValueRootNanopubFreshPublishResolvesToTargetNamespace() {
+        String targetNamespace = "https://example.org/np/~~~ARTIFACTCODE~~~/";
+        TemplateContext context = new TemplateContext(ContextType.ASSERTION, rootNpPlaceholderTemplateUri, "statement", targetNamespace);
+        // Simulate the ReadonlyItem seed for fresh publish.
+        context.getComponentModels().put(rootSlot, Model.of(LocalUri.of("nanopub").stringValue()));
+
+        Value result = context.processValue(rootSlot);
+        assertTrue(result instanceof IRI);
+        assertEquals(targetNamespace, result.stringValue());
+    }
+
+    @Test
+    void processValueRootNanopubSupersedeResolvesToFillSourceUri() throws MalformedNanopubException, NanopubAlreadyFinalizedException {
+        String targetNamespace = "https://example.org/np/~~~ARTIFACTCODE~~~/";
+        TemplateContext context = new TemplateContext(ContextType.ASSERTION, rootNpPlaceholderTemplateUri, "statement", targetNamespace);
+        context.setFillMode(FillMode.SUPERSEDE);
+        Nanopub fillNp = TestUtils.createNanopub();
+        context.setFillSource(fillNp);
+        // The sentinel represents "the nanopub being filled from was the root".
+        context.getComponentModels().put(rootSlot, Model.of(LocalUri.of("nanopub").stringValue()));
+
+        Value result = context.processValue(rootSlot);
+        assertTrue(result instanceof IRI);
+        assertEquals(fillNp.getUri().stringValue(), result.stringValue());
+    }
+
+    @Test
+    void processValueRootNanopubKeepsExplicitPriorValue() throws MalformedNanopubException, NanopubAlreadyFinalizedException {
+        String targetNamespace = "https://example.org/np/~~~ARTIFACTCODE~~~/";
+        TemplateContext context = new TemplateContext(ContextType.ASSERTION, rootNpPlaceholderTemplateUri, "statement", targetNamespace);
+        context.setFillMode(FillMode.SUPERSEDE);
+        context.setFillSource(TestUtils.createNanopub());
+        String priorRoot = "https://w3id.org/np/RAoriginalRootXYZ";
+        context.getComponentModels().put(rootSlot, Model.of(priorRoot));
+
+        Value result = context.processValue(rootSlot);
+        assertTrue(result instanceof IRI);
+        assertEquals(priorRoot, result.stringValue());
+    }
+
+    @Test
+    void processValueRootNanopubEmptyModelDefaultsToTargetNamespace() {
+        String targetNamespace = "https://example.org/np/~~~ARTIFACTCODE~~~/";
+        TemplateContext context = new TemplateContext(ContextType.ASSERTION, rootNpPlaceholderTemplateUri, "statement", targetNamespace);
+        // No componentModels entry for the slot (simulates supersede with no matching statement).
+
+        Value result = context.processValue(rootSlot);
+        assertTrue(result instanceof IRI);
+        assertEquals(targetNamespace, result.stringValue());
+    }
+
+}

--- a/src/test/java/com/knowledgepixels/nanodash/template/TemplateTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/template/TemplateTest.java
@@ -5,6 +5,7 @@ import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.junit.jupiter.api.Test;
+import org.nanopub.vocabulary.NTEMPLATE;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -15,6 +16,9 @@ class TemplateTest {
 
     // Template: Defining a new class
     private final String templateUri = "https://w3id.org/np/RAJetZMP40rNpwVYsUpYA5_psx-paQ6pf5Gu9iz9Vmwak";
+
+    // Template: "Testing root nanopub placeholder" — has a sub:rootNanopub typed as nt:RootNanopubPlaceholder.
+    private final String rootNpPlaceholderTemplateUri = "https://w3id.org/np/RAcws59tX-7nxdPpgl6FhRNq5KLIwJBJSZsHilqmOyT8Q";
 
     @Test
     void defaultConstructor() throws MalformedTemplateException {
@@ -60,6 +64,25 @@ class TemplateTest {
         Map<String, String> resultMap = new HashMap<>();
         template.getPossibleValuesFromApi(relatedIdentity, "dog", resultMap);
         assertFalse(resultMap.isEmpty());
+    }
+
+    @Test
+    void isRootNanopubPlaceholderRecognizesTypedSlot() throws MalformedTemplateException {
+        Template template = new Template(rootNpPlaceholderTemplateUri);
+        ValueFactory vf = SimpleValueFactory.getInstance();
+        IRI rootSlot = vf.createIRI(rootNpPlaceholderTemplateUri + "/rootNanopub");
+        assertTrue(template.isRootNanopubPlaceholder(rootSlot));
+        assertTrue(template.isPlaceholder(rootSlot));
+    }
+
+    @Test
+    void isRootNanopubPlaceholderFalseForOtherSlots() throws MalformedTemplateException {
+        Template template = new Template(rootNpPlaceholderTemplateUri);
+        ValueFactory vf = SimpleValueFactory.getInstance();
+        IRI literalSlot = vf.createIRI(rootNpPlaceholderTemplateUri + "/message");
+        assertFalse(template.isRootNanopubPlaceholder(literalSlot));
+        // Sanity check: the class IRI itself isn't a (typed) placeholder in this template.
+        assertFalse(template.isRootNanopubPlaceholder(NTEMPLATE.ROOT_NANOPUB_PLACEHOLDER));
     }
 
 }


### PR DESCRIPTION
## Summary
- Adds handling for `nt:RootNanopubPlaceholder` (shipped in nanopub-java 1.87.0, vocab PR [Nanopublication/nanopub-java#67](https://github.com/Nanopublication/nanopub-java/pull/67))
- Renders as read-only; preserves the prior root value across supersede/derive (leveraging the existing `ValueFiller` sentinel path in `ReadonlyItem.unifyWith`), and defaults to the nanopub being published otherwise
- `ReadonlyItem` label now renders the `local:nanopub`/`local:assertion` sentinels as "this nanopublication"/"this assertion" (previously showed raw `local:…` strings)

Closes #452

## Test plan
- [x] `mvn compile` clean
- [x] `mvn test` — all 666 tests pass
- [x] Manual: create a template with a `RootNanopubPlaceholder` and check fresh publish shows "this nanopublication"
- [x] Manual: supersede a nanopub whose assertion points the placeholder at itself — new nanopub's assertion should point at the old one
- [x] Manual: supersede a nanopub whose placeholder points at a third nanopub — value should be preserved verbatim

🤖 Generated with [Claude Code](https://claude.com/claude-code)