### PR TITLE
refactor: collapse repo cache + push view-display admin gate server-side

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/QueryApiAccess.java
+++ b/src/main/java/com/knowledgepixels/nanodash/QueryApiAccess.java
@@ -66,7 +66,7 @@ public class QueryApiAccess {
     public static final String GET_LATEST_RIO_CANDIDATES = "RAehKOCOnZ3uDBmI0kkCNTh5k9Nl6YYNj7tyc20tVymxY/get-latest-rio-candidates";
     public static final String GET_REACTIONS = "RAe7k3L0oElPOrFoUMkUhqU9dGUqfBaUSw3cVplOUn3Fk/get-reactions";
     public static final String GET_TERM_DEFINITIONS = "RAZUsK7jU85oUYEVKvMPFlqbwn19oR55IQuFkXuiS_Tkg/get-term-definitions";
-    public static final String GET_VIEW_DISPLAYS = "RAapc3jbJ3GkDy0ncKx3pok_zEKqwrT6-Z5TkCP1k96II/get-view-displays";
+    public static final String GET_VIEW_DISPLAYS = "RAIMs6C9gfjqX-TYGd8mrq7MJ7K-DoofW6v4dzFQJTs7Y/get-view-displays";
 
     // Spaces-repo queries (endpoint: nanopub-query .../repo/spaces)
     public static final String GET_SPACES = "RA1sxIHufQSSPu9ZWG6Est26euNJMhBOO33oQF_TV7xnc/get-spaces";

--- a/src/main/java/com/knowledgepixels/nanodash/domain/AbstractResourceWithProfile.java
+++ b/src/main/java/com/knowledgepixels/nanodash/domain/AbstractResourceWithProfile.java
@@ -132,9 +132,6 @@ public abstract class AbstractResourceWithProfile implements Serializable, Resou
                     ResourceWithProfile newData = new ResourceWithProfile();
 
                     for (ApiResponseEntry r : ApiCache.retrieveResponseSync(new QueryRef(QueryApiAccess.GET_VIEW_DISPLAYS, "resource", id), true).getData()) {
-                        if (space != null && !space.isAdminPubkey(r.get("pubkey"))) {
-                            continue;
-                        }
                         try {
                             newData.viewDisplays.add(ViewDisplay.get(r.get("display")));
                         } catch (IllegalArgumentException ex) {

--- a/src/main/java/com/knowledgepixels/nanodash/domain/Space.java
+++ b/src/main/java/com/knowledgepixels/nanodash/domain/Space.java
@@ -19,8 +19,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.Serializable;
 import java.util.*;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Class representing a "Space", which can be any kind of collaborative unit, like a project, group, or event.
@@ -29,71 +27,57 @@ public class Space extends AbstractResourceWithProfile {
 
     private static final Logger logger = LoggerFactory.getLogger(Space.class);
 
-    @Override
-    public boolean isDataInitialized() {
-        triggerDataUpdate();
-        return dataInitialized && super.isDataInitialized();
-    }
-
-    @Override
-    public void setDataNeedsUpdate() {
-        super.setDataNeedsUpdate();
-        dataNeedsUpdate = true;
-    }
-
-    @Override
-    public void forceRefresh(long waitMillis) {
-        super.forceRefresh(waitMillis);
-        dataNeedsUpdate = true;
-        dataInitialized = false;
-    }
-
     private String label, rootNanopubId, type;
     private Nanopub rootNanopub = null;
-    private SpaceData data = new SpaceData();
+
+    // Core data — derived directly from the root nanopub assertion.
+    private final List<String> altIds = new ArrayList<>();
+    private final List<IRI> rootAdmins = new ArrayList<>();
+    private String description = null;
+    private Calendar startDate, endDate;
+    private IRI defaultProvenance = null;
+
+    // Derived data — admins / members / roles loaded from the spaces repo and
+    // memoised by ApiResponse object identity (rebuild when ApiCache returns a
+    // fresh response for any of the three underlying queries).
+    private volatile ApiResponse cachedAdminsResp, cachedRolesResp, cachedMembersResp;
+    private volatile SpaceData cachedData = SpaceData.EMPTY;
 
     private static class SpaceData implements Serializable {
 
-        List<String> altIds = new ArrayList<>();
+        final List<IRI> admins;
+        final Map<IRI, Set<SpaceMemberRoleRef>> users;
+        final List<SpaceMemberRoleRef> roles;
+        final Map<IRI, SpaceMemberRole> roleMap;
 
-        String description = null;
-        Calendar startDate, endDate;
-        IRI defaultProvenance = null;
-
-        List<IRI> admins = new ArrayList<>();
-        Map<IRI, Set<SpaceMemberRoleRef>> users = new HashMap<>();
-        List<SpaceMemberRoleRef> roles = new ArrayList<>();
-        Map<IRI, SpaceMemberRole> roleMap = new HashMap<>();
-
-        Map<String, IRI> adminPubkeyMap = new HashMap<>();
-
-        void addAdmin(IRI admin, String npId) {
-            // TODO This isn't efficient for long owner lists:
-            if (admins.contains(admin)) return;
-            admins.add(admin);
-            // adminPubkeyMap is populated in bulk by loadAdminPubkeyHashesFromSpacesRepo,
-            // sourcing trust-state-validated (agent, pubkey-hash) pairs from the
-            // spaces repo's npa:AccountState rows.
-            users.computeIfAbsent(admin, (k) -> new HashSet<>()).add(new SpaceMemberRoleRef(SpaceMemberRole.ADMIN_ROLE, npId));
+        SpaceData(List<IRI> admins, Map<IRI, Set<SpaceMemberRoleRef>> users,
+                  List<SpaceMemberRoleRef> roles, Map<IRI, SpaceMemberRole> roleMap) {
+            this.admins = admins;
+            this.users = users;
+            this.roles = roles;
+            this.roleMap = roleMap;
         }
 
+        static final SpaceData EMPTY = new SpaceData(
+                Collections.emptyList(), Collections.emptyMap(),
+                Collections.emptyList(), Collections.emptyMap());
     }
 
     private static final Map<String, String> TYPE_EMOJIS = Map.ofEntries(
-            Map.entry("Alliance", "\uD83E\uDD1D"),
-            Map.entry("Consortium", "\u2602\uFE0F"),
-            Map.entry("Organization", "\uD83C\uDFE2"),
-            Map.entry("Taskforce", "\uD83C\uDFAF"),
-            Map.entry("Division", "\uD83C\uDFD7\uFE0F"),
-            Map.entry("Taskunit", "\u2699\uFE0F"),
-            Map.entry("Group", "\uD83D\uDC65"),
-            Map.entry("Project", "\uD83D\uDE80"),
-            Map.entry("Program", "\uD83D\uDCCB"),
-            Map.entry("Initiative", "\uD83D\uDCA1"),
-            Map.entry("Outlet", "\uD83D\uDCF0"),
-            Map.entry("Campaign", "\uD83D\uDCE3"),
-            Map.entry("Community", "\uD83C\uDF10"),
-            Map.entry("Event", "\uD83C\uDFAA")
+            Map.entry("Alliance", "🤝"),
+            Map.entry("Consortium", "☂️"),
+            Map.entry("Organization", "🏢"),
+            Map.entry("Taskforce", "🎯"),
+            Map.entry("Division", "🏗️"),
+            Map.entry("Taskunit", "⚙️"),
+            Map.entry("Group", "👥"),
+            Map.entry("Project", "🚀"),
+            Map.entry("Program", "📋"),
+            Map.entry("Initiative", "💡"),
+            Map.entry("Outlet", "📰"),
+            Map.entry("Campaign", "📣"),
+            Map.entry("Community", "🌐"),
+            Map.entry("Event", "🎪")
     );
 
     /**
@@ -106,16 +90,6 @@ public class Space extends AbstractResourceWithProfile {
         return TYPE_EMOJIS.getOrDefault(typeName, "");
     }
 
-    private static String getCoreInfoString(ApiResponseEntry resp) {
-        String id = resp.get("space");
-        String rootNanopubId = resp.get("np");
-        return id + " " + rootNanopubId;
-    }
-
-    private volatile boolean dataInitialized = false;
-    private volatile boolean dataNeedsUpdate = true;
-    private transient volatile Future<?> spaceDataFuture = null;
-
     Space(ApiResponseEntry resp) {
         super(resp.get("space"));
         initSpace(this);
@@ -123,7 +97,7 @@ public class Space extends AbstractResourceWithProfile {
         this.type = resp.get("type");
         this.rootNanopubId = resp.get("np");
         this.rootNanopub = Utils.getAsNanopub(rootNanopubId);
-        setCoreData(data);
+        readCoreData();
     }
 
     void updateFromApi(ApiResponseEntry resp) {
@@ -133,6 +107,13 @@ public class Space extends AbstractResourceWithProfile {
             this.type = resp.get("type");
             this.rootNanopubId = newNpId;
             this.rootNanopub = Utils.getAsNanopub(newNpId);
+            altIds.clear();
+            rootAdmins.clear();
+            description = null;
+            startDate = null;
+            endDate = null;
+            defaultProvenance = null;
+            readCoreData();
             setDataNeedsUpdate();
         }
     }
@@ -197,7 +178,7 @@ public class Space extends AbstractResourceWithProfile {
      * @return The start date as a Calendar object, or null if not set.
      */
     public Calendar getStartDate() {
-        return data.startDate;
+        return startDate;
     }
 
     /**
@@ -206,7 +187,7 @@ public class Space extends AbstractResourceWithProfile {
      * @return The end date as a Calendar object, or null if not set.
      */
     public Calendar getEndDate() {
-        return data.endDate;
+        return endDate;
     }
 
     /**
@@ -224,7 +205,7 @@ public class Space extends AbstractResourceWithProfile {
      * @return The description string.
      */
     public String getDescription() {
-        return data.description;
+        return description;
     }
 
 
@@ -234,8 +215,7 @@ public class Space extends AbstractResourceWithProfile {
      * @return List of admin IRIs.
      */
     public List<IRI> getAdmins() {
-        ensureInitialized();
-        return data.admins;
+        return currentData().admins;
     }
 
     /**
@@ -244,8 +224,7 @@ public class Space extends AbstractResourceWithProfile {
      * @return List of member IRIs.
      */
     public List<IRI> getUsers() {
-        ensureInitialized();
-        List<IRI> users = new ArrayList<IRI>(data.users.keySet());
+        List<IRI> users = new ArrayList<>(currentData().users.keySet());
         users.sort(User.getUserData().userComparator);
         return users;
     }
@@ -257,8 +236,7 @@ public class Space extends AbstractResourceWithProfile {
      * @return Set of roles assigned to the member, or null if the member is not part of this space.
      */
     public Set<SpaceMemberRoleRef> getMemberRoles(IRI userId) {
-        ensureInitialized();
-        return data.users.get(userId);
+        return currentData().users.get(userId);
     }
 
     /**
@@ -268,8 +246,7 @@ public class Space extends AbstractResourceWithProfile {
      * @return true if the user is a member, false otherwise.
      */
     public boolean isMember(IRI userId) {
-        ensureInitialized();
-        return data.users.containsKey(userId);
+        return currentData().users.containsKey(userId);
     }
 
     /**
@@ -279,14 +256,14 @@ public class Space extends AbstractResourceWithProfile {
      * @return true if the public key is associated with an admin, false otherwise.
      */
     public boolean isAdminPubkey(String pubkey) {
-        ensureInitialized();
-        return data.adminPubkeyMap.containsKey(pubkey);
-    }
-
-    @Override
-    public boolean appliesTo(String elementId, Set<IRI> classes) {
-        triggerSpaceDataUpdate();
-        return super.appliesTo(elementId, classes);
+        if (pubkey == null) return false;
+        ApiResponse resp = ApiCache.retrieveResponseSync(
+                new QueryRef(QueryApiAccess.GET_SPACE_ADMIN_PUBKEY_HASHES, spaceParams(allSpaceIris())), false);
+        if (resp == null) return false;
+        for (ApiResponseEntry r : resp.getData()) {
+            if (pubkey.equals(r.get("pkh"))) return true;
+        }
+        return false;
     }
 
     /**
@@ -295,7 +272,7 @@ public class Space extends AbstractResourceWithProfile {
      * @return The default provenance IRI, or null if not set.
      */
     public IRI getDefaultProvenance() {
-        return data.defaultProvenance;
+        return defaultProvenance;
     }
 
     /**
@@ -304,7 +281,7 @@ public class Space extends AbstractResourceWithProfile {
      * @return List of roles.
      */
     public List<SpaceMemberRoleRef> getRoles() {
-        return data.roles;
+        return currentData().roles;
     }
 
     /**
@@ -322,72 +299,67 @@ public class Space extends AbstractResourceWithProfile {
      * @return List of alternative IDs.
      */
     public List<String> getAltIDs() {
-        return data.altIds;
-    }
-
-    private synchronized void ensureInitialized() {
-        triggerSpaceDataUpdate();
-        if (!dataInitialized && spaceDataFuture != null) {
-            try {
-                spaceDataFuture.get(30, TimeUnit.SECONDS);
-            } catch (Exception ex) {
-                logger.error("failed to await space data update", ex);
-            }
-        }
-        Future<?> future = super.triggerDataUpdate();
-        if (!dataInitialized && future != null) {
-            try {
-                future.get(30, TimeUnit.SECONDS);
-            } catch (Exception ex) {
-                logger.error("failed to await data update", ex);
-            }
-        }
+        return altIds;
     }
 
     @Override
-    public synchronized Future<?> triggerDataUpdate() {
-        triggerSpaceDataUpdate();
-        return super.triggerDataUpdate();
+    public void forceRefresh(long waitMillis) {
+        super.forceRefresh(waitMillis);
+        Multimap<String, String> params = spaceParams(allSpaceIris());
+        ApiCache.clearCache(new QueryRef(QueryApiAccess.GET_SPACE_ADMINS, params), waitMillis);
+        ApiCache.clearCache(new QueryRef(QueryApiAccess.GET_SPACE_ROLES, params), waitMillis);
+        ApiCache.clearCache(new QueryRef(QueryApiAccess.GET_SPACE_MEMBERS, params), waitMillis);
+        ApiCache.clearCache(new QueryRef(QueryApiAccess.GET_SPACE_ADMIN_PUBKEY_HASHES, params), waitMillis);
     }
 
-    private synchronized Future<?> triggerSpaceDataUpdate() {
-        if (dataNeedsUpdate) {
-            logger.info("Data needs update for space {} core data, starting update thread", getId());
-            dataNeedsUpdate = false;
-            spaceDataFuture = NanodashThreadPool.submit(() -> {
-                try {
-                    if (getRunUpdateAfter() != null) {
-                        while (System.currentTimeMillis() < getRunUpdateAfter()) {
-                            Thread.sleep(100);
-                        }
-                    }
-                    SpaceData newData = new SpaceData();
-                    setCoreData(newData);
+    private List<String> allSpaceIris() {
+        List<String> iris = new ArrayList<>(altIds.size() + 1);
+        iris.add(getId());
+        iris.addAll(altIds);
+        return iris;
+    }
 
-                    newData.roles.add(new SpaceMemberRoleRef(SpaceMemberRole.ADMIN_ROLE, null));
-                    newData.roleMap.put(KPXL_TERMS.HAS_ADMIN_PREDICATE, SpaceMemberRole.ADMIN_ROLE);
-
-                    List<String> spaceIris = new ArrayList<>();
-                    spaceIris.add(getId());
-                    spaceIris.addAll(newData.altIds);
-
-                    loadAdminsFromSpacesRepo(newData, spaceIris);
-                    newData.admins.sort(User.getUserData().userComparator);
-                    loadAdminPubkeyHashesFromSpacesRepo(newData, spaceIris);
-
-                    loadRolesFromSpacesRepo(newData, spaceIris);
-                    loadMembersFromSpacesRepo(newData, spaceIris);
-
-                    data = newData;
-                    dataInitialized = true;
-                } catch (Exception ex) {
-                    logger.error("Error while trying to update space data: {}", ex.getMessage());
-                    dataNeedsUpdate = true;
-                }
-            });
-            return spaceDataFuture;
+    private synchronized SpaceData currentData() {
+        Multimap<String, String> params = spaceParams(allSpaceIris());
+        ApiResponse adminsResp = ApiCache.retrieveResponseSync(
+                new QueryRef(QueryApiAccess.GET_SPACE_ADMINS, params), false);
+        ApiResponse rolesResp = ApiCache.retrieveResponseSync(
+                new QueryRef(QueryApiAccess.GET_SPACE_ROLES, params), false);
+        ApiResponse membersResp = ApiCache.retrieveResponseSync(
+                new QueryRef(QueryApiAccess.GET_SPACE_MEMBERS, params), false);
+        if (adminsResp == cachedAdminsResp && rolesResp == cachedRolesResp && membersResp == cachedMembersResp) {
+            return cachedData;
         }
-        return spaceDataFuture;
+        SpaceData newData = buildData(adminsResp, rolesResp, membersResp);
+        cachedAdminsResp = adminsResp;
+        cachedRolesResp = rolesResp;
+        cachedMembersResp = membersResp;
+        cachedData = newData;
+        return newData;
+    }
+
+    private SpaceData buildData(ApiResponse adminsResp, ApiResponse rolesResp, ApiResponse membersResp) {
+        List<IRI> admins = new ArrayList<>();
+        Map<IRI, Set<SpaceMemberRoleRef>> users = new HashMap<>();
+        List<SpaceMemberRoleRef> roles = new ArrayList<>();
+        Map<IRI, SpaceMemberRole> roleMap = new HashMap<>();
+
+        // Seed from rootNanopub-derived state
+        for (IRI rootAdmin : rootAdmins) {
+            admins.add(rootAdmin);
+            users.computeIfAbsent(rootAdmin, k -> new HashSet<>())
+                    .add(new SpaceMemberRoleRef(SpaceMemberRole.ADMIN_ROLE, rootNanopubId));
+        }
+        roles.add(new SpaceMemberRoleRef(SpaceMemberRole.ADMIN_ROLE, null));
+        roleMap.put(KPXL_TERMS.HAS_ADMIN_PREDICATE, SpaceMemberRole.ADMIN_ROLE);
+
+        loadAdmins(admins, users, adminsResp);
+        admins.sort(User.getUserData().userComparator);
+
+        loadRoles(roles, roleMap, rolesResp);
+        loadMembers(users, roleMap, membersResp);
+
+        return new SpaceData(admins, users, roles, roleMap);
     }
 
     private static Multimap<String, String> spaceParams(List<String> spaceIris) {
@@ -396,37 +368,21 @@ public class Space extends AbstractResourceWithProfile {
         return params;
     }
 
-    private static List<ApiResponseEntry> runSpacesQuery(String queryId, Multimap<String, String> params) {
-        // Like the prior direct-SPARQL path, a failed/empty query yields an empty
-        // list rather than aborting the rest of the space-data load.
-        ApiResponse resp = ApiCache.retrieveResponseSync(new QueryRef(queryId, params), true);
-        return resp == null ? List.of() : resp.getData();
-    }
-
-    private static void loadAdminsFromSpacesRepo(SpaceData data, List<String> spaceIris) {
-        for (ApiResponseEntry r : runSpacesQuery(QueryApiAccess.GET_SPACE_ADMINS, spaceParams(spaceIris))) {
+    private static void loadAdmins(List<IRI> admins, Map<IRI, Set<SpaceMemberRoleRef>> users, ApiResponse resp) {
+        if (resp == null) return;
+        for (ApiResponseEntry r : resp.getData()) {
             IRI adminId = Utils.vf.createIRI(r.get("agent"));
             String np = r.get("np");
-            if (!data.admins.contains(adminId)) data.addAdmin(adminId, np);
+            if (admins.contains(adminId)) continue;
+            admins.add(adminId);
+            users.computeIfAbsent(adminId, k -> new HashSet<>())
+                    .add(new SpaceMemberRoleRef(SpaceMemberRole.ADMIN_ROLE, np));
         }
     }
 
-    private static void loadAdminPubkeyHashesFromSpacesRepo(SpaceData data, List<String> spaceIris) {
-        // TODO Push the view-display admin gate server-side (a published
-        // get-view-displays variant that joins through the spaces-repo admins) so
-        // the adminPubkeyMap dependency disappears entirely — see callers of
-        // Space.isAdminPubkey in AbstractResourceWithProfile and DownloadRdfPage.
-        //
-        // Source: trust-state-validated (agent, pubkey-hash) pairs for the
-        // space's admin RIs. Stricter than the prior UserData.getPubkeyHashes
-        // source (only pubkeys that are in the current trust state count).
-        for (ApiResponseEntry r : runSpacesQuery(QueryApiAccess.GET_SPACE_ADMIN_PUBKEY_HASHES, spaceParams(spaceIris))) {
-            data.adminPubkeyMap.put(r.get("pkh"), Utils.vf.createIRI(r.get("agent")));
-        }
-    }
-
-    private static void loadRolesFromSpacesRepo(SpaceData data, List<String> spaceIris) {
-        for (ApiResponseEntry r : runSpacesQuery(QueryApiAccess.GET_SPACE_ROLES, spaceParams(spaceIris))) {
+    private static void loadRoles(List<SpaceMemberRoleRef> roles, Map<IRI, SpaceMemberRole> roleMap, ApiResponse resp) {
+        if (resp == null) return;
+        for (ApiResponseEntry r : resp.getData()) {
             ApiResponseEntry entry = new ApiResponseEntry();
             for (String k : List.of("role", "roleLabel", "roleName", "roleTitle",
                     "roleAssignmentTemplate", "regularProperties", "inverseProperties")) {
@@ -436,13 +392,13 @@ public class Space extends AbstractResourceWithProfile {
             SpaceMemberRole role = new SpaceMemberRole(entry);
             String raNp = r.get("ra_np");
             if (raNp != null && raNp.isEmpty()) raNp = null;
-            data.roles.add(new SpaceMemberRoleRef(role, raNp));
-            for (IRI p : role.getRegularProperties()) data.roleMap.put(p, role);
-            for (IRI p : role.getInverseProperties()) data.roleMap.put(p, role);
+            roles.add(new SpaceMemberRoleRef(role, raNp));
+            for (IRI p : role.getRegularProperties()) roleMap.put(p, role);
+            for (IRI p : role.getInverseProperties()) roleMap.put(p, role);
         }
     }
 
-    private static void loadMembersFromSpacesRepo(SpaceData data, List<String> spaceIris) {
+    private static void loadMembers(Map<IRI, Set<SpaceMemberRoleRef>> users, Map<IRI, SpaceMemberRole> roleMap, ApiResponse resp) {
         // Pulls RI candidates from the extraction graph (npa:spacesGraph) rather
         // than the validated state graph. The materialiser is correctly stricter
         // (e.g., it stops admitting RIs when their role declaration is
@@ -455,51 +411,52 @@ public class Space extends AbstractResourceWithProfile {
         // role attachment, not on the per-member nanopub) is admitted,
         // regardless of who signed the member RI. Invalidated rows are filtered
         // server-side via the npx:invalidates triple in npa:graph.
-        for (ApiResponseEntry r : runSpacesQuery(QueryApiAccess.GET_SPACE_MEMBERS, spaceParams(spaceIris))) {
+        if (resp == null) return;
+        for (ApiResponseEntry r : resp.getData()) {
             SpaceMemberRole role = null;
             for (String key : new String[] {"regProp", "invProp"}) {
                 String val = r.get(key);
                 if (val != null && !val.isEmpty()) {
                     IRI pred = Utils.vf.createIRI(val);
-                    SpaceMemberRole candidate = data.roleMap.get(pred);
+                    SpaceMemberRole candidate = roleMap.get(pred);
                     if (candidate != null) { role = candidate; break; }
                 }
             }
             // Gate by role-predicate match: only admit members whose predicate
             // corresponds to a role that was attached to this space by an admin
-            // (data.roleMap is populated from validated gen:RoleAssignment rows
-            // in loadRolesFromSpacesRepo).
+            // (roleMap is populated from validated gen:RoleAssignment rows
+            // in loadRoles).
             if (role == null) continue;
             IRI memberId = Utils.vf.createIRI(r.get("member"));
             String np = r.get("np");
-            data.users.computeIfAbsent(memberId, k -> new HashSet<>())
+            users.computeIfAbsent(memberId, k -> new HashSet<>())
                     .add(new SpaceMemberRoleRef(role, np));
         }
     }
 
-    private void setCoreData(SpaceData data) {
+    private void readCoreData() {
         for (Statement st : rootNanopub.getAssertion()) {
             if (st.getSubject().stringValue().equals(getId())) {
                 if (st.getPredicate().equals(OWL.SAMEAS) && st.getObject() instanceof IRI objIri) {
-                    data.altIds.add(objIri.stringValue());
+                    altIds.add(objIri.stringValue());
                 } else if (st.getPredicate().equals(DCTERMS.DESCRIPTION)) {
-                    data.description = st.getObject().stringValue();
+                    description = st.getObject().stringValue();
                 } else if (st.getPredicate().stringValue().equals("http://schema.org/startDate")) {
                     try {
-                        data.startDate = DatatypeConverter.parseDateTime(st.getObject().stringValue());
+                        startDate = DatatypeConverter.parseDateTime(st.getObject().stringValue());
                     } catch (IllegalArgumentException ex) {
                         logger.error("Failed to parse date {}", st.getObject().stringValue());
                     }
                 } else if (st.getPredicate().stringValue().equals("http://schema.org/endDate")) {
                     try {
-                        data.endDate = DatatypeConverter.parseDateTime(st.getObject().stringValue());
+                        endDate = DatatypeConverter.parseDateTime(st.getObject().stringValue());
                     } catch (IllegalArgumentException ex) {
                         logger.error("Failed to parse date {}", st.getObject().stringValue());
                     }
                 } else if (st.getPredicate().equals(KPXL_TERMS.HAS_ADMIN) && st.getObject() instanceof IRI obj) {
-                    data.addAdmin(obj, rootNanopub.getUri().stringValue());
+                    if (!rootAdmins.contains(obj)) rootAdmins.add(obj);
                 } else if (st.getPredicate().equals(NTEMPLATE.HAS_DEFAULT_PROVENANCE) && st.getObject() instanceof IRI obj) {
-                    data.defaultProvenance = obj;
+                    defaultProvenance = obj;
                 }
             }
         }

--- a/src/main/java/com/knowledgepixels/nanodash/page/DownloadRdfPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/DownloadRdfPage.java
@@ -287,7 +287,6 @@ public class DownloadRdfPage extends WebPage {
         }
 
         // Maintained resource declarations
-        MaintainedResourceRepository.get().ensureLoaded();
         for (MaintainedResource resource : MaintainedResourceRepository.get().findResourcesBySpace(space)) {
             if (collected.size() >= MAX_NANOPUBS) break;
             if (resource.getNanopub() != null) {
@@ -558,11 +557,6 @@ public class DownloadRdfPage extends WebPage {
      * Mirrors the logic of AbstractResourceWithProfile.triggerDataUpdate() and getTopLevelViewDisplays().
      */
     private List<ViewDisplay> fetchViewDisplays(AbstractResourceWithProfile resource, String partId, Set<IRI> partClasses) {
-        // For spaces, ensure core data is loaded first (needed for isAdminPubkey check)
-        if (resource instanceof Space space) {
-            space.getUsers(); // triggers ensureInitialized
-        }
-
         ApiResponse response = ApiCache.retrieveResponseSync(
                 new QueryRef(QueryApiAccess.GET_VIEW_DISPLAYS, "resource", resource.getId()), false);
         if (response == null) {
@@ -573,9 +567,6 @@ public class DownloadRdfPage extends WebPage {
         // Build raw view display list (same logic as AbstractResourceWithProfile.triggerDataUpdate)
         List<ViewDisplay> allDisplays = new ArrayList<>();
         for (ApiResponseEntry r : response.getData()) {
-            if (resource.getSpace() != null && !resource.getSpace().isAdminPubkey(r.get("pubkey"))) {
-                continue;
-            }
             try {
                 allDisplays.add(ViewDisplay.get(r.get("display")));
             } catch (IllegalArgumentException ex) {

--- a/src/main/java/com/knowledgepixels/nanodash/page/SpaceListPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/SpaceListPage.java
@@ -86,10 +86,7 @@ public class SpaceListPage extends NanodashPage {
         add(new ItemListPanel<Space>(
                 typePl.toLowerCase(),
                 Space.getTypeEmoji(type) + " " + typePl,
-                () -> {
-                    SpaceRepository.get().ensureLoaded();
-                    return true;
-                },
+                () -> true,
                 () -> SpaceRepository.get().findByType(KPXL_TERMS.NAMESPACE + type),
                 (space) -> {
                     return new ItemListElement("item", SpacePage.class, new PageParameters().set("id", space.getId()), space.getLabel());

--- a/src/main/java/com/knowledgepixels/nanodash/page/SpacePage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/SpacePage.java
@@ -220,10 +220,7 @@ public class SpacePage extends NanodashPage {
         add(new ItemListPanel<MaintainedResource>(
                 "resources",
                 "📦 Maintained Resources",
-                () -> {
-                    MaintainedResourceRepository.get().ensureLoaded();
-                    return true;
-                },
+                () -> true,
                 () -> MaintainedResourceRepository.get().findResourcesBySpace(spaceModel.getObject()),
                 (resource) -> new ItemListElement("item", MaintainedResourcePage.class, new PageParameters().set("id", resource.getId()), resource.getLabel())
         ));

--- a/src/main/java/com/knowledgepixels/nanodash/repository/MaintainedResourceRepository.java
+++ b/src/main/java/com/knowledgepixels/nanodash/repository/MaintainedResourceRepository.java
@@ -5,12 +5,12 @@ import com.knowledgepixels.nanodash.QueryApiAccess;
 import com.knowledgepixels.nanodash.domain.MaintainedResource;
 import com.knowledgepixels.nanodash.domain.MaintainedResourceFactory;
 import com.knowledgepixels.nanodash.domain.Space;
+import org.nanopub.extra.services.ApiResponse;
 import org.nanopub.extra.services.ApiResponseEntry;
 import org.nanopub.extra.services.QueryRef;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -19,18 +19,7 @@ import java.util.Set;
 
 public class MaintainedResourceRepository {
 
-    private static final Logger logger = LoggerFactory.getLogger(MaintainedResourceRepository.class);
-
     private static final MaintainedResourceRepository INSTANCE = new MaintainedResourceRepository();
-
-    private volatile List<MaintainedResource> resourceList;
-    private Map<String, MaintainedResource> resourcesById;
-    private Map<String, MaintainedResource> resourcesByNamespace;
-    private Map<Space, List<MaintainedResource>> resourcesBySpace;
-    private boolean loaded = false;
-    private volatile Long runRootUpdateAfter = null;
-    private volatile long lastRefreshTime = 0;
-    private final Object loadLock = new Object();
 
     /**
      * Get the singleton instance of MaintainedResourceRepository.
@@ -44,20 +33,61 @@ public class MaintainedResourceRepository {
     private MaintainedResourceRepository() {
     }
 
+    private static final class Snapshot {
+        final Map<String, MaintainedResource> resourcesById;
+        final Map<String, MaintainedResource> resourcesByNamespace;
+        final Map<Space, List<MaintainedResource>> resourcesBySpace;
+
+        Snapshot(Map<String, MaintainedResource> byId,
+                 Map<String, MaintainedResource> byNs,
+                 Map<Space, List<MaintainedResource>> bySpace) {
+            this.resourcesById = byId;
+            this.resourcesByNamespace = byNs;
+            this.resourcesBySpace = bySpace;
+        }
+
+        static final Snapshot EMPTY = new Snapshot(
+                Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap());
+    }
+
+    // Source of truth is ApiCache (60s TTL on its own); we memoise the derived
+    // maps keyed by the ApiResponse instance identity so they get rebuilt
+    // exactly when ApiCache returns a fresh response and not on every call.
+    private volatile ApiResponse cachedFor;
+    private volatile Snapshot snapshot = Snapshot.EMPTY;
+
+    private Snapshot current() {
+        ApiResponse resp = ApiCache.retrieveResponseSync(new QueryRef(QueryApiAccess.GET_MAINTAINED_RESOURCES), false);
+        if (resp == null) {
+            return snapshot;
+        }
+        if (resp == cachedFor) {
+            return snapshot;
+        }
+        synchronized (this) {
+            if (resp == cachedFor) {
+                return snapshot;
+            }
+            Snapshot built = build(resp);
+            snapshot = built;
+            cachedFor = resp;
+            return built;
+        }
+    }
+
     /**
-     * Refresh the list of maintained resources from the spaces repo. Pulls
+     * Build the resource lookup maps from the spaces-repo response. Pulls
      * server-validated {@code npa:isMaintainedBy} links from the current
      * space-state graph; only the most recent declaration per resource is kept
      * (the {@code get-maintained-resources} query orders by {@code DESC(?date)},
      * so the first row per resource wins).
      */
-    public synchronized void refresh() {
-        List<MaintainedResource> newResourceList = new ArrayList<>();
-        Map<String, MaintainedResource> newResourcesById = new HashMap<>();
-        Map<Space, List<MaintainedResource>> newResourcesBySpace = new HashMap<>();
-        Map<String, MaintainedResource> newResourcesByNamespace = new HashMap<>();
+    private Snapshot build(ApiResponse resp) {
+        Map<String, MaintainedResource> byId = new HashMap<>();
+        Map<String, MaintainedResource> byNamespace = new HashMap<>();
+        Map<Space, List<MaintainedResource>> bySpace = new HashMap<>();
         Set<String> seenResources = new HashSet<>();
-        for (ApiResponseEntry r : ApiCache.retrieveResponseSync(new QueryRef(QueryApiAccess.GET_MAINTAINED_RESOURCES), true).getData()) {
+        for (ApiResponseEntry r : resp.getData()) {
             String resourceId = r.get("resource");
             if (resourceId == null || resourceId.isEmpty()) continue;
             if (!seenResources.add(resourceId)) continue; // first row (newest date) wins
@@ -72,21 +102,15 @@ public class MaintainedResourceRepository {
             String namespace = r.get("namespace");
             if (namespace != null && !namespace.isEmpty()) entry.add("namespace", namespace);
             MaintainedResource resource = MaintainedResourceFactory.getOrCreate(entry, space);
-            newResourceList.add(resource);
-            newResourcesById.put(resourceId, resource);
-            newResourcesBySpace.computeIfAbsent(space, k -> new ArrayList<>()).add(resource);
+            byId.put(resourceId, resource);
+            bySpace.computeIfAbsent(space, k -> new ArrayList<>()).add(resource);
             if (resource.getNamespace() != null) {
                 // TODO Handle conflicts when two resources claim the same namespace:
-                newResourcesByNamespace.put(resource.getNamespace(), resource);
+                byNamespace.put(resource.getNamespace(), resource);
             }
         }
-        MaintainedResourceFactory.removeStale(newResourcesById.keySet());
-        resourcesById = newResourcesById;
-        resourcesBySpace = newResourcesBySpace;
-        resourcesByNamespace = newResourcesByNamespace;
-        loaded = true;
-        lastRefreshTime = System.currentTimeMillis();
-        resourceList = newResourceList; // volatile write last — establishes happens-before for all above
+        MaintainedResourceFactory.removeStale(byId.keySet());
+        return new Snapshot(byId, byNamespace, bySpace);
     }
 
     /**
@@ -96,8 +120,7 @@ public class MaintainedResourceRepository {
      * @return The MaintainedResource with the given namespace, or null if not found.
      */
     public MaintainedResource findByNamespace(String namespace) {
-        ensureLoaded();
-        return resourcesByNamespace.get(namespace);
+        return current().resourcesByNamespace.get(namespace);
     }
 
     /**
@@ -107,8 +130,8 @@ public class MaintainedResourceRepository {
      * @return The list of maintained resources for the space, possibly empty.
      */
     public List<MaintainedResource> findResourcesBySpace(Space space) {
-        ensureLoaded();
-        return resourcesBySpace.computeIfAbsent(space, k -> new ArrayList<>());
+        List<MaintainedResource> l = current().resourcesBySpace.get(space);
+        return l != null ? l : new ArrayList<>();
     }
 
     /**
@@ -118,53 +141,16 @@ public class MaintainedResourceRepository {
      * @return The corresponding MaintainedResource object, or null if not found.
      */
     public MaintainedResource findById(String id) {
-        ensureLoaded();
-        return resourcesById.get(id);
+        return current().resourcesById.get(id);
     }
 
     /**
-     * Ensure that the resources are loaded, fetching them from the API if necessary.
-     */
-    public void ensureLoaded() {
-        if (resourceList == null) {
-            try {
-                synchronized (loadLock) {
-                    if (runRootUpdateAfter != null) {
-                        while (runRootUpdateAfter != null && System.currentTimeMillis() < runRootUpdateAfter) {
-                            Thread.sleep(100);
-                        }
-                        runRootUpdateAfter = null;
-                    }
-                }
-            } catch (InterruptedException ex) {
-                logger.error("Interrupted", ex);
-            }
-            if (resourceList == null) { // double-check after potential wait
-                refresh();
-            }
-        } else if (System.currentTimeMillis() - lastRefreshTime > 60_000) {
-            refresh();
-        }
-    }
-
-    /**
-     * Force a refresh of the maintained resources on the next access, with an optional delay to allow for updates to propagate.
+     * Invalidate the underlying ApiCache entry, optionally delaying the next refresh.
      *
-     * @param waitMillis Number of milliseconds to wait before allowing the next access to trigger a refresh. If 0, the refresh will happen immediately on the next access.
+     * @param waitMillis Delay in milliseconds before the next access may trigger a refresh; 0 for immediate.
      */
     public void forceRootRefresh(long waitMillis) {
-        resourceList = null;
-        runRootUpdateAfter = System.currentTimeMillis() + waitMillis;
-    }
-
-    /**
-     * Refresh the maintained resources and mark each as needing a downstream data update.
-     */
-    public void refreshAndInvalidate() {
-        refresh();
-        for (MaintainedResource resource : resourceList) {
-            resource.setDataNeedsUpdate();
-        }
+        ApiCache.clearCache(new QueryRef(QueryApiAccess.GET_MAINTAINED_RESOURCES), waitMillis);
     }
 
 }

--- a/src/main/java/com/knowledgepixels/nanodash/repository/SpaceRepository.java
+++ b/src/main/java/com/knowledgepixels/nanodash/repository/SpaceRepository.java
@@ -5,12 +5,20 @@ import com.knowledgepixels.nanodash.ApiCache;
 import com.knowledgepixels.nanodash.QueryApiAccess;
 import com.knowledgepixels.nanodash.domain.Space;
 import com.knowledgepixels.nanodash.domain.SpaceFactory;
+import org.nanopub.extra.services.ApiResponse;
 import org.nanopub.extra.services.ApiResponseEntry;
 import org.nanopub.extra.services.QueryRef;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Repository class for managing Space instances, providing methods to refresh, retrieve, and query spaces based on API responses.
@@ -30,25 +38,63 @@ public class SpaceRepository {
         return INSTANCE;
     }
 
-    private volatile List<Space> spaceList;
-    private Map<String, List<Space>> spaceListByType;
-    private Map<String, Space> spacesById;
-    private Map<String, Space> spacesByAltId;
-    private Map<Space, Set<Space>> subspaceMap;
-    private Map<Space, Set<Space>> superspaceMap;
-    private boolean loaded = false;
-    private volatile Long runRootUpdateAfter = null;
-    private volatile long lastRefreshTime = 0;
-
-    private final Object loadLock = new Object();
-
     private SpaceRepository() {
     }
 
+    private static final class Snapshot {
+        final Map<String, Space> spacesById;
+        final Map<String, Space> spacesByAltId;
+        final Map<String, List<Space>> spaceListByType;
+        final Map<Space, Set<Space>> subspaceMap;
+        final Map<Space, Set<Space>> superspaceMap;
+
+        Snapshot(Map<String, Space> byId,
+                 Map<String, Space> byAltId,
+                 Map<String, List<Space>> byType,
+                 Map<Space, Set<Space>> subspaces,
+                 Map<Space, Set<Space>> superspaces) {
+            this.spacesById = byId;
+            this.spacesByAltId = byAltId;
+            this.spaceListByType = byType;
+            this.subspaceMap = subspaces;
+            this.superspaceMap = superspaces;
+        }
+
+        static final Snapshot EMPTY = new Snapshot(
+                Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
+                Collections.emptyMap(), Collections.emptyMap());
+    }
+
+    // Source of truth is ApiCache (60s TTL on its own); we memoise the derived
+    // maps keyed by the ApiResponse instance identity for get-spaces, and
+    // re-resolve the sub-space link response on each rebuild.
+    private volatile ApiResponse cachedFor;
+    private volatile Snapshot snapshot = Snapshot.EMPTY;
+
+    private Snapshot current() {
+        ApiResponse resp = ApiCache.retrieveResponseSync(new QueryRef(QueryApiAccess.GET_SPACES), false);
+        if (resp == null) {
+            return snapshot;
+        }
+        if (resp == cachedFor) {
+            return snapshot;
+        }
+        synchronized (this) {
+            if (resp == cachedFor) {
+                return snapshot;
+            }
+            Snapshot built = build(resp);
+            snapshot = built;
+            cachedFor = resp;
+            return built;
+        }
+    }
+
     /**
-     * Refresh the list of spaces from the spaces repo. Pulls the latest
-     * non-invalidated SpaceDefinition per Space IRI from {@code npa:spacesGraph}
-     * and joins to the declaring nanopub for label and type.
+     * Build the space lookup maps from the spaces-repo response. Pulls the
+     * latest non-invalidated SpaceDefinition per Space IRI from
+     * {@code npa:spacesGraph} and joins to the declaring nanopub for label and
+     * type.
      * <p>
      * The {@code get-spaces} query returns one row per (SpaceRef, SpaceDefinition)
      * — many spaces have multiple contributing nanopubs (root + updates) and even
@@ -56,15 +102,15 @@ public class SpaceRepository {
      * {@code DESC(?date)}, so dedup'ing by spaceIri here (first row wins) picks the
      * latest update per space.
      */
-    public synchronized void refresh() {
-        List<Space> newSpaceList = new ArrayList<>();
-        Map<String, List<Space>> newSpaceListByType = new HashMap<>();
-        Map<String, Space> newSpacesById = new HashMap<>();
-        Map<String, Space> newSpacesByAltId = new HashMap<>();
-        Map<Space, Set<Space>> newSubspaceMap = new HashMap<>();
-        Map<Space, Set<Space>> newSuperspaceMap = new HashMap<>();
+    private Snapshot build(ApiResponse resp) {
+        Map<String, Space> byId = new HashMap<>();
+        Map<String, Space> byAltId = new HashMap<>();
+        Map<String, List<Space>> byType = new HashMap<>();
+        Map<Space, Set<Space>> subspaceMap = new HashMap<>();
+        Map<Space, Set<Space>> superspaceMap = new HashMap<>();
+        List<Space> spaceList = new ArrayList<>();
         Set<String> seen = new HashSet<>();
-        for (ApiResponseEntry r : ApiCache.retrieveResponseSync(new QueryRef(QueryApiAccess.GET_SPACES), true).getData()) {
+        for (ApiResponseEntry r : resp.getData()) {
             String spaceIri = r.get("spaceIri");
             if (spaceIri == null || spaceIri.isEmpty()) continue;
             if (!seen.add(spaceIri)) continue; // first row (latest date) wins
@@ -74,66 +120,37 @@ public class SpaceRepository {
             entry.add("label", r.get("label"));
             entry.add("type", r.get("type"));
             Space space = SpaceFactory.getOrCreate(entry);
-            newSpaceList.add(space);
-            newSpaceListByType.computeIfAbsent(space.getType(), k -> new ArrayList<>()).add(space);
-            newSpacesById.put(space.getId(), space);
+            spaceList.add(space);
+            byType.computeIfAbsent(space.getType(), k -> new ArrayList<>()).add(space);
+            byId.put(space.getId(), space);
             for (String altId : space.getAltIDs()) {
-                newSpacesByAltId.put(altId, space);
+                byAltId.put(altId, space);
             }
         }
         Comparator<Space> byLabel = Comparator.comparing(Space::getLabel, Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER));
-        for (List<Space> spacesOfType : newSpaceListByType.values()) {
+        for (List<Space> spacesOfType : byType.values()) {
             spacesOfType.sort(byLabel);
         }
-        logger.info("Refreshed spaces from spaces repo: {} distinct spaces", newSpaceList.size());
-        SpaceFactory.removeStale(newSpacesById.keySet());
-        populateSubspaceRelations(newSpacesById, newSubspaceMap, newSuperspaceMap);
-        for (Space space : newSpaceList) {
+        logger.info("Refreshed spaces from spaces repo: {} distinct spaces", spaceList.size());
+        SpaceFactory.removeStale(byId.keySet());
+        populateSubspaceRelations(byId, subspaceMap, superspaceMap);
+        // Mark each space's per-space detail data stale; the upstream spaces
+        // listing has refreshed, so members/admins/roles should be re-fetched
+        // on next access.
+        for (Space space : spaceList) {
             space.setDataNeedsUpdate();
         }
-        spacesById = newSpacesById;
-        spacesByAltId = newSpacesByAltId;
-        spaceListByType = newSpaceListByType;
-        subspaceMap = newSubspaceMap;
-        superspaceMap = newSuperspaceMap;
-        loaded = true;
-        lastRefreshTime = System.currentTimeMillis();
-        spaceList = newSpaceList; // volatile write last — establishes happens-before for all above
+        return new Snapshot(byId, byAltId, byType, subspaceMap, superspaceMap);
     }
 
     /**
-     * Force a refresh of the root spaces after a specified delay, allowing for any ongoing updates to complete before the next refresh.
+     * Invalidate the underlying ApiCache entries, optionally delaying the next refresh.
      *
-     * @param waitMillis The number of milliseconds to wait before allowing the next refresh to occur.
+     * @param waitMillis Delay in milliseconds before the next access may trigger a refresh; 0 for immediate.
      */
     public void forceRootRefresh(long waitMillis) {
-        spaceList = null;
-        runRootUpdateAfter = System.currentTimeMillis() + waitMillis;
-    }
-
-    /**
-     * Ensure that the spaces are loaded, fetching them from the API if necessary.
-     */
-    public void ensureLoaded() {
-        if (spaceList == null) {
-            try {
-                synchronized (loadLock) {
-                    if (runRootUpdateAfter != null) {
-                        while (System.currentTimeMillis() < runRootUpdateAfter) {
-                            Thread.sleep(100);
-                        }
-                        runRootUpdateAfter = null;
-                    }
-                }
-            } catch (InterruptedException ex) {
-                logger.error("Interrupted", ex);
-            }
-            if (spaceList == null) { // double-check after potential wait
-                refresh();
-            }
-        } else if (System.currentTimeMillis() - lastRefreshTime > 60_000) {
-            refresh();
-        }
+        ApiCache.clearCache(new QueryRef(QueryApiAccess.GET_SPACES), waitMillis);
+        ApiCache.clearCache(new QueryRef(QueryApiAccess.GET_SUB_SPACE_LINKS), waitMillis);
     }
 
     /**
@@ -143,8 +160,7 @@ public class SpaceRepository {
      * @return The corresponding Space object, or null if not found.
      */
     public Space findById(String id) {
-        ensureLoaded();
-        return spacesById.get(id);
+        return current().spacesById.get(id);
     }
 
     /**
@@ -154,8 +170,7 @@ public class SpaceRepository {
      * @return The corresponding Space object, or null if not found.
      */
     public Space findByAltId(String altId) {
-        ensureLoaded();
-        return spacesByAltId.get(altId);
+        return current().spacesByAltId.get(altId);
     }
 
     /**
@@ -165,8 +180,8 @@ public class SpaceRepository {
      * @return List of Space objects matching the specified type, or an empty list if none are found.
      */
     public List<Space> findByType(String type) {
-        ensureLoaded();
-        return spaceListByType.computeIfAbsent(type, k -> new ArrayList<>());
+        List<Space> l = current().spaceListByType.get(type);
+        return l != null ? l : new ArrayList<>();
     }
 
     /**
@@ -176,12 +191,11 @@ public class SpaceRepository {
      * @return List of subspaces.
      */
     public List<Space> findSubspaces(Space space) {
-        if (subspaceMap.containsKey(space)) {
-            List<Space> subspaces = new ArrayList<>(subspaceMap.get(space));
-            subspaces.sort(Ordering.usingToString());
-            return subspaces;
-        }
-        return new ArrayList<>();
+        Set<Space> subspaces = current().subspaceMap.get(space);
+        if (subspaces == null) return new ArrayList<>();
+        List<Space> sorted = new ArrayList<>(subspaces);
+        sorted.sort(Ordering.usingToString());
+        return sorted;
     }
 
     /**
@@ -205,29 +219,20 @@ public class SpaceRepository {
      * @return List of superspaces.
      */
     public List<Space> findSuperspaces(Space space) {
-        if (superspaceMap.containsKey(space)) {
-            List<Space> superspaces = new ArrayList<>(superspaceMap.get(space));
-            superspaces.sort(Ordering.usingToString());
-            return superspaces;
-        }
-        return new ArrayList<>();
-    }
-
-    /**
-     * Refresh the spaces and mark each as needing a downstream data update.
-     */
-    public void refreshAndInvalidate() {
-        refresh();
-        for (Space space : spaceList) {
-            space.setDataNeedsUpdate();
-        }
+        Set<Space> superspaces = current().superspaceMap.get(space);
+        if (superspaces == null) return new ArrayList<>();
+        List<Space> sorted = new ArrayList<>(superspaces);
+        sorted.sort(Ordering.usingToString());
+        return sorted;
     }
 
     private static void populateSubspaceRelations(
             Map<String, Space> spacesById,
             Map<Space, Set<Space>> subspaceMap,
             Map<Space, Set<Space>> superspaceMap) {
-        for (ApiResponseEntry r : ApiCache.retrieveResponseSync(new QueryRef(QueryApiAccess.GET_SUB_SPACE_LINKS), true).getData()) {
+        ApiResponse resp = ApiCache.retrieveResponseSync(new QueryRef(QueryApiAccess.GET_SUB_SPACE_LINKS), false);
+        if (resp == null) return;
+        for (ApiResponseEntry r : resp.getData()) {
             Space child = spacesById.get(r.get("child"));
             Space parent = spacesById.get(r.get("parent"));
             if (child == null || parent == null) continue;


### PR DESCRIPTION
## Summary

Three intertwined simplifications of the space/maintained-resource data layer. Net: -70 LOC, two cache layers collapsed to one, view-display trust now enforced server-side.

### Phase 1 — collapse `*Repository` caches onto ApiCache

`MaintainedResourceRepository` and `SpaceRepository` previously held their own 60s TTL + hand-maintained maps on top of `ApiCache` (which already has a 60s TTL). They now memoise the derived lookup maps by the `ApiResponse` object identity returned from `ApiCache.retrieveResponseSync`, rebuilding only when ApiCache returns a fresh response. `ensureLoaded()` and the unused `refreshAndInvalidate()` removed; `forceRootRefresh(waitMs)` delegates to `ApiCache.clearCache(..., waitMs)`. `MaintainedResource` / `Space` classes are unchanged in API.

### Phase 2 — push view-display admin gate server-side

New `get-view-displays` query template (`RAIMs6C9gfjqX-TYGd8mrq7MJ7K-DoofW6v4dzFQJTs7Y`, supersedes the live `RAapc3jbJ3GkDy0ncKx3pok_zEKqwrT6-Z5TkCP1k96II` via an intermediate `RA3IiHoTcBRg54-...` that lacked the no-Space branch). The new query SERVICEs the spaces repo's current state graph, joins through `gen:RoleInstantiation` + `npa:AccountState`, and admits only view-displays signed by trust-state-validated admins of the resource's Space (whether the resource IS a Space or is maintained by one). A UNION branch keeps the prior unfiltered behaviour for resources with no Space association (agent profiles) — without it, `/user/<orcid>` profile pages render zero view-displays.

Client-side filtering removed from:
- `AbstractResourceWithProfile.triggerDataUpdate`
- `DownloadRdfPage.fetchViewDisplays`

`Space.adminPubkeyMap` field and `loadAdminPubkeyHashesFromSpacesRepo` deleted. `Space.isAdminPubkey()` kept (still needed by `ViewDisplayMenu` for UI gating) but now hits the cached `GET_SPACE_ADMIN_PUBKEY_HASHES` response directly instead of a per-Space pre-loaded map.

### Phase 3 — shrink `Space` to a cache façade

The async data-loading machinery (`triggerSpaceDataUpdate`, `ensureInitialized`, `spaceDataFuture`, shadow `dataInitialized`/`dataNeedsUpdate`, plus the four `@Override` shadow methods) all dropped. `SpaceData` is now an immutable snapshot value type rebuilt synchronously in `currentData()`, memoised by the `(adminsResp, rolesResp, membersResp)` ApiResponse identity tuple. Root-nanopub-derived state (`altIds`, `description`, `startDate`, `endDate`, `defaultProvenance`, `rootAdmins`) lives on the `Space` instance directly. `forceRefresh(waitMs)` now also invalidates the four Space-scoped ApiCache entries.

### Runtime behaviour notes

- First call per JVM lifetime to `Space.getAdmins()` / `getUsers()` / `getMemberRoles()` / `isMember()` / `getRoles()` / `isAdminPubkey()` blocks on `ApiCache.retrieveResponseSync` for the underlying spaces-repo queries; subsequent calls within ApiCache's 60s freshness window are O(map-lookup).
- `Space.isDataInitialized()` now reflects only view-display loading (parent's behaviour) — when it flips true, `SpacePage` panels render and call `getUsers()`/`getRoles()` synchronously. In practice this is fine because those queries are already warm by the time view-displays have loaded.

## Test plan

- [x] `mvn clean compile` passes
- [x] `mvn jetty:run` + curl smoke-test: `/`, `/spaces`, `/space?id=https://w3id.org/spaces/knowledgepixels`, `/resource?id=https://w3id.org/spaces/knowledgepixels/nanodash/r/home` all return HTTP 200, no exceptions in logs, expected content rendered
- [x] v3 query output matches v1 row-for-row for: agent IRI (45), space IRI (3), maintained-resource IRI (5), empty-admin space (0)
- [x] Manual: load a Space page, confirm Admins / Members / Roles populate after first request
- [x] Manual: load a User profile page, confirm view-displays render
- [x] Manual: as a space admin, publish a new view-display and confirm `forceRefresh` picks it up

🤖 Generated with [Claude Code](https://claude.com/claude-code)