### PR TITLE
chore(dev): raise Jetty form and response-header size limits

### DIFF
--- a/src/test/jetty/jetty-http.xml
+++ b/src/test/jetty/jetty-http.xml
@@ -6,6 +6,15 @@
 <!-- This configuration must be used in conjunction with jetty.xml -->
 <!-- ============================================================= -->
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
+  <!-- Raise the default form-post limits so large publish forms don't 500 with "Form too large". -->
+  <Call name="setAttribute">
+    <Arg>org.eclipse.jetty.server.Request.maxFormContentSize</Arg>
+    <Arg type="long">10000000</Arg>
+  </Call>
+  <Call name="setAttribute">
+    <Arg>org.eclipse.jetty.server.Request.maxFormKeys</Arg>
+    <Arg type="int">100000</Arg>
+  </Call>
   <!-- =========================================================== -->
   <!-- Add an HTTP Connector.                                      -->
   <!-- Configure an o.e.j.server.ServerConnector with a single     -->

--- a/src/test/jetty/jetty.xml
+++ b/src/test/jetty/jetty.xml
@@ -11,7 +11,7 @@
     </Set>
     <Set name="outputBufferSize">32768</Set>
     <Set name="requestHeaderSize">65536</Set>
-    <Set name="responseHeaderSize">8192</Set>
+    <Set name="responseHeaderSize">65536</Set>
     <Set name="sendServerVersion">false</Set>
     <Set name="sendDateHeader">false</Set>
     <Set name="headerCacheSize">512</Set>


### PR DESCRIPTION
## Summary
Local \`mvn jetty:run\` (via \`./run-dev.sh\`) was returning \`500: Response header too large\` and \`500: Form too large\` for real publish flows. Two Jetty defaults are easy to exceed:

- **Response header size** — default 8 KB. A post-publish redirect that carries \`template\` + \`template-version\` + \`id\` + \`refresh-upon-publish\` (plus session cookies) can overflow it. Raised to 64 KB to match the existing \`requestHeaderSize\`.
- **Form content size** (200 KB) and **form keys** (1000) — templates with many fields blow past 1000 form keys easily. Raised to 10 MB / 100 000 keys via Server attributes in \`jetty-http.xml\`.

Local dev only. Production runs on Tomcat (per the \`tomcat-docker-image\` property in \`pom.xml\`) and has its own analogous defaults that aren't affected by these XML files.

## Test plan
- [ ] \`./run-dev.sh\`, publish a template that previously hit \"Response header too large\" — should no longer 500.
- [ ] Publish a wide template (many fields / multi-value rows) — should no longer 500 with \"Form too large\".

🤖 Generated with [Claude Code](https://claude.com/claude-code)