### PR TITLE
feat: "Pending Admins/Maintainers/Members" space view for unapproved role claims

### DIFF
--- a/docs/queries/list-space-non-approved-ref-v2.trig
+++ b/docs/queries/list-space-non-approved-ref-v2.trig
@@ -1,0 +1,99 @@
+@prefix this: <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
+@prefix sub: <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
+@prefix np: <http://www.nanopub.org/nschema#> .
+@prefix grlc: <https://w3id.org/kpxl/grlc/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix npx: <http://purl.org/nanopub/x/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix orcid: <https://orcid.org/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+sub:Head {
+  this: a np:Nanopublication;
+    np:hasAssertion sub:assertion;
+    np:hasProvenance sub:provenance;
+    np:hasPublicationInfo sub:pubinfo .
+}
+
+sub:assertion {
+  sub:list-space-non-approved a grlc:grlc-query;
+    dct:description "Lists the non-approved role claims of a given space ref (space IRI + root definition): agents who hold a higher-tier role instantiation (admin/maintainer/member) that is NOT in the trust-validated current state, i.e. a self-assigned or otherwise ungranted claim awaiting approval by an equal-or-higher-tier member. Pass the ref's root nanopub (root_np). Observer-tier roles are excluded: they are self-assignable, so a self-declared observer needs no approval and is shown by list-space-observers instead. The higher-tier test is generic — the built-in admin property (gen:hasAdmin) OR a RoleDeclaration whose npa:hasRoleType is gen:AdminRole/gen:MaintainerRole/gen:MemberRole — but because the live spaces repo currently materialises every declaration as gen:ObserverRole, only admin claims are detectable today; maintainer/member claims appear automatically once real tier subclasses exist. Per (member, role) only the latest role-instantiation nanopub is returned (by dct:created). Returns the claimed tier, the role-assignment grant nanopub(s) with the claimed role's label (role_assignments_multi_iri + role_assignments_label_multi), and the role-assignment template (for the approve action, which re-asserts the same triple), plus a hidden agent_iri column the approve action maps into the template's agent placeholder. v2: adds the role_assignments columns.";
+    dct:license <http://www.apache.org/licenses/LICENSE-2.0>;
+    rdfs:label "List space non-approved role claims (ref-scoped)";
+    grlc:endpoint <https://w3id.org/np/l/nanopub-query-1.1/repo/spaces>;
+    grlc:sparql """prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix dct: <http://purl.org/dc/terms/>
+prefix np: <http://www.nanopub.org/nschema#>
+prefix npa: <http://purl.org/nanopub/admin/>
+prefix npx: <http://purl.org/nanopub/x/>
+prefix gen: <https://w3id.org/kpxl/gen/terms/>
+prefix schema: <http://schema.org/>
+
+select ?member
+       (sample(?agentX) as ?agent_iri)
+       (sample(?tierX) as ?tier)
+       (group_concat(distinct ?latestNp; separator=\" \") as ?role_assignments_multi_iri)
+       (group_concat(distinct ?roleLabel; separator=\"\\n\") as ?role_assignments_label_multi)
+       (sample(?rtmplX) as ?roleAssignmentTemplate)
+where {
+  {
+    select ?member ?roleProp
+           (max(?val0) as ?val)
+           (strafter(max(concat(coalesce(str(?dateNp),\"\"), \" \", str(?grantNp))), \" \") as ?latestNp)
+           (sample(?member) as ?agentX)
+           (sample(?tier0) as ?tierX)
+           (sample(?rtmpl0) as ?rtmplX)
+           (sample(?rl) as ?rlRaw)
+    where {
+      values ?_root_np_multi_iri {}
+      graph npa:spacesGraph { ?ref npa:rootNanopub ?_root_np_multi_iri ; npa:spaceIri ?spaceIri . }
+      graph npa:graph { npa:thisRepo npa:hasCurrentSpaceState ?g . }
+      graph npa:spacesGraph {
+        ?ri a gen:RoleInstantiation ; npa:forSpace ?spaceIri ; npa:forAgent ?member ; npa:viaNanopub ?grantNp ;
+            (npa:regularProperty|npa:inverseProperty) ?roleProp .
+      }
+      bind(?roleProp = gen:hasAdmin as ?isAdminProp)
+      bind(exists { graph npa:spacesGraph { ?rdA a npa:RoleDeclaration ; npa:hasRoleType gen:AdminRole ; (gen:hasRegularProperty|gen:hasInverseProperty) ?roleProp } } as ?isAdminDecl)
+      bind(exists { graph npa:spacesGraph { ?rdM a npa:RoleDeclaration ; npa:hasRoleType gen:MaintainerRole ; (gen:hasRegularProperty|gen:hasInverseProperty) ?roleProp } } as ?isMaint)
+      bind(exists { graph npa:spacesGraph { ?rdMe a npa:RoleDeclaration ; npa:hasRoleType gen:MemberRole ; (gen:hasRegularProperty|gen:hasInverseProperty) ?roleProp } } as ?isMemb)
+      filter(?isAdminProp || ?isAdminDecl || ?isMaint || ?isMemb)
+      filter not exists { graph npa:graph { ?invNp npx:invalidates ?grantNp . } }
+      bind(if(exists { graph ?g { ?vri npa:forSpaceRef ?ref ; npa:forAgent ?member ; (npa:regularProperty|npa:inverseProperty) ?roleProp } }, 1, 0) as ?val0)
+      optional { graph npa:graph { ?grantNp dct:created ?dateNp } }
+      bind(if(?isAdminProp || ?isAdminDecl, \"Admin\", if(?isMaint, \"Maintainer\", \"Member\")) as ?tier0)
+      bind(if(?isAdminProp, <https://w3id.org/np/RAsOQ7k3GNnuUqZuLm57PWwWopQJR_4onnCpNR457CZg8>, ?undefTmpl) as ?rtmpl0)
+      optional {
+        graph ?g { ?raRole a gen:RoleAssignment ; npa:forSpaceRef ?ref ; gen:hasRole ?role . }
+        graph npa:spacesGraph { ?rd2 a npa:RoleDeclaration ; npa:role ?role ; (gen:hasRegularProperty|gen:hasInverseProperty) ?roleProp ; npa:viaNanopub ?roleNp . }
+        graph npa:graph { ?roleNp np:hasAssertion ?role_a . }
+        optional { graph ?role_a { ?role schema:name ?rlS } }
+        optional { graph ?role_a { ?role rdfs:label ?rlA } }
+        optional { graph ?role_a { ?role dct:title ?rlB } }
+        bind(coalesce(?rlS, ?rlA, ?rlB) as ?rlResolved)
+      }
+      bind(if(?isAdminProp, \"admin\", ?rlResolved) as ?rl)
+    }
+    group by ?member ?roleProp
+    having (max(?val0) = 0)
+  }
+  bind(coalesce(?rlRaw, \"role\") as ?roleLabel)
+}
+group by ?member
+order by ?member""" .
+}
+
+sub:provenance {
+  sub:assertion prov:wasAttributedTo orcid:0000-0002-1267-0234 .
+}
+
+sub:pubinfo {
+  orcid:0000-0002-1267-0234 foaf:name "Tobias Kuhn" .
+
+  this: dct:created "2026-06-16T15:15:35Z"^^xsd:dateTime;
+    dct:creator orcid:0000-0002-1267-0234;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    npx:embeds sub:list-space-non-approved;
+    npx:supersedes <https://w3id.org/np/RA2HUYSqUdNV6UHbcfBHaBiC86y-BsClf2rlnjy71PNDg> .
+}

--- a/docs/queries/list-space-non-approved-ref.trig
+++ b/docs/queries/list-space-non-approved-ref.trig
@@ -1,0 +1,86 @@
+@prefix this: <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
+@prefix sub: <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
+@prefix np: <http://www.nanopub.org/nschema#> .
+@prefix grlc: <https://w3id.org/kpxl/grlc/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix npx: <http://purl.org/nanopub/x/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix orcid: <https://orcid.org/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+sub:Head {
+  this: a np:Nanopublication;
+    np:hasAssertion sub:assertion;
+    np:hasProvenance sub:provenance;
+    np:hasPublicationInfo sub:pubinfo .
+}
+
+sub:assertion {
+  sub:list-space-non-approved a grlc:grlc-query;
+    dct:description "Lists the non-approved role claims of a given space ref (space IRI + root definition): agents who hold a higher-tier role instantiation (admin/maintainer/member) that is NOT in the trust-validated current state, i.e. a self-assigned or otherwise ungranted claim awaiting approval by an equal-or-higher-tier member. Pass the ref's root nanopub (root_np). Observer-tier roles are excluded: they are self-assignable, so a self-declared observer needs no approval and is shown by list-space-observers instead. The higher-tier test is generic — the built-in admin property (gen:hasAdmin) OR a RoleDeclaration whose npa:hasRoleType is gen:AdminRole/gen:MaintainerRole/gen:MemberRole — but because the live spaces repo currently materialises every declaration as gen:ObserverRole, only admin claims are detectable today; maintainer/member claims appear automatically once real tier subclasses exist. Per (member, role) only the latest role-instantiation nanopub is returned (by dct:created). Also returns the claimed tier, the role IRI, and the role-assignment template (for the approve action, which re-asserts the same triple), plus a hidden agent_iri column the approve action maps into the template's agent placeholder.";
+    dct:license <http://www.apache.org/licenses/LICENSE-2.0>;
+    rdfs:label "List space non-approved role claims (ref-scoped)";
+    grlc:endpoint <https://w3id.org/np/l/nanopub-query-1.1/repo/spaces>;
+    grlc:sparql """prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix dct: <http://purl.org/dc/terms/>
+prefix np: <http://www.nanopub.org/nschema#>
+prefix npa: <http://purl.org/nanopub/admin/>
+prefix npx: <http://purl.org/nanopub/x/>
+prefix gen: <https://w3id.org/kpxl/gen/terms/>
+prefix schema: <http://schema.org/>
+
+select ?member
+       (sample(?agentX) as ?agent_iri)
+       (sample(?tierX) as ?tier)
+       (sample(?rtmplX) as ?roleAssignmentTemplate)
+       (strafter(max(concat(coalesce(str(?dateX),\"\"), \" \", str(?latestNp))), \" \") as ?np)
+where {
+  {
+    select ?member ?roleProp
+           (max(?val0) as ?val)
+           (strafter(max(concat(coalesce(str(?dateNp),\"\"), \" \", str(?grantNp))), \" \") as ?latestNp)
+           (max(?dateNp) as ?dateX)
+           (sample(?member) as ?agentX)
+           (sample(?tier0) as ?tierX)
+           (sample(?rtmpl0) as ?rtmplX)
+    where {
+      values ?_root_np_multi_iri {}
+      graph npa:spacesGraph { ?ref npa:rootNanopub ?_root_np_multi_iri ; npa:spaceIri ?spaceIri . }
+      graph npa:graph { npa:thisRepo npa:hasCurrentSpaceState ?g . }
+      graph npa:spacesGraph {
+        ?ri a gen:RoleInstantiation ; npa:forSpace ?spaceIri ; npa:forAgent ?member ; npa:viaNanopub ?grantNp ;
+            (npa:regularProperty|npa:inverseProperty) ?roleProp .
+      }
+      bind(?roleProp = gen:hasAdmin as ?isAdminProp)
+      bind(exists { graph npa:spacesGraph { ?rdA a npa:RoleDeclaration ; npa:hasRoleType gen:AdminRole ; (gen:hasRegularProperty|gen:hasInverseProperty) ?roleProp } } as ?isAdminDecl)
+      bind(exists { graph npa:spacesGraph { ?rdM a npa:RoleDeclaration ; npa:hasRoleType gen:MaintainerRole ; (gen:hasRegularProperty|gen:hasInverseProperty) ?roleProp } } as ?isMaint)
+      bind(exists { graph npa:spacesGraph { ?rdMe a npa:RoleDeclaration ; npa:hasRoleType gen:MemberRole ; (gen:hasRegularProperty|gen:hasInverseProperty) ?roleProp } } as ?isMemb)
+      filter(?isAdminProp || ?isAdminDecl || ?isMaint || ?isMemb)
+      filter not exists { graph npa:graph { ?invNp npx:invalidates ?grantNp . } }
+      bind(if(exists { graph ?g { ?vri npa:forSpaceRef ?ref ; npa:forAgent ?member ; (npa:regularProperty|npa:inverseProperty) ?roleProp } }, 1, 0) as ?val0)
+      optional { graph npa:graph { ?grantNp dct:created ?dateNp } }
+      bind(if(?isAdminProp || ?isAdminDecl, \"Admin\", if(?isMaint, \"Maintainer\", \"Member\")) as ?tier0)
+      bind(if(?isAdminProp, <https://w3id.org/np/RAsOQ7k3GNnuUqZuLm57PWwWopQJR_4onnCpNR457CZg8>, ?undefTmpl) as ?rtmpl0)
+    }
+    group by ?member ?roleProp
+    having (max(?val0) = 0)
+  }
+}
+group by ?member
+order by ?member""" .
+}
+
+sub:provenance {
+  sub:assertion prov:wasAttributedTo orcid:0000-0002-1267-0234 .
+}
+
+sub:pubinfo {
+  orcid:0000-0002-1267-0234 foaf:name "Tobias Kuhn" .
+
+  this: dct:created "2026-06-16T14:39:09Z"^^xsd:dateTime;
+    dct:creator orcid:0000-0002-1267-0234;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    npx:embeds sub:list-space-non-approved .
+}

--- a/docs/queries/list-space-observers-ref-v2.trig
+++ b/docs/queries/list-space-observers-ref-v2.trig
@@ -1,0 +1,95 @@
+@prefix this: <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
+@prefix sub: <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
+@prefix np: <http://www.nanopub.org/nschema#> .
+@prefix grlc: <https://w3id.org/kpxl/grlc/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix npx: <http://purl.org/nanopub/x/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix orcid: <https://orcid.org/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+sub:Head {
+  this: a np:Nanopublication;
+    np:hasAssertion sub:assertion;
+    np:hasProvenance sub:provenance;
+    np:hasPublicationInfo sub:pubinfo .
+}
+
+sub:assertion {
+  sub:list-space-observers a grlc:grlc-query;
+    dct:description "Lists the observers of a given space ref (space IRI + root definition): agents holding an observer-tier role and no validated admin/maintainer/member role. Pass the ref's root nanopub (root_np). Per (member, role) only the latest role-instantiation nanopub is returned (by dct:created), so a role re-asserted several times shows once. Unlike list-space-observers (validated-only), this also includes self-declared observers whose key is not trust-validated (no accepted introduction), flagging them in the headerless ?unverified_noheader column. The role label is pinned to the role the space actually assigned (RoleAssignment), correct even when several declarations share a property. Ref-scoped; shows un-introduced observers rather than hiding them. v2: excludes higher-tier role claims (the built-in admin property gen:hasAdmin, or a role whose declaration's npa:hasRoleType is gen:AdminRole/gen:MaintainerRole/gen:MemberRole) — those are not self-assignable, so an unapproved one belongs in list-space-non-approved, not here. Because the live spaces repo currently materialises every declaration as gen:ObserverRole, only the admin exclusion is observable today; the maintainer/member exclusion arms automatically once real tier subclasses exist.";
+    dct:license <http://www.apache.org/licenses/LICENSE-2.0>;
+    rdfs:label "List space observers (ref-scoped, with validation flag)";
+    grlc:endpoint <https://w3id.org/np/l/nanopub-query-1.1/repo/spaces>;
+    grlc:sparql """prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix dct: <http://purl.org/dc/terms/>
+prefix np: <http://www.nanopub.org/nschema#>
+prefix npa: <http://purl.org/nanopub/admin/>
+prefix npx: <http://purl.org/nanopub/x/>
+prefix gen: <https://w3id.org/kpxl/gen/terms/>
+prefix schema: <http://schema.org/>
+
+select ?member
+       (group_concat(distinct ?latestNp; separator=\" \") as ?role_assignments_multi_iri)
+       (group_concat(distinct ?roleLabel; separator=\"\\n\") as ?role_assignments_label_multi)
+       (if(max(?val) = 0, \"⚠️\", \"\") as ?unverified_noheader)
+where {
+  {
+    select ?member ?roleProp
+           (max(?val0) as ?val)
+           (strafter(max(concat(coalesce(str(?dateNp),\"\"), \" \", str(?grantNp))), \" \") as ?latestNp)
+           (sample(?rl) as ?rlRaw)
+    where {
+      values ?_root_np_multi_iri {}
+      graph npa:spacesGraph { ?ref npa:rootNanopub ?_root_np_multi_iri ; npa:spaceIri ?spaceIri . }
+      graph npa:graph { npa:thisRepo npa:hasCurrentSpaceState ?g . }
+      graph npa:spacesGraph {
+        ?ri a gen:RoleInstantiation ; npa:forSpace ?spaceIri ; npa:forAgent ?member ; npa:viaNanopub ?grantNp ;
+            (npa:regularProperty|npa:inverseProperty) ?roleProp .
+      }
+      filter exists { graph npa:spacesGraph { ?rdf a npa:RoleDeclaration ; npa:hasRoleType gen:ObserverRole ; (gen:hasRegularProperty|gen:hasInverseProperty) ?roleProp } }
+      filter(?roleProp != gen:hasAdmin)
+      filter not exists { graph npa:spacesGraph { ?rdh a npa:RoleDeclaration ; (gen:hasRegularProperty|gen:hasInverseProperty) ?roleProp .
+        { ?rdh npa:hasRoleType gen:AdminRole } union { ?rdh npa:hasRoleType gen:MaintainerRole } union { ?rdh npa:hasRoleType gen:MemberRole } } }
+      filter not exists { graph npa:graph { ?invNp npx:invalidates ?grantNp . } }
+      filter not exists {
+        graph ?g { ?hri npa:forSpaceRef ?ref ; npa:forAgent ?member ; (npa:regularProperty|npa:inverseProperty) ?hp . }
+        graph npa:spacesGraph { ?hrd a npa:RoleDeclaration ; (gen:hasRegularProperty|gen:hasInverseProperty) ?hp .
+          { ?hrd npa:hasRoleType gen:MemberRole } union { ?hrd npa:hasRoleType gen:MaintainerRole } }
+      }
+      filter not exists { graph ?g { ?ari npa:forSpaceRef ?ref ; npa:forAgent ?member ; npa:inverseProperty gen:hasAdmin . } }
+      bind(if(exists { graph ?g { ?vri npa:forSpaceRef ?ref ; npa:forAgent ?member ; npa:viaNanopub ?grantNp } }, 1, 0) as ?val0)
+      optional { graph npa:graph { ?grantNp dct:created ?dateNp } }
+      optional {
+        graph ?g { ?raRole a gen:RoleAssignment ; npa:forSpaceRef ?ref ; gen:hasRole ?role . }
+        graph npa:spacesGraph { ?rd2 a npa:RoleDeclaration ; npa:role ?role ; (gen:hasRegularProperty|gen:hasInverseProperty) ?roleProp ; npa:viaNanopub ?roleNp . }
+        graph npa:graph { ?roleNp np:hasAssertion ?role_a . }
+        optional { graph ?role_a { ?role schema:name ?rlS } }
+        optional { graph ?role_a { ?role rdfs:label ?rlA } }
+        optional { graph ?role_a { ?role dct:title ?rlB } }
+        bind(coalesce(?rlS, ?rlA, ?rlB) as ?rl)
+      }
+    }
+    group by ?member ?roleProp
+  }
+  bind(coalesce(?rlRaw, \"role\") as ?roleLabel)
+}
+group by ?member
+order by ?unverified_noheader ?member""" .
+}
+
+sub:provenance {
+  sub:assertion prov:wasAttributedTo orcid:0000-0002-1267-0234 .
+}
+
+sub:pubinfo {
+  orcid:0000-0002-1267-0234 foaf:name "Tobias Kuhn" .
+
+  this: dct:created "2026-06-16T14:44:33Z"^^xsd:dateTime;
+    dct:creator orcid:0000-0002-1267-0234;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    npx:embeds sub:list-space-observers;
+    npx:supersedes <https://w3id.org/np/RARc37t3fXMzrFP-PYsdmIqsDdloZaNklY4eYxpUKaLHI> .
+}

--- a/docs/queries/pending-members-view-v2.trig
+++ b/docs/queries/pending-members-view-v2.trig
@@ -1,0 +1,59 @@
+@prefix this: <http://purl.org/nanopub/temp/np001/> .
+@prefix sub: <http://purl.org/nanopub/temp/np001/> .
+@prefix gen: <https://w3id.org/kpxl/gen/terms/> .
+@prefix np: <http://www.nanopub.org/nschema#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix nt: <https://w3id.org/np/o/ntemplate/> .
+@prefix npx: <http://purl.org/nanopub/x/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix orcid: <https://orcid.org/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+sub:Head {
+  this: a np:Nanopublication;
+    np:hasAssertion sub:assertion;
+    np:hasProvenance sub:provenance;
+    np:hasPublicationInfo sub:pubinfo .
+}
+
+sub:assertion {
+  sub:approve-action a gen:ViewEntryAction;
+    rdfs:label "✅ approve...";
+    gen:hasActionTemplate <https://w3id.org/np/RAsOQ7k3GNnuUqZuLm57PWwWopQJR_4onnCpNR457CZg8>;
+    gen:hasActionTemplatePartField "void";
+    gen:hasActionTemplateQueryMapping "roleAssignmentTemplate:@template agent_iri:admin";
+    gen:hasActionTemplateTargetField "space";
+    gen:isVisibleTo gen:MemberRole .
+
+  sub:pending-members-view a gen:ResourceView, gen:TabularView;
+    dct:isVersionOf <https://w3id.org/np/RAnprTkjXNUKbhd6k_Lk50z182uO4g1Rqmg59YLcvLIAk/pending-members-view-kind>;
+    dct:title "❓ Pending Admins/Maintainers/Members";
+    rdfs:label "Space pending members view";
+    gen:appliesToInstancesOf gen:Space;
+    gen:hasDisplayWidth gen:ColumnWidth06of12;
+    gen:hasStructuralPosition "5.8.pendingMembers";
+    gen:hasViewAction sub:approve-action;
+    gen:hasViewQuery <https://w3id.org/np/RAZMAChiW6g1uJ02fYKuw_1tVk6XPUI1PpYiSraUDYpVY/list-space-non-approved>;
+    gen:hasViewQueryTargetField "space" .
+}
+
+sub:provenance {
+  sub:assertion prov:wasAttributedTo orcid:0000-0002-1267-0234 .
+}
+
+sub:pubinfo {
+  orcid:0000-0002-1267-0234 foaf:name "Tobias Kuhn" .
+
+  this: dct:created "2026-06-16T15:16:52Z"^^xsd:dateTime;
+    dct:creator orcid:0000-0002-1267-0234;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    npx:embeds sub:pending-members-view;
+    npx:introduces <https://w3id.org/np/RAnprTkjXNUKbhd6k_Lk50z182uO4g1Rqmg59YLcvLIAk/pending-members-view-kind>;
+    npx:supersedes <https://w3id.org/np/RAnprTkjXNUKbhd6k_Lk50z182uO4g1Rqmg59YLcvLIAk>;
+    nt:wasCreatedFromProvenanceTemplate <https://w3id.org/np/RA7lSq6MuK_TIC6JMSHvLtee3lpLoZDOqLJCLXevnrPoU>;
+    nt:wasCreatedFromPubinfoTemplate <https://w3id.org/np/RA0J4vUn_dekg-U1kK3AOEt02p9mT2WO03uGxLDec1jLw>,
+      <https://w3id.org/np/RAoTD7udB2KtUuOuAe74tJi1t3VzK0DyWS7rYVAq1GRvw>, <https://w3id.org/np/RAukAcWHRDlkqxk7H2XNSegc1WnHI569INvNr-xdptDGI>;
+    nt:wasCreatedFromTemplate <https://w3id.org/np/RA8_hijwsfGCryMYtjtEpec21ZSNY68-qmL0bHRWR0sWM> .
+}

--- a/docs/queries/pending-members-view.trig
+++ b/docs/queries/pending-members-view.trig
@@ -1,0 +1,58 @@
+@prefix this: <http://purl.org/nanopub/temp/np001/> .
+@prefix sub: <http://purl.org/nanopub/temp/np001/> .
+@prefix gen: <https://w3id.org/kpxl/gen/terms/> .
+@prefix np: <http://www.nanopub.org/nschema#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix nt: <https://w3id.org/np/o/ntemplate/> .
+@prefix npx: <http://purl.org/nanopub/x/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix orcid: <https://orcid.org/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+sub:Head {
+  this: a np:Nanopublication;
+    np:hasAssertion sub:assertion;
+    np:hasProvenance sub:provenance;
+    np:hasPublicationInfo sub:pubinfo .
+}
+
+sub:assertion {
+  sub:approve-action a gen:ViewEntryAction;
+    rdfs:label "✅ approve...";
+    gen:hasActionTemplate <https://w3id.org/np/RAsOQ7k3GNnuUqZuLm57PWwWopQJR_4onnCpNR457CZg8>;
+    gen:hasActionTemplatePartField "void";
+    gen:hasActionTemplateQueryMapping "roleAssignmentTemplate:@template agent_iri:admin";
+    gen:hasActionTemplateTargetField "space";
+    gen:isVisibleTo gen:MemberRole .
+
+  sub:pending-members-view a gen:ResourceView, gen:TabularView;
+    dct:isVersionOf sub:pending-members-view-kind;
+    dct:title "❓ Pending Admins/Maintainers/Members";
+    rdfs:label "Space pending members view";
+    gen:appliesToInstancesOf gen:Space;
+    gen:hasDisplayWidth gen:ColumnWidth12of12;
+    gen:hasStructuralPosition "5.8.pendingMembers";
+    gen:hasViewAction sub:approve-action;
+    gen:hasViewQuery <https://w3id.org/np/RA2HUYSqUdNV6UHbcfBHaBiC86y-BsClf2rlnjy71PNDg/list-space-non-approved>;
+    gen:hasViewQueryTargetField "space" .
+}
+
+sub:provenance {
+  sub:assertion prov:wasAttributedTo orcid:0000-0002-1267-0234 .
+}
+
+sub:pubinfo {
+  orcid:0000-0002-1267-0234 foaf:name "Tobias Kuhn" .
+
+  this: dct:created "2026-06-16T14:56:02Z"^^xsd:dateTime;
+    dct:creator orcid:0000-0002-1267-0234;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    npx:embeds sub:pending-members-view;
+    npx:introduces sub:pending-members-view-kind;
+    nt:wasCreatedFromProvenanceTemplate <https://w3id.org/np/RA7lSq6MuK_TIC6JMSHvLtee3lpLoZDOqLJCLXevnrPoU>;
+    nt:wasCreatedFromPubinfoTemplate <https://w3id.org/np/RA0J4vUn_dekg-U1kK3AOEt02p9mT2WO03uGxLDec1jLw>,
+      <https://w3id.org/np/RAoTD7udB2KtUuOuAe74tJi1t3VzK0DyWS7rYVAq1GRvw>, <https://w3id.org/np/RAukAcWHRDlkqxk7H2XNSegc1WnHI569INvNr-xdptDGI>;
+    nt:wasCreatedFromTemplate <https://w3id.org/np/RA8_hijwsfGCryMYtjtEpec21ZSNY68-qmL0bHRWR0sWM> .
+}

--- a/src/main/java/com/knowledgepixels/nanodash/QueryApiAccess.java
+++ b/src/main/java/com/knowledgepixels/nanodash/QueryApiAccess.java
@@ -118,8 +118,20 @@ public class QueryApiAccess {
     // INCLUDING un-introduced self-declared ones (not in the validated state), each flagged
     // via a headerless ?unverified_noheader column (⚠️ when unvalidated). Drives the existing
     // Observers view's table (the view nanopub is left untouched). Published independently.
-    // Source at docs/queries/list-space-observers-ref.trig.
-    public static final String LIST_SPACE_OBSERVERS_REF = "RARc37t3fXMzrFP-PYsdmIqsDdloZaNklY4eYxpUKaLHI/list-space-observers";
+    // v2 (RA58KSjh, supersedes RARc37t3) excludes higher-tier role claims (admin built-in
+    // property, or Maintainer/Member-tier declarations) — those go to LIST_SPACE_NON_APPROVED_REF
+    // instead of showing up here mislabelled as observers. Source at
+    // docs/queries/list-space-observers-ref-v2.trig.
+    public static final String LIST_SPACE_OBSERVERS_REF = "RA58KSjhMzsFjibtL02m11Xptk0A-CtAjG8wWhvA_ljmQ/list-space-observers";
+
+    // Ref-scoped non-approved role claims (root_np): agents holding a higher-tier role
+    // instantiation (admin/maintainer/member) that is NOT in the validated state — a
+    // self-assigned or otherwise ungranted claim awaiting approval by an equal-or-higher-tier
+    // member. Observer-tier roles are excluded (self-assignable, so they need no approval and
+    // are listed by LIST_SPACE_OBSERVERS_REF). Only admin claims are detectable today (the live
+    // repo materialises every declaration as ObserverRole). Drives the "❓ Pending
+    // Admins/Maintainers/Members" view. Source at docs/queries/list-space-non-approved-ref.trig.
+    public static final String LIST_SPACE_NON_APPROVED_REF = "RAZMAChiW6g1uJ02fYKuw_1tVk6XPUI1PpYiSraUDYpVY/list-space-non-approved";
 
     private static final Logger logger = LoggerFactory.getLogger(QueryApiAccess.class);
 

--- a/src/main/java/com/knowledgepixels/nanodash/component/AboutSpacePanel.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/AboutSpacePanel.html
@@ -9,6 +9,7 @@
   <div class="row-section">
     <div class="col-12 section-header"><h3>👥 Users</h3></div>
     <div wicket:id="members"></div>
+    <div wicket:id="pendingmembers"></div>
     <div wicket:id="observers"></div>
   </div>
   <div class="row-section">

--- a/src/main/java/com/knowledgepixels/nanodash/component/AboutSpacePanel.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/AboutSpacePanel.java
@@ -53,6 +53,16 @@ public class AboutSpacePanel extends Panel {
     public static final String MEMBERS_VIEW = "https://w3id.org/np/RAFmrcEqniX7mqrZQ8c4OCqjU-3wwKjLhE2glXAZKFNT0/space-members-view";
 
     /**
+     * View listing a space's non-approved role claims (agents holding an
+     * admin/maintainer/member-tier role instantiation that is not in the
+     * validated state — a self-assigned or otherwise ungranted claim awaiting
+     * approval), built on the list-space-non-approved query. Carries a per-row
+     * "approve" action (visible to members and above) that re-asserts the same
+     * role triple, signed by the approver.
+     */
+    public static final String NON_APPROVED_VIEW = "https://w3id.org/np/RAk5nU4XXK1-CzrE2mcSLcRmJXnANVWgkQ2dNUQzDVR64/pending-members-view";
+
+    /**
      * View listing a space's observers (members whose highest tier is observer,
      * i.e. holding no admin/maintainer/member role), built on the
      * list-space-observers query.
@@ -108,6 +118,20 @@ public class AboutSpacePanel extends Panel {
 
         View membersView = View.get(MEMBERS_VIEW);
         add(QueryResultTableBuilder.create("members", new QueryRef(membersView.getQuery().getQueryId(), "space", space.getId()), new ViewDisplay(membersView)).build());
+
+        // Non-approved (pending) higher-tier role claims, between members and observers.
+        // Ref-scoped (root_np), like the observers table below; there is no IRI-keyed
+        // fallback query, so when the ref root is unknown (pre-v3 data) the table is driven
+        // by the param-less query, which yields no rows. The space is passed as
+        // resource/context so the per-row "approve" action pre-fills param_space; the agent
+        // and role template come from the row via the view's query mappings. postPublishTab
+        // returns the approver to the About tab, where the approved member now shows.
+        View nonApprovedView = View.get(NON_APPROVED_VIEW);
+        String nonApprovedRefRoot = space.getRefRootId();
+        QueryRef nonApprovedQuery = (nonApprovedRefRoot != null && !nonApprovedRefRoot.isEmpty())
+                ? new QueryRef(QueryApiAccess.LIST_SPACE_NON_APPROVED_REF, "root_np", nonApprovedRefRoot)
+                : new QueryRef(QueryApiAccess.LIST_SPACE_NON_APPROVED_REF);
+        add(QueryResultTableBuilder.create("pendingmembers", nonApprovedQuery, new ViewDisplay(nonApprovedView)).resourceWithProfile(space).id(space.getId()).contextId(space.getId()).postPublishTab("about").build());
 
         View observersView = View.get(OBSERVERS_VIEW);
         // Drive the Observers table from the ref-scoped query that also includes un-introduced


### PR DESCRIPTION
## What

A self-assigned admin (signing key not in the ref's validated admin set) previously appeared under **Observers** with a generic "role" label — the ref-scoped observers query includes unvalidated rows, and tier-flattening maps `gen:hasAdmin` to an `ObserverRole` declaration, so the claim was bucketed as an observer.

This splits unapproved higher-tier role claims out of Observers into a dedicated **❓ Pending Admins/Maintainers/Members** view on the space About tab, with a per-row **✅ approve** action (visible to members and above) that re-asserts the same role triple signed by the approver.

## Tier model

Per https://knowledgepixels.com/spaces/: Admin > Maintainer > Member > Observer. Observer is the only self-assignable tier; admin/maintainer/member must be granted by an equal-or-higher tier. So a self-assigned observer is legitimate (stays in Observers), while a self-assigned admin/maintainer/member is "pending" until an authorized member re-asserts it.

## Changes

**Nanopubs (published live):**
- `list-space-non-approved` query (`RAZMAChi…`) — ref-scoped (`root_np`); higher-tier role instantiations not in the validated state. Only **admin** is detectable today (the live repo materialises every declaration as `ObserverRole`); the higher-tier filter is written generically so maintainer/member claims arm automatically once real tier subclasses exist.
- `list-space-observers` **v2** (`RA58KSjh…`, supersedes `RARc37t3…`) — excludes higher-tier claims so they no longer show mislabelled as observers.
- `pending-members-view` (`RAk5nU4X…`) — 6/12 `TabularView`, columns **member · tier · role-assignment** (claimed role linked to its grant nanopub), `approve` `ViewEntryAction` mapping the row's agent + role template.

**Code:**
- `QueryApiAccess`: add `LIST_SPACE_NON_APPROVED_REF`, repoint `LIST_SPACE_OBSERVERS_REF` → v2.
- `AboutSpacePanel(.java/.html)`: render the new table between Members and Observers, ref-scoped (`root_np`) like the observers table; space passed as action context; `postPublishTab("about")`.
- Query/view sources under `docs/queries/`.

## Notes

- Base is `feat/space-ref-disambiguation` (this builds on its unmerged ref-scoped observers wiring), not `master`.
- Accepted simplification: the approve button is shown to all members; a non-admin's approval of an admin claim publishes but the server won't validate it, so it stays pending.
- Verified end-to-end against the live `spaces` repo and rendered locally (`spaces/test/group`: the self-assigned admin moves from Observers into the new table).

🤖 Generated with [Claude Code](https://claude.com/claude-code)