### PR TITLE
feat: expose Nanodash-Version response header

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/WicketApplication.java
+++ b/src/main/java/com/knowledgepixels/nanodash/WicketApplication.java
@@ -27,6 +27,9 @@ import org.apache.wicket.Session;
 import org.apache.wicket.protocol.http.WebApplication;
 import org.apache.wicket.request.Request;
 import org.apache.wicket.request.Response;
+import org.apache.wicket.request.cycle.IRequestCycleListener;
+import org.apache.wicket.request.cycle.RequestCycle;
+import org.apache.wicket.request.http.WebResponse;
 import org.apache.wicket.settings.ExceptionSettings;
 import org.apache.wicket.util.lang.Bytes;
 import org.nanopub.Nanopub;
@@ -188,6 +191,16 @@ public class WicketApplication extends WebApplication implements NanopubPublishe
 
         getCspSettings().blocking().disabled();
         getStoreSettings().setMaxSizePerSession(Bytes.megabytes(100));
+
+        getRequestCycleListeners().add(new IRequestCycleListener() {
+            @Override
+            public void onBeginRequest(RequestCycle cycle) {
+                Response response = cycle.getResponse();
+                if (response instanceof WebResponse) {
+                    ((WebResponse) response).setHeader("Nanodash-Version", getThisVersion());
+                }
+            }
+        });
 
         registerListeners();
 


### PR DESCRIPTION
## Summary
- Add an `IRequestCycleListener` in `WicketApplication.init()` that sets a `Nanodash-Version` HTTP response header on every request, mirroring the `Nanopub-Registry-Version` / `Nanopub-Query-Version` headers emitted by the sibling Vert.x services.
- Value comes from the existing `WicketApplication.getThisVersion()` (Maven-filtered `nanodash.properties`).

## Test plan
- [x] `mvn compile` succeeds
- [x] Start Nanodash locally and confirm `curl -I http://localhost:37373/` returns a `Nanodash-Version: <version>` header
- [ ] Confirm the header is also present on a non-page resource (e.g. a static asset or AJAX response)

🤖 Generated with [Claude Code](https://claude.com/claude-code)