### PR TITLE
Bump nanopub to 1.90.0 and drop placeholder/expansion code it now provides

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
     <dependency>
       <groupId>org.nanopub</groupId>
       <artifactId>nanopub</artifactId>
-      <version>1.89.0</version>
+      <version>1.90.0</version>
     </dependency>
     <!-- Temporary: dependency on Jitpack for snapshot builds -->
     <!-- <dependency>

--- a/src/main/java/com/knowledgepixels/nanodash/GrlcQuery.java
+++ b/src/main/java/com/knowledgepixels/nanodash/GrlcQuery.java
@@ -109,49 +109,21 @@ public class GrlcQuery extends QueryTemplate {
     }
 
     /**
-     * Expands the SPARQL query by substituting placeholder values from the given param fields.
-     * Unlike the strict server-side expansion in {@link QueryTemplate}, missing/unset params are
-     * simply skipped (not thrown as errors), to support the partial substitution used for the
-     * Yasgui link. Placeholder conventions follow {@link QueryParamField} (which recognizes
-     * {@code _multi_val} in addition to the standard suffixes).
+     * Expands the SPARQL query by substituting the user-entered param-field values. This adapts the
+     * UI {@link QueryParamField}s into the parameter map of {@link QueryTemplate#expandQuery(Map, boolean)}
+     * and expands non-strictly: missing/unset params are not errors but left partially expanded (the
+     * placeholder kept for single values, the empty {@code VALUES} block dropped for multi values), as
+     * needed for the Yasgui link.
      *
      * @param paramFields the list of query parameter fields with user-entered values
      * @return the expanded SPARQL query string
      */
     public String expandQuery(List<QueryParamField> paramFields) {
-        Map<String, QueryParamField> fieldMap = new HashMap<>();
+        Map<String, List<String>> params = new HashMap<>();
         for (QueryParamField f : paramFields) {
-            fieldMap.put(f.getParamName(), f);
+            if (f.isSet()) params.put(f.getParamName(), List.of(f.getValues()));
         }
-        String expandedQueryContent = getSparql();
-        for (String ph : getPlaceholdersList()) {
-            String paramName = QueryParamField.getParamName(ph);
-            QueryParamField field = fieldMap.get(paramName);
-            if (field == null || !field.isSet()) continue;
-            if (QueryParamField.isMultiPlaceholder(ph)) {
-                String[] values = field.getValues();
-                StringBuilder valueList = new StringBuilder();
-                for (String v : values) {
-                    if (isIriPlaceholder(ph)) {
-                        valueList.append(serializeIri(v)).append(" ");
-                    } else {
-                        valueList.append(serializeLiteral(v)).append(" ");
-                    }
-                }
-                expandedQueryContent = expandedQueryContent.replaceAll(
-                    "values\\s*\\?" + ph + "\\s*\\{\\s*\\}",
-                    "values ?" + ph + " { " + escapeSlashes(valueList.toString()) + "}"
-                );
-            } else {
-                String val = field.getValues()[0];
-                if (isIriPlaceholder(ph)) {
-                    expandedQueryContent = expandedQueryContent.replaceAll("\\?" + ph + "(?![A-Za-z0-9_])", escapeSlashes(serializeIri(val)));
-                } else {
-                    expandedQueryContent = expandedQueryContent.replaceAll("\\?" + ph + "(?![A-Za-z0-9_])", escapeSlashes(serializeLiteral(val)));
-                }
-            }
-        }
-        return expandedQueryContent;
+        return expandQuery(params, false);
     }
 
     /**
@@ -165,10 +137,6 @@ public class GrlcQuery extends QueryTemplate {
             if (!f.isOptional() && !f.isSet()) return false;
         }
         return true;
-    }
-
-    private static String escapeSlashes(String string) {
-        return string.replace("\\", "\\\\");
     }
 
 }

--- a/src/main/java/com/knowledgepixels/nanodash/LookupApis.java
+++ b/src/main/java/com/knowledgepixels/nanodash/LookupApis.java
@@ -19,6 +19,7 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import org.nanopub.extra.services.ApiResponse;
 import org.nanopub.extra.services.ApiResponseEntry;
 import org.nanopub.extra.services.QueryRef;
+import org.nanopub.extra.services.QueryTemplate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,7 +28,6 @@ import com.github.openjson.JSONArray;
 import com.github.openjson.JSONObject;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
-import com.knowledgepixels.nanodash.component.QueryParamField;
 
 /**
  * Utility class for APIs look up and parsing.
@@ -287,7 +287,7 @@ public class LookupApis {
         }
         String queryParamName = "query";
         if (q.getPlaceholdersList().size() == 1) {
-            queryParamName = QueryParamField.getParamName(q.getPlaceholdersList().get(0));
+            queryParamName = QueryTemplate.getParamName(q.getPlaceholdersList().get(0));
         }
         params.put(queryParamName, searchterm);
         ApiResponse result = ApiCache.retrieveResponseSync(new QueryRef(queryId, params), false);

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryParamField.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryParamField.java
@@ -10,6 +10,7 @@ import org.apache.wicket.validation.INullAcceptingValidator;
 import org.apache.wicket.validation.IValidatable;
 import org.apache.wicket.validation.ValidationError;
 import org.eclipse.rdf4j.common.net.ParsedIRI;
+import org.nanopub.extra.services.QueryTemplate;
 
 import java.net.URISyntaxException;
 
@@ -76,7 +77,7 @@ public class QueryParamField extends Panel {
      * @return the parameter name
      */
     public String getParamName() {
-        return getParamName(paramId);
+        return QueryTemplate.getParamName(paramId);
     }
 
     /**
@@ -108,7 +109,7 @@ public class QueryParamField extends Panel {
      * @return true if the parameter is optional, false otherwise
      */
     public boolean isOptional() {
-        return isOptional(paramId);
+        return QueryTemplate.isOptionalPlaceholder(paramId);
     }
 
     /**
@@ -117,7 +118,7 @@ public class QueryParamField extends Panel {
      * @return true if the parameter is an IRI parameter, false otherwise
      */
     public boolean isIri() {
-        return paramId.endsWith("_iri");
+        return QueryTemplate.isIriPlaceholder(paramId);
     }
 
     /**
@@ -135,7 +136,7 @@ public class QueryParamField extends Panel {
      * @return true if the parameter is a multi parameter, false otherwise
      */
     public boolean isMultiPlaceholder() {
-        return isMultiPlaceholder(paramId);
+        return QueryTemplate.isMultiPlaceholder(paramId);
     }
 
     private class Validator extends InvalidityHighlighting implements INullAcceptingValidator<String> {
@@ -181,20 +182,6 @@ public class QueryParamField extends Panel {
     }
 
     /**
-     * Checks if a parameter ID indicates a multi parameter (ends with "_multi" or "_multi_iri").
-     *
-     * @param p the parameter ID to check
-     * @return true if the parameter ID indicates a multi parameter, false otherwise
-     */
-    public static boolean isMultiPlaceholder(String p) {
-        return p.endsWith("_multi") || p.endsWith("_multi_iri") || p.endsWith("_multi_val");
-    }
-
-    public static boolean isOptional(String p) {
-        return p.startsWith("__");
-    }
-
-    /**
      * Expands the value string into an array of values based on whether the parameter is multi or not.
      *
      * @param s       the value string
@@ -204,21 +191,11 @@ public class QueryParamField extends Panel {
     public static String[] expandValues(String s, String paramId) {
         if (!isSet(s)) {
             return new String[]{};
-        } else if (isMultiPlaceholder(paramId)) {
+        } else if (QueryTemplate.isMultiPlaceholder(paramId)) {
             return s.replaceFirst("\r?\n$", "").split("\r?\n");
         } else {
             return new String[]{s};
         }
-    }
-
-    /**
-     * Extracts the parameter name from the placeholder ID.
-     *
-     * @param placeholderId the placeholder ID, which may start with underscores and end with "_iri" and/or "_multi"
-     * @return the parameter name, stripped of leading underscores and "_iri"/"_multi" suffixes
-     */
-    public static String getParamName(String placeholderId) {
-        return placeholderId.replaceFirst("^_+", "").replaceFirst("_multi_val$", "").replaceFirst("_iri$", "").replaceFirst("_multi$", "");
     }
 
 }

--- a/src/main/java/com/knowledgepixels/nanodash/component/ViewList.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/ViewList.java
@@ -16,6 +16,7 @@ import org.apache.wicket.markup.html.list.ListView;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.eclipse.rdf4j.model.IRI;
 import org.nanopub.extra.services.QueryRef;
+import org.nanopub.extra.services.QueryTemplate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -91,10 +92,10 @@ public class ViewList extends Panel {
                         View view = item.getModelObject().getView();
                         Multimap<String, String> queryRefParams = ArrayListMultimap.create();
                         for (String p : view.getQuery().getPlaceholdersList()) {
-                            String paramName = QueryParamField.getParamName(p);
+                            String paramName = QueryTemplate.getParamName(p);
                             if (paramName.equals(view.getQueryField())) {
                                 queryRefParams.put(view.getQueryField(), id);
-                                if (QueryParamField.isMultiPlaceholder(p) && resourceWithProfile instanceof Space space) {
+                                if (QueryTemplate.isMultiPlaceholder(p) && resourceWithProfile instanceof Space space) {
                                     // TODO Support this also for maintained resources and users.
                                     for (String altId : space.getAltIDs()) {
                                         queryRefParams.put(view.getQueryField(), altId);
@@ -103,12 +104,12 @@ public class ViewList extends Panel {
                             } else if (paramName.equals(view.getQueryField() + "Namespace") && resourceWithProfile.getNamespace() != null) {
                                 queryRefParams.put(view.getQueryField() + "Namespace", resourceWithProfile.getNamespace());
                             } else if (paramName.equals(view.getQueryField() + "Np")) {
-                                if (!QueryParamField.isOptional(p) && npId == null) {
+                                if (!QueryTemplate.isOptionalPlaceholder(p) && npId == null) {
                                     queryRefParams.put(view.getQueryField() + "Np", "x:");
                                 } else {
                                     queryRefParams.put(view.getQueryField() + "Np", npId);
                                 }
-                            } else if (!QueryParamField.isOptional(p)) {
+                            } else if (!QueryTemplate.isOptionalPlaceholder(p)) {
                                 item.add(new Label("view", "<span class=\"negative\">Error: Query has non-optional parameter</span>").setEscapeModelStrings(false));
                                 logger.error("Error: Query has non-optional parameter: {} {}", view.getQuery().getQueryId(), p);
                                 return;

--- a/src/main/java/com/knowledgepixels/nanodash/page/DownloadRdfPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/DownloadRdfPage.java
@@ -8,7 +8,6 @@ import com.knowledgepixels.nanodash.SpaceMemberRoleRef;
 import com.knowledgepixels.nanodash.Utils;
 import com.knowledgepixels.nanodash.View;
 import com.knowledgepixels.nanodash.ViewDisplay;
-import com.knowledgepixels.nanodash.component.QueryParamField;
 import com.knowledgepixels.nanodash.domain.AbstractResourceWithProfile;
 import com.knowledgepixels.nanodash.domain.IndividualAgent;
 import com.knowledgepixels.nanodash.domain.MaintainedResource;
@@ -34,6 +33,7 @@ import org.nanopub.NanopubWithNs;
 import org.nanopub.extra.services.ApiResponse;
 import org.nanopub.extra.services.ApiResponseEntry;
 import org.nanopub.extra.services.QueryRef;
+import org.nanopub.extra.services.QueryTemplate;
 import org.nanopub.extra.setting.IntroNanopub;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -408,10 +408,10 @@ public class DownloadRdfPage extends WebPage {
 
         Multimap<String, String> queryRefParams = ArrayListMultimap.create();
         for (String p : view.getQuery().getPlaceholdersList()) {
-            String paramName = QueryParamField.getParamName(p);
+            String paramName = QueryTemplate.getParamName(p);
             if (paramName.equals(view.getQueryField())) {
                 queryRefParams.put(view.getQueryField(), targetId);
-                if (QueryParamField.isMultiPlaceholder(p) && resource instanceof Space space) {
+                if (QueryTemplate.isMultiPlaceholder(p) && resource instanceof Space space) {
                     for (String altId : space.getAltIDs()) {
                         queryRefParams.put(view.getQueryField(), altId);
                     }
@@ -419,12 +419,12 @@ public class DownloadRdfPage extends WebPage {
             } else if (paramName.equals(view.getQueryField() + "Namespace") && resource.getNamespace() != null) {
                 queryRefParams.put(view.getQueryField() + "Namespace", resource.getNamespace());
             } else if (paramName.equals(view.getQueryField() + "Np")) {
-                if (!QueryParamField.isOptional(p) && targetNpId == null) {
+                if (!QueryTemplate.isOptionalPlaceholder(p) && targetNpId == null) {
                     queryRefParams.put(view.getQueryField() + "Np", "x:");
                 } else {
                     queryRefParams.put(view.getQueryField() + "Np", targetNpId);
                 }
-            } else if (!QueryParamField.isOptional(p)) {
+            } else if (!QueryTemplate.isOptionalPlaceholder(p)) {
                 logger.error("Query has non-optional parameter that cannot be filled: {} {}", view.getQuery().getQueryId(), p);
                 return null;
             }


### PR DESCRIPTION
nanopub `1.90.0` adds `_multi_val` placeholder support (and a `strict` flag) to `QueryTemplate` — the only reason nanodash still carried its own copies of the grlc placeholder conventions and query expansion. With the bump those become redundant.

## Changes
- **`pom.xml`** — nanopub `1.89.0` → `1.90.0`.
- **`QueryParamField`** — removed the duplicated static `isMultiPlaceholder`/`isOptional`/`getParamName` (now identical to `QueryTemplate`'s, including the `_multi_val` support nanodash had added locally). Instance methods and `expandValues` delegate to `QueryTemplate`.
- **`GrlcQuery.expandQuery`** — reduced to a thin adapter that maps the UI `QueryParamField`s into `QueryTemplate.expandQuery(params, false)`. `strict=false` provides the lenient partial expansion used for the Yasgui link. Dropped the duplicated substitution/serialization loop and `escapeSlashes`.
- **`ViewList`, `DownloadRdfPage`, `LookupApis`** — call `QueryTemplate.*` directly (`isOptional` → `isOptionalPlaceholder`); unused `QueryParamField` imports removed.

Net: −81 / +27 across 6 files; the `_multi_val` convention now lives in exactly one place (nanopub-java).

## Behavior note
For an **unfilled multi-value** placeholder, the Yasgui-link query now has its empty `VALUES ?x {}` block **removed** (library behavior) instead of left in place — a runnable, unconstrained query rather than one returning nothing. The `auto_execution_blocker` guard for unfilled mandatory fields is unchanged.

## Verification
- `mvn compile` clean on 1.90.0.
- `mvn test`: **691 run, 0 failures, 0 errors** (incl. `GrlcQueryTest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)