### PR TITLE
feat: render /spaces as a single sortable All Spaces table

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/QueryApiAccess.java
+++ b/src/main/java/com/knowledgepixels/nanodash/QueryApiAccess.java
@@ -69,7 +69,7 @@ public class QueryApiAccess {
     public static final String GET_VIEW_DISPLAYS = "RAIMs6C9gfjqX-TYGd8mrq7MJ7K-DoofW6v4dzFQJTs7Y/get-view-displays";
 
     // Spaces-repo queries (endpoint: nanopub-query .../repo/spaces)
-    public static final String GET_SPACES = "RA1sxIHufQSSPu9ZWG6Est26euNJMhBOO33oQF_TV7xnc/get-spaces";
+    public static final String GET_SPACES = "RAxGboS_juHuMyJQghGV3elEgZmQTew5oyw_aC9O9FFQI/get-spaces";
     public static final String GET_SUB_SPACE_LINKS = "RAWgoQbP9_B9h3Bnwd1FGYX1gLYPyZFOxaeqIeA3TTPSU/get-sub-space-links";
     public static final String GET_MAINTAINED_RESOURCES = "RAOOq81R84exTUKUBQT3BbgCaSJyC2lqPDXIP2XaDTosM/get-maintained-resources";
     public static final String GET_SPACE_ADMINS = "RAaHOXMQ7Kq37T9syR9at0RqushclHenlPOFRwFDn0Cfs/get-space-admins";

--- a/src/main/java/com/knowledgepixels/nanodash/page/SpaceListPage.html
+++ b/src/main/java/com/knowledgepixels/nanodash/page/SpaceListPage.html
@@ -17,51 +17,7 @@
       <h2>🌎 Spaces</h2>
     </div>
 
-    <div class="col-6">
-
-      <div wicket:id="alliances" class="hide-if-empty"></div>
-
-      <div wicket:id="organizations"></div>
-
-      <div wicket:id="divisions" class="hide-if-empty"></div>
-
-      <div wicket:id="groups"></div>
-
-      <div wicket:id="programs"></div>
-
-      <div wicket:id="outlets"></div>
-
-      <div wicket:id="communities"></div>
-
-    </div>
-
-    <div class="col-6">
-
-      <div wicket:id="consortiums" class="hide-if-empty"></div>
-
-      <div wicket:id="taskforces" class="hide-if-empty"></div>
-
-      <div wicket:id="taskunits" class="hide-if-empty"></div>
-
-      <div wicket:id="projects" class="hide-if-empty"></div>
-
-      <div wicket:id="initiatives" class="hide-if-empty"></div>
-
-      <div wicket:id="campaigns" class="hide-if-empty"></div>
-
-      <div wicket:id="events" class="hide-if-empty"></div>
-
-    </div>
-
-  </div>
-
-  <div class="row-section">
-
-    <div class="col-6">
-
-      <div wicket:id="legacy-projects"></div>
-
-    </div>
+    <div wicket:id="spaces"></div>
 
   </div>
 

--- a/src/main/java/com/knowledgepixels/nanodash/page/SpaceListPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/SpaceListPage.java
@@ -1,18 +1,15 @@
 package com.knowledgepixels.nanodash.page;
 
-import com.knowledgepixels.nanodash.domain.Project;
-import com.knowledgepixels.nanodash.QueryApiAccess;
-import com.knowledgepixels.nanodash.domain.Space;
-import com.knowledgepixels.nanodash.component.ItemListElement;
-import com.knowledgepixels.nanodash.component.ItemListPanel;
-import com.knowledgepixels.nanodash.component.TitleBar;
-import com.knowledgepixels.nanodash.repository.SpaceRepository;
-import com.knowledgepixels.nanodash.vocabulary.KPXL_TERMS;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
 import org.nanopub.extra.services.QueryRef;
 
+import com.knowledgepixels.nanodash.View;
+import com.knowledgepixels.nanodash.ViewDisplay;
+import com.knowledgepixels.nanodash.component.QueryResultTableBuilder;
+import com.knowledgepixels.nanodash.component.TitleBar;
+
 /**
- * A page that lists all available connectors.
+ * The Spaces page: a single sortable table of all known spaces, including type.
  */
 public class SpaceListPage extends NanodashPage {
 
@@ -20,6 +17,8 @@ public class SpaceListPage extends NanodashPage {
      * The mount path for this page.
      */
     public static final String MOUNT_PATH = "/spaces";
+
+    private static final String ALL_SPACES_VIEW = "https://w3id.org/np/RANB1bHSVXw8W0aFTvPURWpq960qJm9jEsI1rUDxXwMDY/all-spaces-view";
 
     /**
      * {@inheritDoc}
@@ -39,59 +38,9 @@ public class SpaceListPage extends NanodashPage {
 
         add(new TitleBar("titlebar", this, "connectors"));
 
-        addSpacePanel("Alliance", true);
-        addSpacePanel("Consortium", false);
-        addSpacePanel("Organization", true);
-        addSpacePanel("Taskforce", false);
-        addSpacePanel("Division", true);
-        addSpacePanel("Taskunit", false);
-        addSpacePanel("Group", true);
-        addSpacePanel("Project", false);
-        addSpacePanel("Program", true);
-        addSpacePanel("Initiative", false);
-        addSpacePanel("Outlet", true);
-        addSpacePanel("Campaign", false);
-        addSpacePanel("Community", true);
-        addSpacePanel("Event", false);
-
-        add(new ItemListPanel<Project>(
-                "legacy-projects",
-                "📁 Legacy Projects",
-                new QueryRef(QueryApiAccess.GET_PROJECTS),
-                (apiResponse) -> {
-                    Project.refresh(apiResponse);
-                    return Project.getProjectList();
-                },
-                (project) -> {
-                    return new ItemListElement("item", ProjectPage.class, new PageParameters().set("id", project.getId()), project.getLabel());
-                }
-        ).setDescription("These legacy project pages will be migrated into the Spaces above:"));
-    }
-
-    private void addSpacePanel(String type, boolean openEnded) {
-        String typePl = type + "s";
-        typePl = typePl.replaceFirst("ys$", "ies");
-
-        PageParameters newLinkParams = new PageParameters()
-                .set("param_type", KPXL_TERMS.NAMESPACE + type)
-                .set("template-version", "latest")
-                .set("refresh-upon-publish", "spaces")
-                .set("postpub-redirect-url", SpacePage.MOUNT_PATH);
-        if (openEnded) {
-            newLinkParams.set("template", "https://w3id.org/np/RA7dQfmndqKmooQ4PlHyQsAql9i2tg_8GLHf_dqtxsGEQ");
-        } else {
-            newLinkParams.set("template", "https://w3id.org/np/RAaE7NP9RNIx03AHZxanFMdtUuaTfe50ns5tHhpEVloQ4");
-        }
-
-        add(new ItemListPanel<Space>(
-                typePl.toLowerCase(),
-                Space.getTypeEmoji(type) + " " + typePl,
-                () -> true,
-                () -> SpaceRepository.get().findByType(KPXL_TERMS.NAMESPACE + type),
-                (space) -> {
-                    return new ItemListElement("item", SpacePage.class, new PageParameters().set("id", space.getId()), space.getLabel());
-                }
-        ).addButton("+", PublishPage.class, newLinkParams));
+        View allSpacesView = View.get(ALL_SPACES_VIEW);
+        QueryRef queryRef = new QueryRef(allSpacesView.getQuery().getQueryId());
+        add(QueryResultTableBuilder.create("spaces", queryRef, new ViewDisplay(allSpacesView)).build());
     }
 
 }

--- a/src/main/java/com/knowledgepixels/nanodash/repository/SpaceRepository.java
+++ b/src/main/java/com/knowledgepixels/nanodash/repository/SpaceRepository.java
@@ -13,7 +13,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -44,24 +43,21 @@ public class SpaceRepository {
     private static final class Snapshot {
         final Map<String, Space> spacesById;
         final Map<String, Space> spacesByAltId;
-        final Map<String, List<Space>> spaceListByType;
         final Map<Space, Set<Space>> subspaceMap;
         final Map<Space, Set<Space>> superspaceMap;
 
         Snapshot(Map<String, Space> byId,
                  Map<String, Space> byAltId,
-                 Map<String, List<Space>> byType,
                  Map<Space, Set<Space>> subspaces,
                  Map<Space, Set<Space>> superspaces) {
             this.spacesById = byId;
             this.spacesByAltId = byAltId;
-            this.spaceListByType = byType;
             this.subspaceMap = subspaces;
             this.superspaceMap = superspaces;
         }
 
         static final Snapshot EMPTY = new Snapshot(
-                Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
+                Collections.emptyMap(), Collections.emptyMap(),
                 Collections.emptyMap(), Collections.emptyMap());
     }
 
@@ -105,31 +101,25 @@ public class SpaceRepository {
     private Snapshot build(ApiResponse resp) {
         Map<String, Space> byId = new HashMap<>();
         Map<String, Space> byAltId = new HashMap<>();
-        Map<String, List<Space>> byType = new HashMap<>();
         Map<Space, Set<Space>> subspaceMap = new HashMap<>();
         Map<Space, Set<Space>> superspaceMap = new HashMap<>();
         List<Space> spaceList = new ArrayList<>();
         Set<String> seen = new HashSet<>();
         for (ApiResponseEntry r : resp.getData()) {
-            String spaceIri = r.get("spaceIri");
+            String spaceIri = r.get("space_iri");
             if (spaceIri == null || spaceIri.isEmpty()) continue;
             if (!seen.add(spaceIri)) continue; // first row (latest date) wins
             ApiResponseEntry entry = new ApiResponseEntry();
             entry.add("space", spaceIri);
             entry.add("np", r.get("np"));
-            entry.add("label", r.get("label"));
+            entry.add("label", r.get("space_iri_label"));
             entry.add("type", r.get("type"));
             Space space = SpaceFactory.getOrCreate(entry);
             spaceList.add(space);
-            byType.computeIfAbsent(space.getType(), k -> new ArrayList<>()).add(space);
             byId.put(space.getId(), space);
             for (String altId : space.getAltIDs()) {
                 byAltId.put(altId, space);
             }
-        }
-        Comparator<Space> byLabel = Comparator.comparing(Space::getLabel, Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER));
-        for (List<Space> spacesOfType : byType.values()) {
-            spacesOfType.sort(byLabel);
         }
         logger.info("Refreshed spaces from spaces repo: {} distinct spaces", spaceList.size());
         SpaceFactory.removeStale(byId.keySet());
@@ -140,7 +130,7 @@ public class SpaceRepository {
         for (Space space : spaceList) {
             space.setDataNeedsUpdate();
         }
-        return new Snapshot(byId, byAltId, byType, subspaceMap, superspaceMap);
+        return new Snapshot(byId, byAltId, subspaceMap, superspaceMap);
     }
 
     /**
@@ -171,17 +161,6 @@ public class SpaceRepository {
      */
     public Space findByAltId(String altId) {
         return current().spacesByAltId.get(altId);
-    }
-
-    /**
-     * Get spaces by their type.
-     *
-     * @param type The type of spaces to retrieve.
-     * @return List of Space objects matching the specified type, or an empty list if none are found.
-     */
-    public List<Space> findByType(String type) {
-        List<Space> l = current().spaceListByType.get(type);
-        return l != null ? l : new ArrayList<>();
     }
 
     /**


### PR DESCRIPTION
## Summary

- Replace the 14 per-type `ItemListPanel` columns and the legacy-projects panel on `/spaces` with one `gen:TabularView`, modeled on the All Templates view on `/publish`.
- The table includes the **space type** column and is ordered alphabetically by space label.
- `ProjectPage` and the `Project` domain class are kept so existing `/project?id=...` links still resolve — only the listing is gone.

## Backing nanopubs (live)

- View (latest):       <https://w3id.org/np/RAS8OVZaJPIGC9HoVRAU4zdXYOK64ssGYURx_f_b3NOpA>
- View-kind (stable):  <https://w3id.org/np/RANB1bHSVXw8W0aFTvPURWpq960qJm9jEsI1rUDxXwMDY/all-spaces-view-kind>
- Table query:         <https://w3id.org/np/RAlSgMFS1RJc1z7DM69BQ6HT2FEo46fm9JER7bQ6q1TA8/get-all-spaces>
- Repo query (v2):     <https://w3id.org/np/RAxGboS_juHuMyJQghGV3elEgZmQTew5oyw_aC9O9FFQI/get-spaces>

`SpaceRepository` keeps using the v2 `get-spaces` query (date-ordered, includes `?np` for root nanopub lookup); the table view uses a separate collapsed query so it only carries the space + type columns. `findByType()` and the `byType` snapshot map are dropped — no remaining callers after the per-type panels are gone.

## Test plan

- [ ] `/spaces` renders one table with rows for each space, type column populated, alphabetical default order
- [ ] Clicking a space row navigates to the corresponding `SpacePage` (label resolves via `NanodashLink` → `SpaceRepository.findById`)
- [ ] Existing `/project?id=<legacy>` URLs still resolve to `ProjectPage`
- [ ] Sub-space relationships on `SpacePage` still work (relies on `SpaceRepository` snapshot)
- [ ] No regression on `/publish` (All Templates table) or other consumers of `QueryResultTableBuilder`

🤖 Generated with [Claude Code](https://claude.com/claude-code)