### PR TITLE
fix: restore F5 form-state preservation via singleton LDMs (#456)

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/WicketApplication.java
+++ b/src/main/java/com/knowledgepixels/nanodash/WicketApplication.java
@@ -28,7 +28,6 @@ import org.apache.wicket.protocol.http.WebApplication;
 import org.apache.wicket.request.Request;
 import org.apache.wicket.request.Response;
 import org.apache.wicket.settings.ExceptionSettings;
-import org.apache.wicket.settings.RequestCycleSettings;
 import org.apache.wicket.util.lang.Bytes;
 import org.nanopub.Nanopub;
 import org.nanopub.extra.services.QueryRef;
@@ -136,7 +135,6 @@ public class WicketApplication extends WebApplication implements NanopubPublishe
         WicketWebjars.install(this);
 
         getMarkupSettings().setDefaultMarkupEncoding("UTF-8");
-        getRequestCycleSettings().setRenderStrategy(RequestCycleSettings.RenderStrategy.ONE_PASS_RENDER);
 
         getExceptionSettings().setUnexpectedExceptionDisplay(ExceptionSettings.SHOW_NO_EXCEPTION_PAGE);
 

--- a/src/main/java/com/knowledgepixels/nanodash/page/ExplorePage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/ExplorePage.java
@@ -16,6 +16,7 @@ import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.link.BookmarkablePageLink;
 import org.apache.wicket.markup.html.link.ExternalLink;
+import org.apache.wicket.model.LoadableDetachableModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.request.flow.RedirectToUrlException;
 import org.apache.wicket.request.mapper.parameter.INamedParameters.NamedPair;
@@ -126,11 +127,17 @@ public class ExplorePage extends NanodashPage {
         add(new TitleBar("titlebar", this, null));
 
         if (SpaceRepository.get().findById(contextId) != null) {
-            add(new BookmarkablePageLink<Void>("back-to-context-link", SpacePage.class, new PageParameters().set("id", contextId)).setBody(Model.of("back to " + SpaceRepository.get().findById(contextId).getLabel())));
+            add(new BookmarkablePageLink<Void>("back-to-context-link", SpacePage.class, new PageParameters().set("id", contextId)).setBody(LoadableDetachableModel.of(() -> {
+                var space = SpaceRepository.get().findById(contextId);
+                return "back to " + (space == null ? contextId : space.getLabel());
+            })));
         } else if (MaintainedResourceRepository.get().findById(contextId) != null) {
-            add(new BookmarkablePageLink<Void>("back-to-context-link", MaintainedResourcePage.class, new PageParameters().set("id", contextId)).setBody(Model.of("back to " + MaintainedResourceRepository.get().findById(contextId).getLabel())));
+            add(new BookmarkablePageLink<Void>("back-to-context-link", MaintainedResourcePage.class, new PageParameters().set("id", contextId)).setBody(LoadableDetachableModel.of(() -> {
+                var resource = MaintainedResourceRepository.get().findById(contextId);
+                return "back to " + (resource == null ? contextId : resource.getLabel());
+            })));
         } else if (IndividualAgent.isUser(contextId)) {
-            add(new BookmarkablePageLink<Void>("back-to-context-link", UserPage.class, new PageParameters().set("id", contextId)).setBody(Model.of("back to " + User.getShortDisplayName(Utils.vf.createIRI(contextId)))));
+            add(new BookmarkablePageLink<Void>("back-to-context-link", UserPage.class, new PageParameters().set("id", contextId)).setBody(LoadableDetachableModel.of(() -> "back to " + User.getShortDisplayName(Utils.vf.createIRI(contextId)))));
         } else {
             add(new Label("back-to-context-link").setVisible(false));
         }

--- a/src/main/java/com/knowledgepixels/nanodash/page/HomePage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/HomePage.java
@@ -12,6 +12,8 @@ import com.knowledgepixels.nanodash.repository.MaintainedResourceRepository;
 import org.apache.wicket.Component;
 import org.apache.wicket.extensions.ajax.markup.html.AjaxLazyLoadPanel;
 import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.LoadableDetachableModel;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
 import org.apache.wicket.util.string.Strings;
 
@@ -69,7 +71,7 @@ public class HomePage extends NanodashPage {
 
         setOutputMarkupId(true);
 
-        String homeResourceId = NanodashPreferences.get().getHomeResource();
+        final String homeResourceId = NanodashPreferences.get().getHomeResource();
         MaintainedResource homeResource = MaintainedResourceRepository.get().findById(homeResourceId);
         if (homeResource == null) {
             String msg = "Configured home resource <code>" + Strings.escapeMarkup(homeResourceId) + "</code> could not be found. " +
@@ -78,6 +80,13 @@ public class HomePage extends NanodashPage {
             return;
         }
         homeResource.triggerDataUpdate();
+
+        final IModel<MaintainedResource> homeResourceModel = new LoadableDetachableModel<MaintainedResource>() {
+            @Override
+            protected MaintainedResource load() {
+                return MaintainedResourceRepository.get().findById(homeResourceId);
+            }
+        };
 
         if (homeResource.isDataInitialized()) {
             ViewList viewList = new ViewList("views", homeResource);
@@ -88,19 +97,25 @@ public class HomePage extends NanodashPage {
 
                 @Override
                 public Component getLazyLoadComponent(String markupId) {
-                    ViewList viewList = new ViewList(markupId, homeResource);
+                    ViewList viewList = new ViewList(markupId, homeResourceModel.getObject());
                     viewList.setPageFooter(new Fragment("page-footer", "homeFooterFragment", HomePage.this));
                     return viewList;
                 }
 
                 @Override
                 protected boolean isContentReady() {
-                    return homeResource.isDataInitialized();
+                    return homeResourceModel.getObject().isDataInitialized();
                 }
 
                 @Override
                 public Component getLoadingComponent(String id) {
                     return new Label(id, "<div class=\"row-section\"><div class=\"col-12\">" + ResultComponent.getWaitIconHtml() + "</div></div>").setEscapeModelStrings(false);
+                }
+
+                @Override
+                protected void onDetach() {
+                    homeResourceModel.detach();
+                    super.onDetach();
                 }
 
             });

--- a/src/main/java/com/knowledgepixels/nanodash/page/MaintainedResourcePage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/MaintainedResourcePage.java
@@ -11,6 +11,8 @@ import org.apache.wicket.Component;
 import org.apache.wicket.extensions.ajax.markup.html.AjaxLazyLoadPanel;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.link.BookmarkablePageLink;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.LoadableDetachableModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
 import org.eclipse.rdf4j.model.util.Values;
@@ -36,14 +38,29 @@ public class MaintainedResourcePage extends NanodashPage {
     }
 
     /**
-     * Maintained resource object with the data shown on this page.
+     * Id of the maintained resource shown on this page. Only the id is held in
+     * the page state; the {@link MaintainedResource} itself is re-fetched from
+     * the repository on every render via {@link #resourceModel}, so the page
+     * tree never carries a serialized snapshot of singleton data.
      */
-    private final MaintainedResource resource;
+    private final String resourceId;
+
+    /**
+     * LDM that resolves {@link #resourceId} to the live {@link MaintainedResource} singleton.
+     */
+    private final IModel<MaintainedResource> resourceModel;
 
     public MaintainedResourcePage(final PageParameters parameters) {
         super(parameters);
 
-        resource = MaintainedResourceRepository.get().findById(parameters.get("id").toString());
+        MaintainedResource resource = MaintainedResourceRepository.get().findById(parameters.get("id").toString());
+        resourceId = resource.getId();
+        resourceModel = new LoadableDetachableModel<MaintainedResource>() {
+            @Override
+            protected MaintainedResource load() {
+                return MaintainedResourceRepository.get().findById(resourceId);
+            }
+        };
         Space space = resource.getSpace();
         resource.triggerDataUpdate();
 
@@ -82,12 +99,12 @@ public class MaintainedResourcePage extends NanodashPage {
 
                 @Override
                 public Component getLazyLoadComponent(String markupId) {
-                    return new ViewList(markupId, resource);
+                    return new ViewList(markupId, resourceModel.getObject());
                 }
 
                 @Override
                 protected boolean isContentReady() {
-                    return resource.isDataInitialized();
+                    return resourceModel.getObject().isDataInitialized();
                 }
 
                 @Override
@@ -106,6 +123,15 @@ public class MaintainedResourcePage extends NanodashPage {
      */
     protected boolean hasAutoRefreshEnabled() {
         return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void onDetach() {
+        resourceModel.detach();
+        super.onDetach();
     }
 
 }

--- a/src/main/java/com/knowledgepixels/nanodash/page/SpacePage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/SpacePage.java
@@ -19,6 +19,8 @@ import org.apache.wicket.RestartResponseException;
 import org.apache.wicket.extensions.ajax.markup.html.AjaxLazyLoadPanel;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.link.BookmarkablePageLink;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.LoadableDetachableModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
 import org.nanopub.Nanopub;
@@ -48,9 +50,18 @@ public class SpacePage extends NanodashPage {
     }
 
     /**
-     * Space object with the data shown on this page.
+     * Id of the space shown on this page. Only the id is held in the page
+     * state; the {@link Space} itself is re-fetched from the repository on
+     * every render via {@link #spaceModel}, so the page tree never carries
+     * a serialized snapshot of singleton data.
      */
-    private final Space space;
+    private final String spaceId;
+
+    /**
+     * LDM that resolves {@link #spaceId} to the live {@link Space} singleton.
+     */
+    private final IModel<Space> spaceModel;
+
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
     private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
 
@@ -62,7 +73,14 @@ public class SpacePage extends NanodashPage {
     public SpacePage(final PageParameters parameters) {
         super(parameters);
 
-        space = resolveSpace(parameters);
+        Space space = resolveSpace(parameters);
+        spaceId = space.getId();
+        spaceModel = new LoadableDetachableModel<Space>() {
+            @Override
+            protected Space load() {
+                return SpaceRepository.get().findById(spaceId);
+            }
+        };
         space.triggerDataUpdate();
 
         Nanopub np = space.getNanopub();
@@ -135,12 +153,12 @@ public class SpacePage extends NanodashPage {
 
                 @Override
                 public Component getLazyLoadComponent(String markupId) {
-                    return new ViewList(markupId, space);
+                    return new ViewList(markupId, spaceModel.getObject());
                 }
 
                 @Override
                 protected boolean isContentReady() {
-                    return space.isDataInitialized();
+                    return spaceModel.getObject().isDataInitialized();
                 }
 
                 @Override
@@ -154,8 +172,8 @@ public class SpacePage extends NanodashPage {
         add(new ItemListPanel<>(
                         "roles",
                         "Roles:",
-                        space::isDataInitialized,
-                        space::getRoles,
+                        () -> spaceModel.getObject().isDataInitialized(),
+                        () -> spaceModel.getObject().getRoles(),
                         r -> new ItemListElement("item", ExplorePage.class, new PageParameters().set("id", r.getRole().getId()), r.getRole().getName(), null, Utils.getAsNanopub(r.getNanopubUri()))
                 )
                         .makeInline()
@@ -175,12 +193,12 @@ public class SpacePage extends NanodashPage {
 
                 @Override
                 public Component getLazyLoadComponent(String markupId) {
-                    return new SpaceUserList(markupId, space);
+                    return new SpaceUserList(markupId, spaceModel.getObject());
                 }
 
                 @Override
                 protected boolean isContentReady() {
-                    return space.isDataInitialized();
+                    return spaceModel.getObject().isDataInitialized();
                 }
 
             });
@@ -207,7 +225,7 @@ public class SpacePage extends NanodashPage {
                 new QueryRef(QueryApiAccess.GET_MAINTAINED_RESOURCES),
                 (apiResponse) -> {
                     MaintainedResourceRepository.get().ensureLoaded();
-                    return MaintainedResourceRepository.get().findResourcesBySpace(space);
+                    return MaintainedResourceRepository.get().findResourcesBySpace(spaceModel.getObject());
                 },
                 (resource) -> new ItemListElement("item", MaintainedResourcePage.class, new PageParameters().set("id", resource.getId()), resource.getLabel())
         ));
@@ -228,8 +246,8 @@ public class SpacePage extends NanodashPage {
         add(new ItemListPanel<>(
                         typePl.toLowerCase(),
                         Space.getTypeEmoji(type) + " " + typePl,
-                        SpaceRepository.get().findSubspaces(space, KPXL_TERMS.NAMESPACE + type),
-                        (space) -> new ItemListElement("item", SpacePage.class, new PageParameters().set("id", space), space.getLabel())
+                        SpaceRepository.get().findSubspaces(spaceModel.getObject(), KPXL_TERMS.NAMESPACE + type),
+                        (subspace) -> new ItemListElement("item", SpacePage.class, new PageParameters().set("id", subspace), subspace.getLabel())
                 )
         );
     }
@@ -241,6 +259,15 @@ public class SpacePage extends NanodashPage {
      */
     protected boolean hasAutoRefreshEnabled() {
         return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void onDetach() {
+        spaceModel.detach();
+        super.onDetach();
     }
 
     /**

--- a/src/test/java/com/knowledgepixels/nanodash/WicketApplicationTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/WicketApplicationTest.java
@@ -1,6 +1,7 @@
 package com.knowledgepixels.nanodash;
 
 import com.knowledgepixels.nanodash.page.HomePage;
+import org.apache.wicket.settings.RequestCycleSettings;
 import org.apache.wicket.util.tester.WicketTester;
 import org.junit.jupiter.api.Test;
 
@@ -44,6 +45,15 @@ class WicketApplicationTest {
     void getLatestVersionWhenFetchSucceeds() {
         String result = WicketApplication.getLatestVersion();
         assertTrue(result.matches("\\d+.\\d+(.\\d+)*"));
+    }
+
+    // Guards #456: ONE_PASS_RENDER must not be re-introduced — it breaks F5 form-state preservation.
+    @Test
+    void initUsesDefaultRedirectToBufferRenderStrategy() {
+        assertEquals(
+                RequestCycleSettings.RenderStrategy.REDIRECT_TO_BUFFER,
+                tester.getApplication().getRequestCycleSettings().getRenderStrategy()
+        );
     }
 
 }

--- a/src/test/java/com/knowledgepixels/nanodash/page/MaintainedResourcePageTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/page/MaintainedResourcePageTest.java
@@ -1,0 +1,37 @@
+package com.knowledgepixels.nanodash.page;
+
+import com.knowledgepixels.nanodash.domain.MaintainedResource;
+import com.knowledgepixels.nanodash.domain.Space;
+import org.apache.wicket.model.IModel;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MaintainedResourcePageTest {
+
+    // Guards #456: instance state must not embed live singleton references, otherwise
+    // the page-store snapshot drifts from the repository between renders.
+    @Test
+    void doesNotHoldDirectMaintainedResourceOrSpaceInstanceField() {
+        for (Field f : MaintainedResourcePage.class.getDeclaredFields()) {
+            if (Modifier.isStatic(f.getModifiers())) continue;
+            assertNotEquals(MaintainedResource.class, f.getType(),
+                    "MaintainedResourcePage must not hold a direct MaintainedResource field: " + f.getName());
+            assertNotEquals(Space.class, f.getType(),
+                    "MaintainedResourcePage must not hold a direct Space field: " + f.getName());
+        }
+    }
+
+    @Test
+    void holdsResourceIdAndResourceModelFields() throws NoSuchFieldException {
+        Field idField = MaintainedResourcePage.class.getDeclaredField("resourceId");
+        assertEquals(String.class, idField.getType());
+
+        Field modelField = MaintainedResourcePage.class.getDeclaredField("resourceModel");
+        assertEquals(IModel.class, modelField.getType());
+    }
+
+}

--- a/src/test/java/com/knowledgepixels/nanodash/page/SpacePageTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/page/SpacePageTest.java
@@ -1,0 +1,37 @@
+package com.knowledgepixels.nanodash.page;
+
+import com.knowledgepixels.nanodash.domain.MaintainedResource;
+import com.knowledgepixels.nanodash.domain.Space;
+import org.apache.wicket.model.IModel;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SpacePageTest {
+
+    // Guards #456: instance state must not embed live singleton references, otherwise
+    // the page-store snapshot drifts from the repository between renders.
+    @Test
+    void doesNotHoldDirectSpaceOrMaintainedResourceInstanceField() {
+        for (Field f : SpacePage.class.getDeclaredFields()) {
+            if (Modifier.isStatic(f.getModifiers())) continue;
+            assertNotEquals(Space.class, f.getType(),
+                    "SpacePage must not hold a direct Space field: " + f.getName());
+            assertNotEquals(MaintainedResource.class, f.getType(),
+                    "SpacePage must not hold a direct MaintainedResource field: " + f.getName());
+        }
+    }
+
+    @Test
+    void holdsSpaceIdAndSpaceModelFields() throws NoSuchFieldException {
+        Field idField = SpacePage.class.getDeclaredField("spaceId");
+        assertEquals(String.class, idField.getType());
+
+        Field modelField = SpacePage.class.getDeclaredField("spaceModel");
+        assertEquals(IModel.class, modelField.getType());
+    }
+
+}


### PR DESCRIPTION
## Summary

- Revert `ONE_PASS_RENDER` (introduced in #401) so Wicket falls back to its default `REDIRECT_TO_BUFFER` strategy — F5 restores the stored page instance, which preserves partly-filled form values on `PublishPage`, `GenPublishPage`, and the connector forms.
- Hold only the resource id in the page state on `SpacePage` and `MaintainedResourcePage`; wrap the `Space` / `MaintainedResource` in a `LoadableDetachableModel` so restored pages re-fetch the live singleton instead of rendering from a serialized snapshot.
- Route `AjaxLazyLoadPanel` inner classes, `ItemListPanel` suppliers, and `addSubspacePanel` through the model; override `onDetach()`.
- Fix the three `Model.of(\"back to \" + findById().getLabel())` snapshots in `ExplorePage` with `LoadableDetachableModel`.
- Wrap the home resource in `HomePage`'s lazy-loaded `ViewList` path in a `LoadableDetachableModel`.

Implements the plan in #456. Other pages flagged as medium-risk there (`ResourcePartPage`, `UserPage`, `SearchPage`, `ChannelPage`, `ListPage`, `PreviewPage`, `ViewPage`, `SpaceListPage`, `DownloadRdfPage`) were left untouched — convert any that surface stale data during testing.

Closes #456.

## Test plan

- [x] `mvn -o clean compile` passes
- [x] `mvn -o test` passes (682 tests, 0 failures)
- [x] Open `/publish?template=...`, partly fill the form, press F5 — values are restored
- [x] Navigate to a Space page, publish something targeted at it (e.g. add a member/role) from another tab, and confirm the originating Space page reflects the new data after F5 (auto-refresh + LDM both apply)
- [ ] Same check for a Maintained Resource page
- [x] Visit `/explore?id=<term>&context=<spaceId|resourceId|userId>` — the \"back to ...\" link shows the current label
- [x] Visit `/` — home resource views load both fast-path and via the lazy loader

🤖 Generated with [Claude Code](https://claude.com/claude-code)