### PR TITLE
Render /userlist Human/Software/Non-Approved lists as item-list views

### DIFF
--- a/docs/userlist-views.md
+++ b/docs/userlist-views.md
@@ -1,0 +1,155 @@
+# /userlist views — draft queries to publish
+
+Goal: turn the three remaining hard-coded lists on `UserListPage` (👤 Human Users,
+🤖 Software Agents, ❓ Non-Approved Users) into proper views, the same way
+`topcreators` and `latestusers` already are.
+
+This needs, per list, **(1) a published grlc query nanopub** (SPARQL below) and
+**(2) a published View nanopub** (`gen:ItemListView`) referencing it. Then the Java
+in `UserListPage` just needs the three `*_VIEW` constants set to the published View
+nanopub IDs.
+
+## Published (live, 2026-05-27)
+
+Current (v2) IRIs — the v1 set was superseded to fix duplicate rows for users
+with multiple `foaf:name` values (now `group by ?user_iri` + `sample(?name)`):
+
+| List | Query nanopub (current) | View resource IRI (in `UserListPage`) |
+|---|---|---|
+| 👤 Human Users | `RAN3bBS3Hbeom7JNYBhKtGc-4RjkGYHBBHlnRAaGPvl7k/get-approved-human-users` | `RAeDwLoelA43CfcetS7LVQOAgQuDCw-Yf5naRYdmCmCXs/human-users-view` |
+| 🤖 Software Agents | `RAFMW55TSw7rwAi-mLRsgnhOugd7ZYf4L5zvzFeoU9OWQ/get-approved-software-agents` | `RAr4qrDh77rNoRcodAoGDOJLEECu3sBvrUJPAhuK73e1c/software-agents-view` |
+| ❓ Non-Approved Users | `RAOnj3-qfGOYazNRGoOiAZRck3PxGT8zJMzucI4DUGQU0/get-non-approved-users` | `RA8Xkr-SnsRqu0RBGExZ3Ms8J1TviL_1bRQVRnymaWafw/non-approved-users-view` |
+
+All under the `https://w3id.org/np/` prefix. The view-kind IRIs (stable across
+supersedes, used in `dct:isVersionOf`) remain under the v1 nanopubs
+(`RAWM…/human-users-view-kind`, `RAe87…/software-agents-view-kind`,
+`RA2p4…/non-approved-users-view-kind`). Signed TriG sources are in `../nanopub-skill/tmp/`.
+
+The SPARQL below reflects the published v2 queries (one row per user).
+
+## How approval/software become queryable
+
+The blocker that previously forced these client-side — approval living only in the
+registry `list.json` joined in `UserData` — is gone. The query service `trust` repo
+exposes the current trust state as `npa:AccountState` rows (`npa:agent`, `npa:pubkey`
+= sha256 hash, `npa:trustStatus`). `trustStatus = npa:loaded` ≈ approved. `isSoftware`
+comes from `?user a npx:SoftwareAgent` in the intro nanopubs (IntroNanopub type repo).
+All three queries below were validated live against query.knowledgepixels.com (~0.6s each).
+
+Endpoints (grlc `endpoint`):
+- IntroNanopub type repo: `https://w3id.org/np/l/nanopub-query-1.1/repo/type/77757cabf6184c51c20b8b0fe5dc5e1365b7f628448335184ad54319a0affdfc`
+- Trust repo (federated via `SERVICE`): `https://w3id.org/np/l/nanopub-query-1.1/repo/trust`
+
+The renderer (`QueryResultItemList`) keys off a column ending in `user_iri` (icon +
+`UserPage` link; bot icon when the user is a `SoftwareAgent`). The `user_iri_label`
+column is used as the link text, falling back to `User.getShortDisplayName` when blank.
+
+---
+
+## Query 1 — 👤 Human Users (approved, not software)
+
+Endpoint: **trust repo** (drive from the small ~635-row approved set; `SERVICE` into intros).
+Suggested `rdfs:label` / view `dct:title`: `👤 Human Users`
+
+```sparql
+prefix np: <http://www.nanopub.org/nschema#>
+prefix npx: <http://purl.org/nanopub/x/>
+prefix npa: <http://purl.org/nanopub/admin/>
+prefix foaf: <http://xmlns.com/foaf/0.1/>
+
+select ?user_iri (sample(?name) as ?user_iri_label) where {
+  graph npa:graph { npa:thisRepo npa:hasCurrentTrustState ?g . }
+  graph ?g { ?acct a npa:AccountState ; npa:agent ?user_iri ; npa:trustStatus npa:loaded . }
+  service <https://w3id.org/np/l/nanopub-query-1.1/repo/type/77757cabf6184c51c20b8b0fe5dc5e1365b7f628448335184ad54319a0affdfc> {
+    graph ?a { ?kd npx:declaredBy ?user_iri . }
+    filter not exists { graph ?a2 { ?user_iri a npx:SoftwareAgent } }
+    optional { graph ?a { ?user_iri foaf:name ?name } }
+  }
+} group by ?user_iri order by lcase(str(sample(?name)))
+```
+
+## Query 2 — 🤖 Software Agents (approved, software)
+
+Identical to Query 1 but flip the software filter to `filter exists`.
+Suggested label/title: `🤖 Software Agents`
+
+```sparql
+prefix np: <http://www.nanopub.org/nschema#>
+prefix npx: <http://purl.org/nanopub/x/>
+prefix npa: <http://purl.org/nanopub/admin/>
+prefix foaf: <http://xmlns.com/foaf/0.1/>
+
+select ?user_iri (sample(?name) as ?user_iri_label) where {
+  graph npa:graph { npa:thisRepo npa:hasCurrentTrustState ?g . }
+  graph ?g { ?acct a npa:AccountState ; npa:agent ?user_iri ; npa:trustStatus npa:loaded . }
+  service <https://w3id.org/np/l/nanopub-query-1.1/repo/type/77757cabf6184c51c20b8b0fe5dc5e1365b7f628448335184ad54319a0affdfc> {
+    graph ?a { ?kd npx:declaredBy ?user_iri . }
+    filter exists { graph ?a2 { ?user_iri a npx:SoftwareAgent } }
+    optional { graph ?a { ?user_iri foaf:name ?name } }
+  }
+} group by ?user_iri order by lcase(str(sample(?name)))
+```
+
+## Query 3 — ❓ Non-Approved Users (have an intro, no loaded account)
+
+Endpoint: **IntroNanopub type repo** (drive from intros; `MINUS` the approved agents from trust).
+Suggested label/title: `❓ Non-Approved Users`
+
+```sparql
+prefix np: <http://www.nanopub.org/nschema#>
+prefix npx: <http://purl.org/nanopub/x/>
+prefix npa: <http://purl.org/nanopub/admin/>
+prefix foaf: <http://xmlns.com/foaf/0.1/>
+
+select distinct ?user_iri (?name as ?user_iri_label) where {
+  graph npa:graph {
+    ?intronp npa:hasValidSignatureForPublicKey ?pk ; np:hasAssertion ?a .
+    filter not exists { ?x npx:invalidates ?intronp ; npa:hasValidSignatureForPublicKey ?pk . }
+  }
+  graph ?a {
+    ?kd npx:declaredBy ?user_iri .
+    optional { ?user_iri foaf:name ?name }
+  }
+  minus {
+    service <https://w3id.org/np/l/nanopub-query-1.1/repo/trust> {
+      graph npa:graph { npa:thisRepo npa:hasCurrentTrustState ?g . }
+      graph ?g { ?acct npa:agent ?user_iri ; npa:trustStatus npa:loaded . }
+    }
+  }
+} group by ?user_iri order by lcase(str(sample(?name)))
+```
+
+---
+
+## View nanopub shape (one per query, modeled on `latest-users`)
+
+```turtle
+sub:human-users a gen:ItemListView, gen:ResourceView ;
+    dct:isVersionOf sub:human-users-kind ;
+    dct:title "👤 Human Users" ;
+    rdfs:label "Human Users View" ;
+    gen:hasViewQuery <.../RA…#human-users-query> ;
+    gen:hasViewQueryTargetField "resource" .
+```
+
+`UserListPage` calls the item-list builder directly, so the view type drives
+nothing in code — but type it `gen:ItemListView` for correctness/discoverability.
+The queries take no per-resource parameter (global lists), so `hasViewQueryTargetField`
+is irrelevant here; the `QueryRef` is built with no params.
+
+## Open decisions / caveats
+
+- **Approval semantics:** `trustStatus = npa:loaded` is treated as approved. Decide how
+  `contested` (4) / `skipped` (3) should map. The registry `list.json` (current client
+  source) and the query `trust` repo derive from the same trust state but are separate
+  snapshots — minor drift possible.
+- **Sort parity:** the old lists sort by `User.getShortDisplayName`; these sort by
+  `foaf:name` server-side (users without a name sort first and render via
+  `getShortDisplayName`). Close but not identical ordering.
+- **Per-key vs per-agent approval:** Non-Approved is computed per *agent* (no loaded
+  account at all). The old client logic is per (agent, pubkey-hash); a user with both an
+  approved and an unapproved key could differ at the edges. Validate against the live
+  list before publishing.
+- **Display width:** the three lists sit in `col-6` wrappers in `UserListPage.html`;
+  check the rendered width once live and tune via the view's `gen:hasDisplayWidth` or
+  `ViewDisplay.withDisplayWidth(...)` if needed.

--- a/src/main/java/com/knowledgepixels/nanodash/page/UserListPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/UserListPage.java
@@ -2,19 +2,12 @@ package com.knowledgepixels.nanodash.page;
 
 import com.knowledgepixels.nanodash.View;
 import com.knowledgepixels.nanodash.ViewDisplay;
-import com.knowledgepixels.nanodash.component.ItemListElement;
-import com.knowledgepixels.nanodash.component.ItemListPanel;
+import com.knowledgepixels.nanodash.component.QueryResultItemListBuilder;
 import com.knowledgepixels.nanodash.component.QueryResultListBuilder;
 import com.knowledgepixels.nanodash.component.TitleBar;
-import com.knowledgepixels.nanodash.domain.IndividualAgent;
-import com.knowledgepixels.nanodash.domain.User;
 import org.apache.wicket.markup.html.link.ExternalLink;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
-import org.eclipse.rdf4j.model.IRI;
 import org.nanopub.extra.services.QueryRef;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Page that lists all users and groups.
@@ -25,6 +18,10 @@ public class UserListPage extends NanodashPage {
      * The mount path for this page.
      */
     public static final String MOUNT_PATH = "/userlist";
+
+    private static final String HUMAN_USERS_VIEW = "https://w3id.org/np/RAeDwLoelA43CfcetS7LVQOAgQuDCw-Yf5naRYdmCmCXs/human-users-view";
+    private static final String SOFTWARE_AGENTS_VIEW = "https://w3id.org/np/RAr4qrDh77rNoRcodAoGDOJLEECu3sBvrUJPAhuK73e1c/software-agents-view";
+    private static final String NON_APPROVED_USERS_VIEW = "https://w3id.org/np/RA8Xkr-SnsRqu0RBGExZ3Ms8J1TviL_1bRQVRnymaWafw/non-approved-users-view";
 
     /**
      * {@inheritDoc}
@@ -67,29 +64,17 @@ public class UserListPage extends NanodashPage {
         QueryRef luQueryRef = new QueryRef(latestUsersView.getQuery().getQueryId());
         add(QueryResultListBuilder.create("latestusers", luQueryRef, new ViewDisplay(latestUsersView).withDisplayWidth(6)).build());
 
-        add(new ItemListPanel<IRI>(
-                "approved-human-users",
-                "👤 Human Users",
-                User.getUsers(true).stream().filter(iri -> !IndividualAgent.isSoftware(iri)).collect(Collectors.toList()),
-                (userIri) -> new ItemListElement("item", UserPage.class, new PageParameters().set("id", userIri), User.getShortDisplayName(userIri)),
-                User::getShortDisplayName
-        ));
+        View humanUsersView = View.get(HUMAN_USERS_VIEW);
+        add(QueryResultItemListBuilder.create("approved-human-users",
+                new QueryRef(humanUsersView.getQuery().getQueryId()), new ViewDisplay(humanUsersView)).build());
 
-        add(new ItemListPanel<IRI>(
-                "approved-software-agents",
-                "🤖 Software Agents",
-                User.getUsers(true).stream().filter(IndividualAgent::isSoftware).collect(Collectors.toList()),
-                (userIri) -> new ItemListElement("item", UserPage.class, new PageParameters().set("id", userIri), User.getShortDisplayName(userIri)),
-                User::getShortDisplayName
-        ));
+        View softwareAgentsView = View.get(SOFTWARE_AGENTS_VIEW);
+        add(QueryResultItemListBuilder.create("approved-software-agents",
+                new QueryRef(softwareAgentsView.getQuery().getQueryId()), new ViewDisplay(softwareAgentsView)).build());
 
-        add(new ItemListPanel<IRI>(
-                "other-users",
-                "❓ Non-Approved Users",
-                User.getUsers(false),
-                (userIri) -> new ItemListElement("item", UserPage.class, new PageParameters().set("id", userIri), User.getShortDisplayName(userIri)),
-                User::getShortDisplayName
-        ));
+        View nonApprovedUsersView = View.get(NON_APPROVED_USERS_VIEW);
+        add(QueryResultItemListBuilder.create("other-users",
+                new QueryRef(nonApprovedUsersView.getQuery().getQueryId()), new ViewDisplay(nonApprovedUsersView)).build());
 
         add(new ExternalLink("approve", PublishPage.MOUNT_PATH + "?template=http://purl.org/np/RA6TVVSnZChEwyxjvFDNAujk1i8sSPnQx60ZQjldtiDkw&template-version=latest", "approve somebody else..."));
         //add(new ExternalLink("newgroup", PublishPage.MOUNT_PATH + "?template=http://purl.org/np/RAJz6w5cvlsFGkCDtWOUXt2VwEQ3tVGtPdy3atPj_DUhk&template-version=latest", "new group"));


### PR DESCRIPTION
Converts the three remaining hard-coded lists on `/userlist` (👤 Human Users, 🤖 Software Agents, ❓ Non-Approved Users) into proper item-list views, mirroring the existing `topcreators`/`latestusers` views on the same page.

## What changed
- `UserListPage`: the three `ItemListPanel<IRI>` blocks are replaced by `QueryResultItemListBuilder` calls wired to published `ITEM_LIST_VIEW` nanopubs. Unused imports trimmed. No HTML change (both are self-rendering panels in the same `<div class="users">` containers).
- `docs/userlist-views.md`: design notes, the validated SPARQL, published IRIs, and caveats.

## Why this is now possible
The approval/software distinction was previously a client-side join in `UserData` against the registry `list.json`. It is now sourced server-side: the Nanopub Query `trust` repo exposes the trust state (`AccountState`, `trustStatus = loaded`) and the IntroNanopub type repo provides `isSoftware`, federated via `SERVICE`.

## Published nanopubs (live, 2026-05-27)
| List | View IRI | Rows |
|---|---|---|
| 👤 Human Users | `RAeDwLoelA43CfcetS7LVQOAgQuDCw-Yf5naRYdmCmCXs/human-users-view` | 627 |
| 🤖 Software Agents | `RAr4qrDh77rNoRcodAoGDOJLEECu3sBvrUJPAhuK73e1c/software-agents-view` | 8 |
| ❓ Non-Approved Users | `RA8Xkr-SnsRqu0RBGExZ3Ms8J1TviL_1bRQVRnymaWafw/non-approved-users-view` | 230 |

Each view's query returns one row per user (`group by ?user_iri` + `sample(?name)`; an initial version was superseded to fix duplicate rows for users with multiple `foaf:name` values).

## Caveats
- `trustStatus = loaded` counts as approved; `contested`/`skipped` are excluded.
- Sort is by `foaf:name` server-side (close to, not identical to, the old `getShortDisplayName` ordering).
- Worth a visual check of the `col-6` column width on `/userlist` once deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)