### PR TITLE
chore: refresh Java dependency and plugin versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -265,7 +265,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.5.3</version>
+        <version>3.5.5</version>
         <configuration>
           <argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar}</argLine>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -253,7 +253,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>3.8.1</version>
+        <version>3.10.0</version>
         <executions>
           <execution>
             <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>6.0.2</version>
+      <version>6.0.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
     <dependency>
       <groupId>tools.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
-      <version>3.1.2</version>
+      <version>3.1.3</version>
     </dependency>
     <dependency>
       <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -232,7 +232,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
-        <version>3.4.0</version>
+        <version>3.5.1</version>
       </plugin>
       <plugin>
         <inherited>true</inherited>


### PR DESCRIPTION
## Summary
- Bumps small / patch versions for one runtime dep, one test dep, and three Maven plugins.
- Each bump is a separate commit so it can be reverted independently.

## Bumps
- `jackson-dataformat-yaml` 3.1.2 → 3.1.3
- `junit-jupiter` 6.0.2 → 6.0.3
- `maven-war-plugin` 3.4.0 → 3.5.1
- `maven-dependency-plugin` 3.8.1 → 3.10.0
- `maven-surefire-plugin` 3.5.3 → 3.5.5

## Not included
- **Wicket 10.8.0 → 10.9.0**: dropped from this PR. `wicketstuff-kendo-ui`, `wicketstuff-kendo-ui-theme-default`, and `wicketstuff-select2` are pinned to `${wicket.version}` but wicketstuff has not yet published 10.9.0 to Maven Central. Re-bump once wicketstuff catches up.
- **httpclient 4.5.14**: Apache HttpClient 4.x is EOL, but moving to `httpclient5` 5.x is an API migration, not a version bump.
- **maven-compiler-plugin 4.0.0-beta-4**: beta, skipped.

## Test plan
- [x] `mvn test` — 673 tests, 0 failures. (Two `WicketApplicationTest` errors on the first run were transient network failures during `new WicketApplication()`; re-running the class in isolation passed 6/6.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)