### PR TITLE
Show all templates on Publish page as a single sortable table

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultTable.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultTable.java
@@ -109,6 +109,8 @@ public class QueryResultTable extends QueryResult {
                     displayLabel = displayLabel.substring(0, displayLabel.length() - "_multi_val".length());
                 } else if (displayLabel.endsWith("_multi")) {
                     displayLabel = displayLabel.substring(0, displayLabel.length() - "_multi".length());
+                } else if (displayLabel.endsWith("_iri")) {
+                    displayLabel = displayLabel.substring(0, displayLabel.length() - "_iri".length());
                 }
                 columns.add(new Column(displayLabel.replaceAll("_", " "), h));
             }

--- a/src/main/java/com/knowledgepixels/nanodash/component/TemplateList.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/TemplateList.html
@@ -22,19 +22,7 @@
 
 <div class="row-section">
 
-<div class="col-12">
-
-<h3>📋 All Templates</h3>
-
-<div class="columncontainer">
-
-<div wicket:id="topics" class="columnelement">
-<div wicket:id="templates" class="forms"></div>
-</div>
-
-</div>
-
-</div>
+<div wicket:id="all-templates" class="forms"></div>
 
 </div>
 

--- a/src/main/java/com/knowledgepixels/nanodash/component/TemplateList.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/TemplateList.java
@@ -1,31 +1,19 @@
 package com.knowledgepixels.nanodash.component;
 
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.HashMap;
-import java.util.Map;
-
 import org.apache.wicket.markup.html.panel.Panel;
-import org.apache.wicket.markup.repeater.Item;
-import org.apache.wicket.markup.repeater.data.DataView;
-import org.apache.wicket.markup.repeater.data.ListDataProvider;
-import org.nanopub.extra.services.ApiResponseEntry;
 import org.nanopub.extra.services.QueryRef;
 
 import com.knowledgepixels.nanodash.View;
 import com.knowledgepixels.nanodash.ViewDisplay;
-import com.knowledgepixels.nanodash.template.TemplateData;
-
-import jakarta.xml.bind.DatatypeConverter;
 
 /**
- * A list of templates, grouped by topic.
+ * The template chooser shown on the Publish page: the highlighted "popular" and
+ * "get started" views, followed by a single filterable list of all templates.
  */
 public class TemplateList extends Panel {
 
     /**
-     * A list of templates, grouped by topic.
+     * Constructs the template list.
      *
      * @param id the wicket id of this component
      */
@@ -41,64 +29,9 @@ public class TemplateList extends Panel {
         QueryRef gsQueryRef = new QueryRef(getStartedView.getQuery().getQueryId());
         add(QueryResultListBuilder.create("getstarted-templates", gsQueryRef, new ViewDisplay(getStartedView).withDisplayWidth(6)).build());
 
-        ArrayList<ApiResponseEntry> templateList = new ArrayList<>(TemplateData.get().getAssertionTemplates());
-        templateList.sort((t1, t2) -> {
-            Calendar c1 = getTime(t1);
-            Calendar c2 = getTime(t2);
-            if (c1 == null && c2 == null) return 0;
-            if (c1 == null) return 1;
-            if (c2 == null) return -1;
-            return c2.compareTo(c1);
-        });
-
-        Map<String, Topic> topics = new HashMap<>();
-        for (ApiResponseEntry entry : templateList) {
-            String tag = entry.get("tag");
-            if (tag.isEmpty()) tag = null;
-            if (!topics.containsKey(tag)) {
-                topics.put(tag, new Topic(tag));
-            }
-            topics.get(tag).templates.add(entry);
-
-        }
-        ArrayList<Topic> topicList = new ArrayList<Topic>(topics.values());
-        topicList.sort((t0, t1) -> {
-            if (t0.tag == null) return 1;
-            if (t1.tag == null) return -1;
-            return t1.templates.size() - t0.templates.size();
-        });
-        DataView<Topic> topicDataView = new DataView<Topic>("topics", new ListDataProvider<Topic>(topicList)) {
-
-            @Override
-            protected void populateItem(Item<Topic> item) {
-                String tag = item.getModelObject().tag;
-                if (tag == null) tag = "Other";
-                item.add(new ItemListPanel<ApiResponseEntry>(
-                        "templates",
-                        tag,
-                        item.getModelObject().templates,
-                        (respEntry) -> new TemplateItem("item", respEntry)
-                ));
-            }
-        };
-        topicDataView.setOutputMarkupId(true);
-        add(topicDataView);
-    }
-
-    private static Calendar getTime(ApiResponseEntry entry) {
-        return DatatypeConverter.parseDateTime(entry.get("date"));
-    }
-
-
-    private static class Topic implements Serializable {
-
-        String tag;
-        ArrayList<ApiResponseEntry> templates = new ArrayList<>();
-
-        Topic(String tag) {
-            this.tag = tag;
-        }
-
+        View allTemplatesView = View.get("https://w3id.org/np/RA33Eah2-MF_vAZfMf9BCSKrHJRHxLPm7DNxJ14RPxdN8/all-templates-view");
+        QueryRef atQueryRef = new QueryRef(allTemplatesView.getQuery().getQueryId());
+        add(QueryResultTableBuilder.create("all-templates", atQueryRef, new ViewDisplay(allTemplatesView)).build());
     }
 
 }


### PR DESCRIPTION
Replaces the topic-grouped **All Templates** section on the Publish page with a single, sortable table of all templates.

## Changes
- **`TemplateList`** — the per-tag grouping (`DataView<Topic>` + `ItemListPanel` + client-side `TemplateData` sort) is replaced by one view over the published `get-all-templates` query, rendered with `QueryResultTableBuilder`. This reuses the existing `all-templates-view` (a `TabularView`), so the renderer now matches the view's declared type. Columns: **template** (clickable → publish form) · **tag** · **creator** · **date**, each with a sortable header, plus the built-in filter box and pagination. (`TemplateList.html` simplified to a single `all-templates` container; the redundant `<h3>` dropped since the view supplies its title.)
- **`QueryResultTable`** — strip a trailing `_iri` when deriving column headers, so headers read "template"/"user" instead of "template iri"/"user iri". Completes the pattern already applied to `_multi`/`_multi_iri`/`_multi_val`; the full column key is untouched, so the publish-link special-casing, label pairing, and sorting are unaffected.

## Notes
- Sorting applies across the full result set (not just the visible page); IRI columns sort on their `_label` companion (template sorts by name).
- Cosmetic, query-driven leftovers: the header reads "creator" (the query's `?creator`/signer), and the date shows as a raw ISO string (sorts chronologically). Prettifying those (author name, formatted date) would require editing + republishing the `get-all-templates` query.

## Verification
- `mvn compile` clean; wicket:ids match; `WicketApplicationTest` green. No automated PublishPage render test exists, so the page itself wasn't machine-rendered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)