### PR TITLE
fix: don't reseed shared model from URL param on repetition (#271)

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/component/AgentChoiceItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/AgentChoiceItem.java
@@ -66,12 +66,14 @@ public class AgentChoiceItem extends AbstractContextComponent {
         this.iri = iriP;
         final Template template = context.getTemplate();
         model = (IModel<String>) context.getComponentModels().get(iri);
+        boolean modelIsNew = false;
         if (model == null) {
             model = Model.of("");
             context.getComponentModels().put(iri, model);
+            modelIsNew = true;
         }
         String postfix = Utils.getUriPostfix(iri);
-        if (context.hasParam(postfix)) {
+        if (modelIsNew && context.hasParam(postfix)) {
             model.setObject(context.getParam(postfix));
         }
         final List<String> possibleValues = new ArrayList<>();

--- a/src/main/java/com/knowledgepixels/nanodash/component/GuidedChoiceItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/GuidedChoiceItem.java
@@ -99,12 +99,14 @@ public class GuidedChoiceItem extends AbstractContextComponent {
         this.iri = iriP;
         final Template template = context.getTemplate();
         model = (IModel<String>) context.getComponentModels().get(iri);
+        boolean modelIsNew = false;
         if (model == null) {
             model = Model.of("");
             context.getComponentModels().put(iri, model);
+            modelIsNew = true;
         }
         String postfix = Utils.getUriPostfix(iri);
-        if (context.hasParam(postfix)) {
+        if (modelIsNew && context.hasParam(postfix)) {
             String objId = context.getParam(postfix);
             if (AbstractResourceWithProfile.get(objId) != null && AbstractResourceWithProfile.get(objId).getLabel() != null) {
                 labelMap.put(objId, AbstractResourceWithProfile.get(objId).getLabel());

--- a/src/main/java/com/knowledgepixels/nanodash/component/IriTextfieldItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/IriTextfieldItem.java
@@ -54,12 +54,14 @@ public class IriTextfieldItem extends AbstractContextComponent {
         this.iri = iriP;
         final Template template = context.getTemplate();
         IModel<String> model = (IModel<String>) context.getComponentModels().get(iri);
+        boolean modelIsNew = false;
         if (model == null) {
             model = Model.of("");
             context.getComponentModels().put(iri, model);
+            modelIsNew = true;
         }
         String postfix = Utils.getUriPostfix(iri);
-        if (context.hasParam(postfix)) {
+        if (modelIsNew && context.hasParam(postfix)) {
             model.setObject(context.getParam(postfix));
         }
         prefix = template.getPrefix(iri);

--- a/src/main/java/com/knowledgepixels/nanodash/component/LiteralDateItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/LiteralDateItem.java
@@ -52,12 +52,14 @@ public class LiteralDateItem extends AbstractContextComponent {
         this.iri = iri;
         regex = template.getRegex(iri);
         IModel<Date> model = (IModel<Date>) context.getComponentModels().get(iri);
+        boolean modelIsNew = false;
         if (model == null) {
             model = Model.of((Date) null);
             context.getComponentModels().put(iri, model);
+            modelIsNew = true;
         }
         String postfix = Utils.getUriPostfix(iri);
-        if (context.hasParam(postfix)) {
+        if (modelIsNew && context.hasParam(postfix)) {
             try {
                 model.setObject(format.parse(context.getParam(postfix)));
             } catch (ParseException e) {

--- a/src/main/java/com/knowledgepixels/nanodash/component/LiteralDateTimeItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/LiteralDateTimeItem.java
@@ -48,12 +48,14 @@ public class LiteralDateTimeItem extends AbstractContextComponent {
         this.iri = iri;
         regex = template.getRegex(iri);
         IModel<ZonedDateTime> model = (IModel<ZonedDateTime>) context.getComponentModels().get(iri);
+        boolean modelIsNew = false;
         if (model == null) {
             model = Model.of((ZonedDateTime) null);
             context.getComponentModels().put(iri, model);
+            modelIsNew = true;
         }
         String postfix = Utils.getUriPostfix(iri);
-        if (context.hasParam(postfix)) {
+        if (modelIsNew && context.hasParam(postfix)) {
             String zoncontext = context.getParam(postfix);
             if (zoncontext != null) {
                 model.setObject(ZonedDateTime.parse(zoncontext));

--- a/src/main/java/com/knowledgepixels/nanodash/component/LiteralTextfieldItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/LiteralTextfieldItem.java
@@ -49,12 +49,14 @@ public class LiteralTextfieldItem extends AbstractContextComponent {
         this.iri = iri;
         regex = template.getRegex(iri);
         IModel<String> model = (IModel<String>) context.getComponentModels().get(iri);
+        boolean modelIsNew = false;
         if (model == null) {
             model = Model.of("");
             context.getComponentModels().put(iri, model);
+            modelIsNew = true;
         }
         String postfix = Utils.getUriPostfix(iri);
-        if (context.hasParam(postfix)) {
+        if (modelIsNew && context.hasParam(postfix)) {
             model.setObject(context.getParam(postfix));
         }
         AbstractTextComponent<String> tc = initTextComponent(model);

--- a/src/main/java/com/knowledgepixels/nanodash/component/ReadonlyItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/ReadonlyItem.java
@@ -78,12 +78,14 @@ public class ReadonlyItem extends AbstractContextComponent {
         this.iri = iriP;
         template = context.getTemplate();
         model = (IModel<String>) context.getComponentModels().get(iri);
+        boolean modelIsNew = false;
         if (model == null) {
             model = Model.of("");
             context.getComponentModels().put(iri, model);
+            modelIsNew = true;
         }
         String postfix = Utils.getUriPostfix(iri);
-        if (context.hasParam(postfix)) {
+        if (modelIsNew && context.hasParam(postfix)) {
             model.setObject(context.getParam(postfix));
         }
         if (model.getObject().isEmpty() && template.isRootNanopubPlaceholder(iri) && context.getReferenceNanopub() == null) {

--- a/src/main/java/com/knowledgepixels/nanodash/component/RestrictedChoiceItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/RestrictedChoiceItem.java
@@ -57,12 +57,14 @@ public class RestrictedChoiceItem extends AbstractContextComponent {
         this.iri = iri;
         Template template = context.getTemplate();
         model = (IModel<String>) context.getComponentModels().get(iri);
+        boolean modelIsNew = false;
         if (model == null) {
             model = Model.of("");
             context.getComponentModels().put(iri, model);
+            modelIsNew = true;
         }
         String postfix = Utils.getUriPostfix(iri);
-        if (context.hasParam(postfix)) {
+        if (modelIsNew && context.hasParam(postfix)) {
             model.setObject(context.getParam(postfix));
         }
         restrictedChoice = new RestrictedChoice(iri, context);

--- a/src/main/java/com/knowledgepixels/nanodash/component/ValueTextfieldItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/ValueTextfieldItem.java
@@ -48,12 +48,14 @@ public class ValueTextfieldItem extends AbstractContextComponent {
         this.iri = iriP;
         final Template template = context.getTemplate();
         IModel<String> model = (IModel<String>) context.getComponentModels().get(iri);
+        boolean modelIsNew = false;
         if (model == null) {
             model = Model.of("");
             context.getComponentModels().put(iri, model);
+            modelIsNew = true;
         }
         String postfix = Utils.getUriPostfix(iri);
-        if (context.hasParam(postfix)) {
+        if (modelIsNew && context.hasParam(postfix)) {
             model.setObject(context.getParam(postfix));
         }
         textfield = new TextField<>("textfield", model);

--- a/src/test/java/com/knowledgepixels/nanodash/component/ComponentParamSeedTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/component/ComponentParamSeedTest.java
@@ -1,0 +1,122 @@
+package com.knowledgepixels.nanodash.component;
+
+import com.knowledgepixels.nanodash.WicketApplication;
+import com.knowledgepixels.nanodash.template.ContextType;
+import com.knowledgepixels.nanodash.template.TemplateContext;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.Model;
+import org.apache.wicket.util.tester.WicketTester;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.Serializable;
+import java.time.ZonedDateTime;
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Regression test for issue #271: when a new repetition group is added, the
+ * shared {@code IModel} of a global-scope placeholder must keep the user's
+ * edit instead of being re-seeded from the URL param by the new component's
+ * constructor.
+ */
+class ComponentParamSeedTest {
+
+    private static final String TEMPLATE_URI = "https://w3id.org/np/RAcws59tX-7nxdPpgl6FhRNq5KLIwJBJSZsHilqmOyT8Q";
+    private static final ValueFactory vf = SimpleValueFactory.getInstance();
+    private static final String POSTFIX = "myPlaceholder";
+
+    private TemplateContext context;
+    private IRI iri;
+
+    @BeforeEach
+    void setUp() {
+        new WicketTester(new WicketApplication());
+        context = new TemplateContext(ContextType.ASSERTION, TEMPLATE_URI, "statement", (String) null);
+        iri = vf.createIRI(TEMPLATE_URI + "/" + POSTFIX);
+    }
+
+    private <T extends Serializable> IModel<T> seedSharedModel(T userValue) {
+        IModel<T> model = Model.of(userValue);
+        context.getComponentModels().put(iri, model);
+        return model;
+    }
+
+    @Test
+    void iriTextfieldItemPreservesEditedSharedModel() {
+        IModel<String> shared = seedSharedModel("USER_EDITED");
+        context.setParam(POSTFIX, "PARAM_DEFAULT");
+        new IriTextfieldItem("id", "subj", iri, false, context);
+        assertEquals("USER_EDITED", shared.getObject());
+    }
+
+    @Test
+    void iriTextfieldItemSeedsNewModelFromParam() {
+        context.setParam(POSTFIX, "PARAM_DEFAULT");
+        new IriTextfieldItem("id", "subj", iri, false, context);
+        assertEquals("PARAM_DEFAULT", context.getComponentModels().get(iri).getObject());
+    }
+
+    @Test
+    void restrictedChoiceItemPreservesEditedSharedModel() {
+        IModel<String> shared = seedSharedModel("USER_EDITED");
+        context.setParam(POSTFIX, "PARAM_DEFAULT");
+        new RestrictedChoiceItem("id", "subj", iri, false, context);
+        assertEquals("USER_EDITED", shared.getObject());
+    }
+
+    @Test
+    void valueTextfieldItemPreservesEditedSharedModel() {
+        IModel<String> shared = seedSharedModel("USER_EDITED");
+        context.setParam(POSTFIX, "PARAM_DEFAULT");
+        new ValueTextfieldItem("id", "subj", iri, false, context);
+        assertEquals("USER_EDITED", shared.getObject());
+    }
+
+    @Test
+    void guidedChoiceItemPreservesEditedSharedModel() {
+        IModel<String> shared = seedSharedModel("USER_EDITED");
+        context.setParam(POSTFIX, "PARAM_DEFAULT");
+        new GuidedChoiceItem("id", "subj", iri, false, context);
+        assertEquals("USER_EDITED", shared.getObject());
+    }
+
+    @Test
+    void agentChoiceItemPreservesEditedSharedModel() {
+        IModel<String> shared = seedSharedModel("USER_EDITED");
+        context.setParam(POSTFIX, "PARAM_DEFAULT");
+        new AgentChoiceItem("id", "subj", iri, false, context);
+        assertEquals("USER_EDITED", shared.getObject());
+    }
+
+    @Test
+    void literalTextfieldItemPreservesEditedSharedModel() {
+        IModel<String> shared = seedSharedModel("USER_EDITED");
+        context.setParam(POSTFIX, "PARAM_DEFAULT");
+        new LiteralTextfieldItem("id", iri, false, context);
+        assertEquals("USER_EDITED", shared.getObject());
+    }
+
+    @Test
+    void literalDateItemPreservesEditedSharedModel() {
+        Date userDate = new Date(0);
+        IModel<Date> shared = seedSharedModel(userDate);
+        context.setParam(POSTFIX, "2024-01-01");
+        new LiteralDateItem("id", iri, false, context);
+        assertEquals(userDate, shared.getObject());
+    }
+
+    @Test
+    void literalDateTimeItemPreservesEditedSharedModel() {
+        ZonedDateTime userDateTime = ZonedDateTime.parse("2020-01-01T00:00:00Z");
+        IModel<ZonedDateTime> shared = seedSharedModel(userDateTime);
+        context.setParam(POSTFIX, "2024-01-01T00:00:00Z");
+        new LiteralDateTimeItem("id", iri, false, context);
+        assertEquals(userDateTime, shared.getObject());
+    }
+
+}


### PR DESCRIPTION
## Summary
- When clicking "+" to add a repetition group, the new component's constructor unconditionally re-applied the URL param to the shared `IModel` in `TemplateContext.componentModels`. For placeholders with global scope (shared across statements), the model is the same instance the user just edited, so their edit got overwritten with the original `param_*` value.
- Fix: only seed the model from the URL param on first creation. Applied to all 9 components that share this pattern (`IriTextfieldItem`, `RestrictedChoiceItem`, `ValueTextfieldItem`, `GuidedChoiceItem`, `AgentChoiceItem`, `LiteralTextfieldItem`, `LiteralDateItem`, `LiteralDateTimeItem`, `ReadonlyItem`).
- Adds `ComponentParamSeedTest` with one preservation case per affected class (skipping `ReadonlyItem`, which needs a full `RepetitionGroup`) plus a first-seed sanity check.

Closes #271.

## Test plan
- [x] `mvn test -Dtest=ComponentParamSeedTest` — 9 / 9 pass
- [x] Manual repro from the issue: open `publish?template=…RArfO1jDTJ3CEvLpUz6kYoov_Ziq3J3jCrhmEOy0pHJ3Y&param_class=…<SET-SUFFIX>`, change the subject, click "+" — value sticks
- [ ] Spot-check a template with date/datetime placeholders shared across statements

🤖 Generated with [Claude Code](https://claude.com/claude-code)