### PR TITLE
fix: skip IRI creation for empty creator in TemplateItem (#485)

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/component/TemplateItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/TemplateItem.java
@@ -61,10 +61,13 @@ public class TemplateItem extends Panel {
         WebMarkupContainer statusPart = new WebMarkupContainer("status");
         if (extended) {
             IRI userIri = null;
-            try {
-                userIri = Utils.vf.createIRI(entry.get("creator"));
-            } catch (IllegalArgumentException | NullPointerException ex) {
-                logger.error("Error creating IRI from creator string: {}", entry.get("creator"), ex);
+            String creator = entry.get("creator");
+            if (creator != null && !creator.isBlank()) {
+                try {
+                    userIri = Utils.vf.createIRI(creator);
+                } catch (IllegalArgumentException | NullPointerException ex) {
+                    logger.error("Error creating IRI from creator string: {}", creator, ex);
+                }
             }
             String userString = User.getShortDisplayNameForPubkeyhash(userIri, entry.get("pubkeyhash"));
             statusPart.add(new Label("user", userString));


### PR DESCRIPTION
Fixes the `ERROR ... Error creating IRI from creator string:` log from #485.

`TemplateItem` called `Utils.vf.createIRI(entry.get("creator"))`, which throws
`IllegalArgumentException` when a template has no `dct:creator` (empty string).
The exception was caught and logged as ERROR per creator-less template. Functionally
harmless — `userIri` stayed `null` and the display already falls back to the pubkeyhash,
then to `"(unknown)"` — but noisy.

Guard on a non-blank `creator` before constructing the IRI. Empty creators fall through to
the existing pubkeyhash / `"(unknown)"` resolution; genuinely-malformed (non-empty) creator
strings are still logged.

Note: the 4.28.0 trigger (`TemplateList`'s entry-based `TemplateItem`) was already replaced
by a guarded `QueryResultTable` (6aa25212, in the upcoming release), so the error path is
already gone there; this hardens the now-latent public constructor.

Closes #485

🤖 Generated with [Claude Code](https://claude.com/claude-code)