### PR TITLE
feat: per-type "add preset" templates (type-filtered preset choice)

### DIFF
--- a/docs/queries/add-preset-maintained-resource.trig
+++ b/docs/queries/add-preset-maintained-resource.trig
@@ -1,0 +1,89 @@
+@prefix this: <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
+@prefix sub: <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
+@prefix gen: <https://w3id.org/kpxl/gen/terms/> .
+@prefix np: <http://www.nanopub.org/nschema#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix nt: <https://w3id.org/np/o/ntemplate/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix orcid: <https://orcid.org/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix npx: <http://purl.org/nanopub/x/> .
+
+sub:Head {
+  this: a np:Nanopublication;
+    np:hasAssertion sub:assertion;
+    np:hasProvenance sub:provenance;
+    np:hasPublicationInfo sub:pubinfo .
+}
+
+sub:assertion {
+  rdf:type rdfs:label "is a" .
+
+  gen:ActivatedPresetAssignment rdfs:label "activated preset assignment" .
+
+  gen:DeactivatedPresetAssignment rdfs:label "deactivated preset assignment" .
+
+  gen:PresetAssignment rdfs:label "preset assignment" .
+
+  gen:isAssignmentFor rdfs:label "is an assignment for" .
+
+  gen:isAssignmentOfPreset rdfs:label "is an assignment of the preset" .
+
+  sub:assertion a nt:AssertionTemplate;
+    dct:description """<p>Assign a <strong>preset</strong> (a named bundle of default views and roles) to a <strong>maintained resource</strong>, so that the resource picks up the preset's views and roles.</p>
+
+<p>Only presets designed for maintained resources (<code>gen:appliesToInstancesOf gen:MaintainedResource</code>) are offered. Like view displays, a preset assignment is identified by the <em>(preset, resource)</em> pair rather than by this nanopublication's URI, so it can later be deactivated by an equal-or-higher-tier member.</p>""";
+    rdfs:label "Assigning a preset to a maintained resource";
+    nt:hasNanopubLabelPattern "${resource} uses preset: ${preset}";
+    nt:hasStatement sub:st10, sub:st12, sub:st20, sub:st30;
+    nt:hasTag "Spaces" .
+
+  sub:assignment a nt:EmbeddedResource, nt:LocalResource;
+    rdfs:label "this" .
+
+  sub:assignmentMode a nt:RestrictedChoicePlaceholder;
+    rdfs:label "select whether this assignment is activated or deactivated";
+    nt:hasDefaultValue gen:ActivatedPresetAssignment;
+    nt:possibleValue gen:ActivatedPresetAssignment, gen:DeactivatedPresetAssignment .
+
+  sub:preset a nt:GuidedChoicePlaceholder;
+    rdfs:label "choose the preset";
+    nt:possibleValuesFromApi "https://w3id.org/np/l/nanopub-query-1.1/api/RASzbAAibVFh25rujZN2MwgyUB7zHogsxo7-UgI05Dotg/find-presets?appliedPresetClass=https://w3id.org/kpxl/gen/terms/MaintainedResource" .
+
+  sub:resource a nt:GuidedChoicePlaceholder;
+    rdfs:label "the ID of the resource";
+    nt:possibleValuesFromApi "https://w3id.org/np/l/nanopub-query-1.1/api/RAyMrQ89RECTi9gZK5q7gjL1wKTiP8StkLy0NIkkCiyew/find-things?type=https://w3id.org/kpxl/gen/terms/MaintainedResource" .
+
+  sub:st10 rdf:object gen:PresetAssignment;
+    rdf:predicate rdf:type;
+    rdf:subject sub:assignment .
+
+  sub:st12 a nt:AdvancedStatement;
+    rdf:object sub:assignmentMode;
+    rdf:predicate rdf:type;
+    rdf:subject sub:assignment .
+
+  sub:st20 rdf:object sub:preset;
+    rdf:predicate gen:isAssignmentOfPreset;
+    rdf:subject sub:assignment .
+
+  sub:st30 rdf:object sub:resource;
+    rdf:predicate gen:isAssignmentFor;
+    rdf:subject sub:assignment .
+}
+
+sub:provenance {
+  sub:assertion prov:wasAttributedTo orcid:0000-0002-1267-0234 .
+}
+
+sub:pubinfo {
+  orcid:0000-0002-1267-0234 foaf:name "Tobias Kuhn" .
+
+  this: dct:created "2026-06-19T13:18:21Z"^^xsd:dateTime;
+    dct:creator orcid:0000-0002-1267-0234;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    rdfs:label "Assigning a preset to a maintained resource" .
+}

--- a/docs/queries/add-preset-space.trig
+++ b/docs/queries/add-preset-space.trig
@@ -1,0 +1,89 @@
+@prefix this: <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
+@prefix sub: <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
+@prefix gen: <https://w3id.org/kpxl/gen/terms/> .
+@prefix np: <http://www.nanopub.org/nschema#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix nt: <https://w3id.org/np/o/ntemplate/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix orcid: <https://orcid.org/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix npx: <http://purl.org/nanopub/x/> .
+
+sub:Head {
+  this: a np:Nanopublication;
+    np:hasAssertion sub:assertion;
+    np:hasProvenance sub:provenance;
+    np:hasPublicationInfo sub:pubinfo .
+}
+
+sub:assertion {
+  rdf:type rdfs:label "is a" .
+
+  gen:ActivatedPresetAssignment rdfs:label "activated preset assignment" .
+
+  gen:DeactivatedPresetAssignment rdfs:label "deactivated preset assignment" .
+
+  gen:PresetAssignment rdfs:label "preset assignment" .
+
+  gen:isAssignmentFor rdfs:label "is an assignment for" .
+
+  gen:isAssignmentOfPreset rdfs:label "is an assignment of the preset" .
+
+  sub:assertion a nt:AssertionTemplate;
+    dct:description """<p>Assign a <strong>preset</strong> (a named bundle of default views and roles) to a <strong>space</strong>, so that the space picks up the preset's views and roles.</p>
+
+<p>Only presets designed for spaces (<code>gen:appliesToInstancesOf gen:Space</code>) are offered. Like view displays, a preset assignment is identified by the <em>(preset, resource)</em> pair rather than by this nanopublication's URI, so it can later be deactivated by an equal-or-higher-tier member.</p>""";
+    rdfs:label "Assigning a preset to a space";
+    nt:hasNanopubLabelPattern "${resource} uses preset: ${preset}";
+    nt:hasStatement sub:st10, sub:st12, sub:st20, sub:st30;
+    nt:hasTag "Spaces" .
+
+  sub:assignment a nt:EmbeddedResource, nt:LocalResource;
+    rdfs:label "this" .
+
+  sub:assignmentMode a nt:RestrictedChoicePlaceholder;
+    rdfs:label "select whether this assignment is activated or deactivated";
+    nt:hasDefaultValue gen:ActivatedPresetAssignment;
+    nt:possibleValue gen:ActivatedPresetAssignment, gen:DeactivatedPresetAssignment .
+
+  sub:preset a nt:GuidedChoicePlaceholder;
+    rdfs:label "choose the preset";
+    nt:possibleValuesFromApi "https://w3id.org/np/l/nanopub-query-1.1/api/RASzbAAibVFh25rujZN2MwgyUB7zHogsxo7-UgI05Dotg/find-presets?appliedPresetClass=https://w3id.org/kpxl/gen/terms/Space" .
+
+  sub:resource a nt:GuidedChoicePlaceholder;
+    rdfs:label "choose the space";
+    nt:possibleValuesFromApi "https://w3id.org/np/l/nanopub-query-1.1/api/RAyMrQ89RECTi9gZK5q7gjL1wKTiP8StkLy0NIkkCiyew/find-things?type=https://w3id.org/kpxl/gen/terms/Space" .
+
+  sub:st10 rdf:object gen:PresetAssignment;
+    rdf:predicate rdf:type;
+    rdf:subject sub:assignment .
+
+  sub:st12 a nt:AdvancedStatement;
+    rdf:object sub:assignmentMode;
+    rdf:predicate rdf:type;
+    rdf:subject sub:assignment .
+
+  sub:st20 rdf:object sub:preset;
+    rdf:predicate gen:isAssignmentOfPreset;
+    rdf:subject sub:assignment .
+
+  sub:st30 rdf:object sub:resource;
+    rdf:predicate gen:isAssignmentFor;
+    rdf:subject sub:assignment .
+}
+
+sub:provenance {
+  sub:assertion prov:wasAttributedTo orcid:0000-0002-1267-0234 .
+}
+
+sub:pubinfo {
+  orcid:0000-0002-1267-0234 foaf:name "Tobias Kuhn" .
+
+  this: dct:created "2026-06-19T13:18:21Z"^^xsd:dateTime;
+    dct:creator orcid:0000-0002-1267-0234;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    rdfs:label "Assigning a preset to a space" .
+}

--- a/docs/queries/add-preset-user.trig
+++ b/docs/queries/add-preset-user.trig
@@ -1,0 +1,88 @@
+@prefix this: <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
+@prefix sub: <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
+@prefix gen: <https://w3id.org/kpxl/gen/terms/> .
+@prefix np: <http://www.nanopub.org/nschema#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix nt: <https://w3id.org/np/o/ntemplate/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix orcid: <https://orcid.org/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix npx: <http://purl.org/nanopub/x/> .
+
+sub:Head {
+  this: a np:Nanopublication;
+    np:hasAssertion sub:assertion;
+    np:hasProvenance sub:provenance;
+    np:hasPublicationInfo sub:pubinfo .
+}
+
+sub:assertion {
+  rdf:type rdfs:label "is a" .
+
+  gen:ActivatedPresetAssignment rdfs:label "activated preset assignment" .
+
+  gen:DeactivatedPresetAssignment rdfs:label "deactivated preset assignment" .
+
+  gen:PresetAssignment rdfs:label "preset assignment" .
+
+  gen:isAssignmentFor rdfs:label "is an assignment for" .
+
+  gen:isAssignmentOfPreset rdfs:label "is an assignment of the preset" .
+
+  sub:assertion a nt:AssertionTemplate;
+    dct:description """<p>Assign a <strong>preset</strong> (a named bundle of default views and roles) to a <strong>user</strong>, so that the user's page picks up the preset's views and roles.</p>
+
+<p>Only presets designed for users (<code>gen:appliesToInstancesOf gen:IndividualAgent</code>) are offered. Like view displays, a preset assignment is identified by the <em>(preset, resource)</em> pair rather than by this nanopublication's URI, so it can later be deactivated.</p>""";
+    rdfs:label "Assigning a preset to a user";
+    nt:hasNanopubLabelPattern "${resource} uses preset: ${preset}";
+    nt:hasStatement sub:st10, sub:st12, sub:st20, sub:st30;
+    nt:hasTag "Spaces" .
+
+  sub:assignment a nt:EmbeddedResource, nt:LocalResource;
+    rdfs:label "this" .
+
+  sub:assignmentMode a nt:RestrictedChoicePlaceholder;
+    rdfs:label "select whether this assignment is activated or deactivated";
+    nt:hasDefaultValue gen:ActivatedPresetAssignment;
+    nt:possibleValue gen:ActivatedPresetAssignment, gen:DeactivatedPresetAssignment .
+
+  sub:preset a nt:GuidedChoicePlaceholder;
+    rdfs:label "choose the preset";
+    nt:possibleValuesFromApi "https://w3id.org/np/l/nanopub-query-1.1/api/RASzbAAibVFh25rujZN2MwgyUB7zHogsxo7-UgI05Dotg/find-presets?appliedPresetClass=https://w3id.org/kpxl/gen/terms/IndividualAgent" .
+
+  sub:resource a nt:AgentPlaceholder;
+    rdfs:label "choose the user" .
+
+  sub:st10 rdf:object gen:PresetAssignment;
+    rdf:predicate rdf:type;
+    rdf:subject sub:assignment .
+
+  sub:st12 a nt:AdvancedStatement;
+    rdf:object sub:assignmentMode;
+    rdf:predicate rdf:type;
+    rdf:subject sub:assignment .
+
+  sub:st20 rdf:object sub:preset;
+    rdf:predicate gen:isAssignmentOfPreset;
+    rdf:subject sub:assignment .
+
+  sub:st30 rdf:object sub:resource;
+    rdf:predicate gen:isAssignmentFor;
+    rdf:subject sub:assignment .
+}
+
+sub:provenance {
+  sub:assertion prov:wasAttributedTo orcid:0000-0002-1267-0234 .
+}
+
+sub:pubinfo {
+  orcid:0000-0002-1267-0234 foaf:name "Tobias Kuhn" .
+
+  this: dct:created "2026-06-19T13:18:21Z"^^xsd:dateTime;
+    dct:creator orcid:0000-0002-1267-0234;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    rdfs:label "Assigning a preset to a user" .
+}

--- a/docs/queries/find-presets.trig
+++ b/docs/queries/find-presets.trig
@@ -1,0 +1,63 @@
+@prefix this: <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
+@prefix sub: <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
+@prefix np: <http://www.nanopub.org/nschema#> .
+@prefix grlc: <https://w3id.org/kpxl/grlc/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix npx: <http://purl.org/nanopub/x/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix orcid: <https://orcid.org/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+sub:Head {
+  this: a np:Nanopublication;
+    np:hasAssertion sub:assertion;
+    np:hasProvenance sub:provenance;
+    np:hasPublicationInfo sub:pubinfo .
+}
+
+sub:assertion {
+  sub:find-presets a grlc:grlc-query;
+    dct:description "Finds presets (gen:Preset) by a text query for auto-complete lookup, restricted to those designed for a given entity type — i.e. whose gen:appliesToInstancesOf matches the passed appliedPresetClass. Mirrors find-views, for presets.";
+    dct:license <http://www.apache.org/licenses/LICENSE-2.0>;
+    rdfs:label "Find presets";
+    grlc:endpoint <https://w3id.org/np/l/nanopub-query-1.1/repo/full>;
+    grlc:sparql """prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix np: <http://www.nanopub.org/nschema#>
+prefix npa: <http://purl.org/nanopub/admin/>
+prefix npx: <http://purl.org/nanopub/x/>
+prefix dct: <http://purl.org/dc/terms/>
+prefix gen: <https://w3id.org/kpxl/gen/terms/>
+
+select distinct ?thing ?label ?description ?np ?pubkey ?date where {
+  graph npa:graph {
+    ?np npx:hasNanopubType gen:Preset .
+    ?np npa:hasValidSignatureForPublicKey ?pubkey .
+    filter not exists { ?npx npx:invalidates ?np ; npa:hasValidSignatureForPublicKey ?pubkey . }
+    ?np dct:created ?date .
+    ?np npx:embeds ?thing .
+    ?np rdfs:label ?label .
+    optional { ?np dct:description ?description . }
+    filter(contains(lcase(?label), lcase(?_query)))
+    ?np np:hasAssertion ?a .
+  }
+  graph ?a {
+    ?thing gen:appliesToInstancesOf ?__appliedPresetClass_iri .
+  }
+}
+limit 10""" .
+}
+
+sub:provenance {
+  sub:assertion prov:wasAttributedTo orcid:0000-0002-1267-0234 .
+}
+
+sub:pubinfo {
+  orcid:0000-0002-1267-0234 foaf:name "Tobias Kuhn" .
+
+  this: dct:created "2026-06-19T13:18:21Z"^^xsd:dateTime;
+    dct:creator orcid:0000-0002-1267-0234;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    npx:embeds sub:find-presets .
+}

--- a/docs/queries/list-part-view-displays.trig
+++ b/docs/queries/list-part-view-displays.trig
@@ -1,7 +1,6 @@
 @prefix this: <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
 @prefix sub: <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
 @prefix np: <http://www.nanopub.org/nschema#> .
-@prefix grlc: <https://w3id.org/kpxl/grlc/> .
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix npx: <http://purl.org/nanopub/x/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
@@ -9,65 +8,60 @@
 @prefix orcid: <https://orcid.org/> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
-sub:Head { this: a np:Nanopublication; np:hasAssertion sub:assertion; np:hasProvenance sub:provenance; np:hasPublicationInfo sub:pubinfo . }
+
+sub:Head {
+  this: a np:Nanopublication;
+    np:hasAssertion sub:assertion;
+    np:hasProvenance sub:provenance;
+    np:hasPublicationInfo sub:pubinfo .
+}
+
 sub:assertion {
-  sub:list-view-displays a grlc:grlc-query;
-    dct:description "Ref-scoped view displays for a single space ref. Like list-view-displays but takes TWO inputs: the space IRI (resource) and the ref's root nanopub (root_np). The authority gate is scoped to admins/maintainers of THAT ref (npa:forSpaceRef resolved from root_np) rather than the space IRI merged across all its refs. Both inputs are concrete (VALUES) so federation bindings propagate (a single auto-detecting param can't: a service-derived resource IRI does not push into the federated SERVICE blocks). Space-only companion to list-view-displays; same columns. Regenerate from the latest list-view-displays by adding the root_np VALUES, the ?passedRef npa:rootNanopub resolution, and npa:forSpaceRef ?passedRef on the gate's RoleInstantiation.";
+  sub:list-part-view-displays a <https://w3id.org/kpxl/grlc/grlc-query>;
+    dct:description "Lists, for a PART page (a resource viewed as a part of a maintained resource/space/user), the view displays configured on the part's owning resource, flagged for this specific part (read-only). Same display set and admin/maintainer authorization as list-view-displays, keyed on the owning resource (the 'resource' parameter): standalone view displays plus preset-contributed views, deactivations applied, each view resolved to its latest version. The displayed_here column is a flag (check mark, else blank) indicating whether the view is shown on THIS part -- i.e. its appliesToInstancesOf matches one of the part's own classes (the 'partclass' multi-valued parameter), or it is pinned to the part via gen:appliesTo, or its namespace targeting covers the part's IRI (the 'partid' parameter). A hasTopLevelView preset is pinned to the owning resource's own page and is therefore never shown on a part (blank); a hasView preset falls back to the view's own targeting. For blank (not-shown) rows the target_multi_iri column lists the class(es)/namespace(s) the view targets. Rows are ordered shown-here first, then by structural position.";
     dct:license <http://www.apache.org/licenses/LICENSE-2.0>;
-    rdfs:label "List view displays (ref-scoped)";
-    grlc:endpoint <https://w3id.org/np/l/nanopub-query-1.1/repo/type/11daee46fdfff957dc17b46f5dc1a618045afd4f5634d5334ce9db19c3689a3c>;
-    grlc:sparql """prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+    rdfs:label "List part view displays";
+    <https://w3id.org/kpxl/grlc/endpoint> <https://w3id.org/np/l/nanopub-query-1.1/repo/type/11daee46fdfff957dc17b46f5dc1a618045afd4f5634d5334ce9db19c3689a3c>;
+    <https://w3id.org/kpxl/grlc/sparql> """prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 prefix dct: <http://purl.org/dc/terms/>
 prefix np: <http://www.nanopub.org/nschema#>
 prefix npa: <http://purl.org/nanopub/admin/>
 prefix npx: <http://purl.org/nanopub/x/>
 prefix gen: <https://w3id.org/kpxl/gen/terms/>
 
-select ?view
-       (sample(?view_label) as ?view_label)
-       (sample(?displayed_here) as ?displayed_here)
-       (sample(?position) as ?position)
-       (sample(?via_preset) as ?via_preset)
-       (sample(?via_preset_label) as ?via_preset_label)
-       (sample(?added_by) as ?added_by)
-       (max(?date_added) as ?date_added)
-       (iri(strafter(max(concat(str(?date_added), \"\\\\t\", str(?np))), \"\\\\t\")) as ?np)
-       (\"^\" as ?np_label) where {
 select ?view ?view_label ?displayed_here ?position
        (if(?displayed_here = \"\", ?target_multi_iri_raw, \"\") as ?target_multi_iri)
        (if(?displayed_here = \"\", ?target_label_multi_raw, \"\") as ?target_label_multi)
-       ?via_preset ?via_preset_label ?added_by ?date_added ?deactivateView ?np ?np_label
+       ?via_preset ?via_preset_label ?added_by ?date_added ?np ?np_label
 where {
  select ?view ?view_label ?position
        (if(bound(?presetScope), ?presetScope,
          if(bound(?preset),
-            if(?aVHasTarget > 0, if(?aVMatch > 0, \"✓\", \"\"), \"✓\"),
+            if(?aVHasTarget > 0, if(?aVMatch > 0, \"✓\", \"\"), \"\"),
           if(?aDApplyHere > 0, \"✓\",
            if(?aDHasTarget > 0, if(?aDMatch > 0, \"✓\", \"\"),
             if(?aDHasApply > 0, \"\",
-             if(?aVHasTarget > 0, if(?aVMatch > 0, \"✓\", \"\"), \"✓\")))))) as ?displayed_here)
+             if(?aVHasTarget > 0, if(?aVMatch > 0, \"✓\", \"\"), \"\")))))) as ?displayed_here)
        ?target_multi_iri_raw ?target_label_multi_raw
        (?preset as ?via_preset) (?preset_label as ?via_preset_label)
        (?user as ?added_by) (?date as ?date_added)
-       ?deactivateView ?np (\"^\" as ?np_label) where {
-  select ?view ?view_label ?position ?preset ?preset_label ?presetScope ?user ?date ?deactivateView ?np
+       ?np (\"^\" as ?np_label) where {
+  select ?view ?view_label ?position ?preset ?preset_label ?presetScope ?user ?date ?np
          (max(?fDApplyHere) as ?aDApplyHere) (max(?fDHasApply) as ?aDHasApply) (max(?fDHasTarget) as ?aDHasTarget)
          (max(?fDMatch) as ?aDMatch) (max(?fVHasTarget) as ?aVHasTarget) (max(?fVMatch) as ?aVMatch)
          (group_concat(distinct ?targetIri; separator=\" \") as ?target_multi_iri_raw)
-         (group_concat(distinct ?targetLabel; separator=\"\\\\n\") as ?target_label_multi_raw)
+         (group_concat(distinct ?targetLabel; separator=\"\\n\") as ?target_label_multi_raw)
   where {
   {
     select ?_resource_multi_iri ?viewRef ?viewLatest ?view_label ?position ?preset ?preset_label ?presetScope ?user ?date ?np
-           ?ownClass ?dApply ?dTarget ?vTarget where {
+           ?dApply ?dTarget ?vTarget where {
       values ?_resource_multi_iri {}
-      values ?_root_np_multi_iri {}
       service <https://w3id.org/np/l/nanopub-query-1.1/repo/spaces> {
         graph npa:graph { npa:thisRepo npa:hasCurrentSpaceState ?stateG . }
-        graph npa:spacesGraph { ?passedRef npa:rootNanopub ?_root_np_multi_iri . }
         {
           graph ?stateG {
             ?_resource_multi_iri npa:isMaintainedBy? ?space .
-            ?ri a gen:RoleInstantiation ; npa:forSpace ?space ; npa:forSpaceRef ?passedRef ; npa:forAgent ?authAgent ;
+            ?ri a gen:RoleInstantiation ; npa:forSpace ?space ; npa:forAgent ?authAgent ;
                 (npa:inverseProperty|npa:regularProperty) ?roleProp .
             ?authAcct a npa:AccountState ; npa:agent ?authAgent ; npa:pubkey ?pubkey .
           }
@@ -83,9 +77,6 @@ where {
         } union {
           graph ?stateG { ?selfAcct a npa:AccountState ; npa:agent ?_resource_multi_iri ; npa:pubkey ?pubkey . }
         }
-        bind(if(exists { graph ?stateG { ?_resource_multi_iri npa:isMaintainedBy ?anyMaintainer } }, gen:MaintainedResource,
-             if(exists { graph ?stateG { ?ownAcc a npa:AccountState ; npa:agent ?_resource_multi_iri } }, gen:IndividualAgent,
-             gen:Space)) as ?ownClass)
       }
       {
         graph npa:graph {
@@ -149,7 +140,7 @@ where {
             graph ?pa {
               ?preset a gen:Preset .
               optional { ?preset rdfs:label ?preset_label . }
-              { ?preset gen:hasTopLevelView ?viewRef . bind(\"✓\" as ?presetScope) }
+              { ?preset gen:hasTopLevelView ?viewRef . bind(\"\" as ?presetScope) }
               union { ?preset gen:hasView ?viewRef }
             }
           }
@@ -202,27 +193,36 @@ where {
       bind(coalesce(?dispPos, ?viewPos, \"\") as ?position)
     }
   }
-  bind(if(coalesce(str(?dApply) = str(?_resource_multi_iri), false), 1, 0) as ?fDApplyHere)
+  values ?__partclass_multi_iri {}
+  bind(if(coalesce(str(?dApply) = str(?_partid_iri), false), 1, 0) as ?fDApplyHere)
   bind(if(bound(?dApply), 1, 0) as ?fDHasApply)
   bind(if(bound(?dTarget), 1, 0) as ?fDHasTarget)
-  bind(if(coalesce(str(?dTarget) = str(?ownClass), false) || coalesce(strstarts(str(?_resource_multi_iri), str(?dTarget)), false), 1, 0) as ?fDMatch)
+  bind(if(coalesce(?dTarget = ?__partclass_multi_iri, false) || coalesce(strstarts(str(?_partid_iri), str(?dTarget)), false), 1, 0) as ?fDMatch)
   bind(if(bound(?vTarget), 1, 0) as ?fVHasTarget)
-  bind(if(coalesce(str(?vTarget) = str(?ownClass), false) || coalesce(strstarts(str(?_resource_multi_iri), str(?vTarget)), false), 1, 0) as ?fVMatch)
+  bind(if(coalesce(?vTarget = ?__partclass_multi_iri, false) || coalesce(strstarts(str(?_partid_iri), str(?vTarget)), false), 1, 0) as ?fVMatch)
   bind(coalesce(?dTarget, ?vTarget) as ?targetIri)
   bind(replace(str(?targetIri), \"^.*[/#]\", \"\") as ?targetLocalName)
   bind(if(coalesce(strlen(?targetLocalName) > 0, false), ?targetLocalName, str(?targetIri)) as ?targetLabel)
   bind(coalesce(?viewLatest, ?viewRef) as ?view)
-  bind(str(?viewRef) as ?deactivateView)
   }
-  group by ?view ?view_label ?position ?preset ?preset_label ?presetScope ?user ?date ?deactivateView ?np
+  group by ?view ?view_label ?position ?preset ?preset_label ?presetScope ?user ?date ?np
  }
 }
+order by desc(?displayed_here) ?position desc(?date_added)""" .
 }
-group by ?view
-order by desc(?displayed_here) ?position""" .
+
+sub:provenance {
+  sub:assertion prov:wasAttributedTo orcid:0000-0002-1267-0234 .
 }
-sub:provenance { sub:assertion prov:wasAttributedTo orcid:0000-0002-1267-0234 . }
+
 sub:pubinfo {
   orcid:0000-0002-1267-0234 foaf:name "Tobias Kuhn" .
-  this: dct:created "2026-06-19T13:58:40Z"^^xsd:dateTime; dct:creator orcid:0000-0002-1267-0234; dct:license <https://creativecommons.org/licenses/by/4.0/>; npx:embeds sub:list-view-displays; npx:supersedes <https://w3id.org/np/RAKfr2_TxPCXE-u-Ol0UDb2-8U8sej8aqKhD32EtDTob0> .
+  
+  this: dct:created "2026-06-19T13:59:59Z"^^xsd:dateTime;
+    dct:creator orcid:0000-0002-1267-0234;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    npx:embeds sub:list-part-view-displays;
+    npx:supersedes <https://w3id.org/np/RAPaHJiDMXHu8IAl21kd1b5uSXCRaLwCX9tRiVVlJFuHU>;
+    rdfs:label "List part view displays" .
 }
+

--- a/docs/queries/list-view-displays.trig
+++ b/docs/queries/list-view-displays.trig
@@ -1,7 +1,6 @@
 @prefix this: <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
 @prefix sub: <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
 @prefix np: <http://www.nanopub.org/nschema#> .
-@prefix grlc: <https://w3id.org/kpxl/grlc/> .
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix npx: <http://purl.org/nanopub/x/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
@@ -9,14 +8,21 @@
 @prefix orcid: <https://orcid.org/> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
-sub:Head { this: a np:Nanopublication; np:hasAssertion sub:assertion; np:hasProvenance sub:provenance; np:hasPublicationInfo sub:pubinfo . }
+
+sub:Head {
+  this: a np:Nanopublication;
+    np:hasAssertion sub:assertion;
+    np:hasProvenance sub:provenance;
+    np:hasPublicationInfo sub:pubinfo .
+}
+
 sub:assertion {
-  sub:list-view-displays a grlc:grlc-query;
-    dct:description "Ref-scoped view displays for a single space ref. Like list-view-displays but takes TWO inputs: the space IRI (resource) and the ref's root nanopub (root_np). The authority gate is scoped to admins/maintainers of THAT ref (npa:forSpaceRef resolved from root_np) rather than the space IRI merged across all its refs. Both inputs are concrete (VALUES) so federation bindings propagate (a single auto-detecting param can't: a service-derived resource IRI does not push into the federated SERVICE blocks). Space-only companion to list-view-displays; same columns. Regenerate from the latest list-view-displays by adding the root_np VALUES, the ?passedRef npa:rootNanopub resolution, and npa:forSpaceRef ?passedRef on the gate's RoleInstantiation.";
+  sub:list-view-displays a <https://w3id.org/kpxl/grlc/grlc-query>;
+    dct:description "Lists the currently active view displays of a resource for the About page (standalone + preset-contributed, deactivations applied, latest version, one row per resolved view keeping the latest). displayed_here flags whether the view is shown on this resource's own page. Ordered shown-here first, then by structural position.";
     dct:license <http://www.apache.org/licenses/LICENSE-2.0>;
-    rdfs:label "List view displays (ref-scoped)";
-    grlc:endpoint <https://w3id.org/np/l/nanopub-query-1.1/repo/type/11daee46fdfff957dc17b46f5dc1a618045afd4f5634d5334ce9db19c3689a3c>;
-    grlc:sparql """prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+    rdfs:label "List view displays";
+    <https://w3id.org/kpxl/grlc/endpoint> <https://w3id.org/np/l/nanopub-query-1.1/repo/type/11daee46fdfff957dc17b46f5dc1a618045afd4f5634d5334ce9db19c3689a3c>;
+    <https://w3id.org/kpxl/grlc/sparql> """prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 prefix dct: <http://purl.org/dc/terms/>
 prefix np: <http://www.nanopub.org/nschema#>
 prefix npa: <http://purl.org/nanopub/admin/>
@@ -31,7 +37,7 @@ select ?view
        (sample(?via_preset_label) as ?via_preset_label)
        (sample(?added_by) as ?added_by)
        (max(?date_added) as ?date_added)
-       (iri(strafter(max(concat(str(?date_added), \"\\\\t\", str(?np))), \"\\\\t\")) as ?np)
+       (iri(strafter(max(concat(str(?date_added), \"\\t\", str(?np))), \"\\t\")) as ?np)
        (\"^\" as ?np_label) where {
 select ?view ?view_label ?displayed_here ?position
        (if(?displayed_here = \"\", ?target_multi_iri_raw, \"\") as ?target_multi_iri)
@@ -54,20 +60,18 @@ where {
          (max(?fDApplyHere) as ?aDApplyHere) (max(?fDHasApply) as ?aDHasApply) (max(?fDHasTarget) as ?aDHasTarget)
          (max(?fDMatch) as ?aDMatch) (max(?fVHasTarget) as ?aVHasTarget) (max(?fVMatch) as ?aVMatch)
          (group_concat(distinct ?targetIri; separator=\" \") as ?target_multi_iri_raw)
-         (group_concat(distinct ?targetLabel; separator=\"\\\\n\") as ?target_label_multi_raw)
+         (group_concat(distinct ?targetLabel; separator=\"\\n\") as ?target_label_multi_raw)
   where {
   {
     select ?_resource_multi_iri ?viewRef ?viewLatest ?view_label ?position ?preset ?preset_label ?presetScope ?user ?date ?np
            ?ownClass ?dApply ?dTarget ?vTarget where {
       values ?_resource_multi_iri {}
-      values ?_root_np_multi_iri {}
       service <https://w3id.org/np/l/nanopub-query-1.1/repo/spaces> {
         graph npa:graph { npa:thisRepo npa:hasCurrentSpaceState ?stateG . }
-        graph npa:spacesGraph { ?passedRef npa:rootNanopub ?_root_np_multi_iri . }
         {
           graph ?stateG {
             ?_resource_multi_iri npa:isMaintainedBy? ?space .
-            ?ri a gen:RoleInstantiation ; npa:forSpace ?space ; npa:forSpaceRef ?passedRef ; npa:forAgent ?authAgent ;
+            ?ri a gen:RoleInstantiation ; npa:forSpace ?space ; npa:forAgent ?authAgent ;
                 (npa:inverseProperty|npa:regularProperty) ?roleProp .
             ?authAcct a npa:AccountState ; npa:agent ?authAgent ; npa:pubkey ?pubkey .
           }
@@ -221,8 +225,19 @@ where {
 group by ?view
 order by desc(?displayed_here) ?position""" .
 }
-sub:provenance { sub:assertion prov:wasAttributedTo orcid:0000-0002-1267-0234 . }
+
+sub:provenance {
+  sub:assertion prov:wasAttributedTo orcid:0000-0002-1267-0234 .
+}
+
 sub:pubinfo {
   orcid:0000-0002-1267-0234 foaf:name "Tobias Kuhn" .
-  this: dct:created "2026-06-19T13:58:40Z"^^xsd:dateTime; dct:creator orcid:0000-0002-1267-0234; dct:license <https://creativecommons.org/licenses/by/4.0/>; npx:embeds sub:list-view-displays; npx:supersedes <https://w3id.org/np/RAKfr2_TxPCXE-u-Ol0UDb2-8U8sej8aqKhD32EtDTob0> .
+  
+  this: dct:created "2026-06-19T14:01:16Z"^^xsd:dateTime;
+    dct:creator orcid:0000-0002-1267-0234;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    npx:embeds sub:list-view-displays;
+    npx:supersedes <https://w3id.org/np/RAdWeDNFHaMMxJ5RVKtSPdj_0wQHfdicHd0YDnX1X7nSM>;
+    rdfs:label "List view displays" .
 }
+

--- a/docs/queries/maintained-resource-preset-assignments-view.trig
+++ b/docs/queries/maintained-resource-preset-assignments-view.trig
@@ -1,0 +1,62 @@
+@prefix this: <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
+@prefix sub: <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
+@prefix gen: <https://w3id.org/kpxl/gen/terms/> .
+@prefix np: <http://www.nanopub.org/nschema#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix npx: <http://purl.org/nanopub/x/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix orcid: <https://orcid.org/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+sub:Head {
+  this: a np:Nanopublication;
+    np:hasAssertion sub:assertion;
+    np:hasProvenance sub:provenance;
+    np:hasPublicationInfo sub:pubinfo .
+}
+
+sub:assertion {
+  sub:add-preset-action a gen:ViewResultAction;
+    rdfs:label "➕ add preset";
+    gen:hasActionTemplate <https://w3id.org/np/RAwpNZMM1Bgppqam84yXsIYvt8aLCPP2KNB8J8KSGU4Qo>;
+    gen:hasActionTemplatePartField "void";
+    gen:hasActionTemplateQueryMapping "void";
+    gen:hasActionTemplateTargetField "resource";
+    gen:isVisibleTo gen:MaintainerRole .
+
+  sub:deactivate-action a gen:ViewEntryAction;
+    rdfs:label "❌ deactivate";
+    gen:hasActionTemplate <https://w3id.org/np/RAFzdaAgvIUvpzMz98mlyO__xETbCxdMY_Dj4G9aZYO_Q>;
+    gen:hasActionTemplatePartField "void";
+    gen:hasActionTemplateQueryMapping "deactivatePreset:preset";
+    gen:hasActionTemplateTargetField "resource";
+    gen:isVisibleTo gen:MaintainerRole .
+
+  sub:preset-assignments-view a gen:ResourceView, gen:TabularView;
+    dct:isVersionOf sub:maintained-resource-preset-assignments-view-kind;
+    dct:title "🪟 Assigned presets";
+    rdfs:label "Assigned presets view (maintained resource)";
+    gen:appliesToInstancesOf gen:MaintainedResource;
+    gen:hasDisplayWidth gen:ColumnWidth06of12;
+    gen:hasStructuralPosition "5.4.presets";
+    gen:hasViewAction sub:add-preset-action, sub:deactivate-action;
+    gen:hasViewQuery <https://w3id.org/np/RAZYHKDeAsHTPN5IsXNKa0rZwmhiWklXcnxOU7IBS4vtk/list-preset-assignments>;
+    gen:hasViewQueryTargetField "resource" .
+}
+
+sub:provenance {
+  sub:assertion prov:wasAttributedTo orcid:0000-0002-1267-0234 .
+}
+
+sub:pubinfo {
+  orcid:0000-0002-1267-0234 foaf:name "Tobias Kuhn" .
+
+  this: dct:created "2026-06-19T13:18:21Z"^^xsd:dateTime;
+    dct:creator orcid:0000-0002-1267-0234;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    npx:embeds sub:preset-assignments-view;
+    npx:introduces sub:maintained-resource-preset-assignments-view-kind;
+    rdfs:label "Assigned presets view (maintained resource)" .
+}

--- a/docs/queries/part-view-displays-view.trig
+++ b/docs/queries/part-view-displays-view.trig
@@ -1,0 +1,52 @@
+@prefix this: <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
+@prefix sub: <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
+@prefix gen: <https://w3id.org/kpxl/gen/terms/> .
+@prefix np: <http://www.nanopub.org/nschema#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix npx: <http://purl.org/nanopub/x/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix orcid: <https://orcid.org/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+sub:Head {
+  this: a np:Nanopublication;
+    np:hasAssertion sub:assertion;
+    np:hasProvenance sub:provenance;
+    np:hasPublicationInfo sub:pubinfo .
+}
+
+sub:assertion {
+  sub:add-view-display-action a gen:ViewResultAction;
+    rdfs:label "➕ add view display";
+    gen:hasActionTemplate <https://w3id.org/np/RAe0zantvnJlVWIC2LueG1IAMktXGFIqCdWliok1rOrmU>;
+    gen:hasActionTemplatePartField "void";
+    gen:hasActionTemplateQueryMapping "void";
+    gen:hasActionTemplateTargetField "resource";
+    gen:isVisibleTo gen:MaintainerRole .
+
+  sub:part-view-displays-view a gen:ResourceView, gen:TabularView;
+    dct:isVersionOf sub:part-view-displays-view-kind;
+    dct:title "⬜ View displays";
+    rdfs:label "Part view displays view";
+    gen:appliesToInstancesOf gen:MaintainedResource;
+    gen:hasViewAction sub:add-view-display-action;
+    gen:hasViewQuery <https://w3id.org/np/RAPaHJiDMXHu8IAl21kd1b5uSXCRaLwCX9tRiVVlJFuHU/list-part-view-displays>;
+    gen:hasViewQueryTargetField "resource" .
+}
+
+sub:provenance {
+  sub:assertion prov:wasAttributedTo orcid:0000-0002-1267-0234 .
+}
+
+sub:pubinfo {
+  orcid:0000-0002-1267-0234 foaf:name "Tobias Kuhn" .
+
+  this: dct:created "2026-06-19T13:37:28Z"^^xsd:dateTime;
+    dct:creator orcid:0000-0002-1267-0234;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    npx:embeds sub:part-view-displays-view;
+    npx:introduces sub:part-view-displays-view-kind;
+    rdfs:label "Part view displays view" .
+}

--- a/docs/queries/space-preset-assignments-view.trig
+++ b/docs/queries/space-preset-assignments-view.trig
@@ -1,0 +1,62 @@
+@prefix this: <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
+@prefix sub: <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
+@prefix gen: <https://w3id.org/kpxl/gen/terms/> .
+@prefix np: <http://www.nanopub.org/nschema#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix npx: <http://purl.org/nanopub/x/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix orcid: <https://orcid.org/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+sub:Head {
+  this: a np:Nanopublication;
+    np:hasAssertion sub:assertion;
+    np:hasProvenance sub:provenance;
+    np:hasPublicationInfo sub:pubinfo .
+}
+
+sub:assertion {
+  sub:add-preset-action a gen:ViewResultAction;
+    rdfs:label "➕ add preset";
+    gen:hasActionTemplate <https://w3id.org/np/RAI5NAXRmn5qdjgNnwVO_iLn4Um2mOGluILtRfRPz-rAM>;
+    gen:hasActionTemplatePartField "void";
+    gen:hasActionTemplateQueryMapping "void";
+    gen:hasActionTemplateTargetField "resource";
+    gen:isVisibleTo gen:MaintainerRole .
+
+  sub:deactivate-action a gen:ViewEntryAction;
+    rdfs:label "❌ deactivate";
+    gen:hasActionTemplate <https://w3id.org/np/RAFzdaAgvIUvpzMz98mlyO__xETbCxdMY_Dj4G9aZYO_Q>;
+    gen:hasActionTemplatePartField "void";
+    gen:hasActionTemplateQueryMapping "deactivatePreset:preset";
+    gen:hasActionTemplateTargetField "resource";
+    gen:isVisibleTo gen:MaintainerRole .
+
+  sub:preset-assignments-view a gen:ResourceView, gen:TabularView;
+    dct:isVersionOf sub:space-preset-assignments-view-kind;
+    dct:title "🪟 Assigned presets";
+    rdfs:label "Assigned presets view (space)";
+    gen:appliesToInstancesOf gen:Space;
+    gen:hasDisplayWidth gen:ColumnWidth06of12;
+    gen:hasStructuralPosition "5.4.presets";
+    gen:hasViewAction sub:add-preset-action, sub:deactivate-action;
+    gen:hasViewQuery <https://w3id.org/np/RAZYHKDeAsHTPN5IsXNKa0rZwmhiWklXcnxOU7IBS4vtk/list-preset-assignments>;
+    gen:hasViewQueryTargetField "resource" .
+}
+
+sub:provenance {
+  sub:assertion prov:wasAttributedTo orcid:0000-0002-1267-0234 .
+}
+
+sub:pubinfo {
+  orcid:0000-0002-1267-0234 foaf:name "Tobias Kuhn" .
+
+  this: dct:created "2026-06-19T13:18:21Z"^^xsd:dateTime;
+    dct:creator orcid:0000-0002-1267-0234;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    npx:embeds sub:preset-assignments-view;
+    npx:introduces sub:space-preset-assignments-view-kind;
+    rdfs:label "Assigned presets view (space)" .
+}

--- a/docs/queries/user-preset-assignments-view.trig
+++ b/docs/queries/user-preset-assignments-view.trig
@@ -1,0 +1,62 @@
+@prefix this: <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
+@prefix sub: <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
+@prefix gen: <https://w3id.org/kpxl/gen/terms/> .
+@prefix np: <http://www.nanopub.org/nschema#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix npx: <http://purl.org/nanopub/x/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix orcid: <https://orcid.org/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+sub:Head {
+  this: a np:Nanopublication;
+    np:hasAssertion sub:assertion;
+    np:hasProvenance sub:provenance;
+    np:hasPublicationInfo sub:pubinfo .
+}
+
+sub:assertion {
+  sub:add-preset-action a gen:ViewResultAction;
+    rdfs:label "➕ add preset";
+    gen:hasActionTemplate <https://w3id.org/np/RAEKxVpk1FHItIKnTCAwfAqwmuM9FUCw7HKlIyzUB2oSc>;
+    gen:hasActionTemplatePartField "void";
+    gen:hasActionTemplateQueryMapping "void";
+    gen:hasActionTemplateTargetField "resource";
+    gen:isVisibleTo gen:MaintainerRole .
+
+  sub:deactivate-action a gen:ViewEntryAction;
+    rdfs:label "❌ deactivate";
+    gen:hasActionTemplate <https://w3id.org/np/RAFzdaAgvIUvpzMz98mlyO__xETbCxdMY_Dj4G9aZYO_Q>;
+    gen:hasActionTemplatePartField "void";
+    gen:hasActionTemplateQueryMapping "deactivatePreset:preset";
+    gen:hasActionTemplateTargetField "resource";
+    gen:isVisibleTo gen:MaintainerRole .
+
+  sub:preset-assignments-view a gen:ResourceView, gen:TabularView;
+    dct:isVersionOf sub:user-preset-assignments-view-kind;
+    dct:title "🪟 Assigned presets";
+    rdfs:label "Assigned presets view (user)";
+    gen:appliesToInstancesOf gen:IndividualAgent;
+    gen:hasDisplayWidth gen:ColumnWidth06of12;
+    gen:hasStructuralPosition "5.4.presets";
+    gen:hasViewAction sub:add-preset-action, sub:deactivate-action;
+    gen:hasViewQuery <https://w3id.org/np/RAZYHKDeAsHTPN5IsXNKa0rZwmhiWklXcnxOU7IBS4vtk/list-preset-assignments>;
+    gen:hasViewQueryTargetField "resource" .
+}
+
+sub:provenance {
+  sub:assertion prov:wasAttributedTo orcid:0000-0002-1267-0234 .
+}
+
+sub:pubinfo {
+  orcid:0000-0002-1267-0234 foaf:name "Tobias Kuhn" .
+
+  this: dct:created "2026-06-19T13:18:21Z"^^xsd:dateTime;
+    dct:creator orcid:0000-0002-1267-0234;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    npx:embeds sub:preset-assignments-view;
+    npx:introduces sub:user-preset-assignments-view-kind;
+    rdfs:label "Assigned presets view (user)" .
+}

--- a/src/main/java/com/knowledgepixels/nanodash/QueryApiAccess.java
+++ b/src/main/java/com/knowledgepixels/nanodash/QueryApiAccess.java
@@ -195,7 +195,19 @@ public class QueryApiAccess {
     // AboutSpacePanel with both params; falls back to the IRI-keyed query when the ref root is
     // unknown. Source at docs/queries/list-view-displays-ref.trig (regenerate from the latest
     // list-view-displays by adding the root_np VALUES + ?passedRef resolution + forSpaceRef gate).
-    public static final String LIST_VIEW_DISPLAYS_REF = "RAKfr2_TxPCXE-u-Ol0UDb2-8U8sej8aqKhD32EtDTob0/list-view-displays";
+    // RAPTW1r (supersedes RAKfr2) renames the ?shown_here column to ?displayed_here.
+    public static final String LIST_VIEW_DISPLAYS_REF = "RAPTW1rmsOd0XOYdYO1cXU0aXGaxFYsSJykJWSoDf1uqw/list-view-displays";
+
+    // IRI-keyed view-displays listing (resource param), used for users / maintained resources and
+    // the space ref-less fallback. Like LIST_VIEW_DISPLAYS_REF it carries a ?displayed_here flag
+    // (✓ when the display applies to the resource itself, blank for part-level displays).
+    // RAxKzcn supersedes the list-view-displays head RAdWeDNF (renames ?shown_here → ?displayed_here).
+    public static final String LIST_VIEW_DISPLAYS = "RAxKzcnWKNa_ufbAR_v2P8_eefeOIoEmRzKuEA9sm0IIQ/list-view-displays";
+
+    // Part view-displays listing (resource + partid + partclass): the owning resource's displays,
+    // each ?displayed_here-flagged for the specific part. RAMy6Nu supersedes RAPaHJiD (renames
+    // ?shown_here → ?displayed_here).
+    public static final String LIST_PART_VIEW_DISPLAYS = "RAMy6Nufw1pXjtI4SuxFNxLl_6s7-18rFi5jyJ1no5a5A/list-part-view-displays";
 
     // Ref-scoped preset-assignment listing (root_np): reads the server-materialised
     // npa:PresetAssignment rows scoped by npa:forSpaceRef from the validated current space-state

--- a/src/main/java/com/knowledgepixels/nanodash/component/AboutPartPanel.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/AboutPartPanel.java
@@ -34,7 +34,7 @@ public class AboutPartPanel extends Panel {
      * The "⬜ View displays" view for a part: the owning resource's view displays,
      * each flagged for this specific part via the partid/partclass parameters.
      */
-    public static final String PART_VIEW_DISPLAYS_VIEW = "https://w3id.org/np/RAHPaxWXTO6Utt54oRFQqTjyGuk4w7y8IDZEsmNqeptwE/part-view-displays-view";
+    public static final String PART_VIEW_DISPLAYS_VIEW = "https://w3id.org/np/RACcSq7Rz961_1pIB0FYGRbVHAUiVCeXcJsqlCLs0TxpE/part-view-displays-view";
 
     /**
      * @param id          the Wicket markup id
@@ -67,8 +67,10 @@ public class AboutPartPanel extends Panel {
         add(QueryResultTableBuilder.create("info", new QueryRef(infoView.getQuery().getQueryId(), infoParams), new ViewDisplay(infoView)).resourceWithProfile(context).id(context.getId()).contextId(context.getId()).build());
 
         // Presets are assigned to the owning resource (a part has none of its own),
-        // so this lists the owning resource's presets.
-        View presetsView = View.get(AboutSpacePanel.PRESET_ASSIGNMENTS_VIEW);
+        // so this lists the owning resource's presets. Uses the maintained-resource preset
+        // view, so the "add preset" action links the maintained-resource template and
+        // pre-fills the owning resource IRI (id = context), not the part.
+        View presetsView = View.get(AboutResourcePanel.MAINTAINED_RESOURCE_PRESET_ASSIGNMENTS_VIEW);
         add(QueryResultTableBuilder.create("presets", new QueryRef(presetsView.getQuery().getQueryId(), "resource", context.getId()), new ViewDisplay(presetsView)).resourceWithProfile(context).id(context.getId()).contextId(context.getId()).build());
 
         // View displays: the owning resource's displays (resource = context, for the

--- a/src/main/java/com/knowledgepixels/nanodash/component/AboutPartPanel.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/AboutPartPanel.java
@@ -1,5 +1,6 @@
 package com.knowledgepixels.nanodash.component;
 
+import com.knowledgepixels.nanodash.QueryApiAccess;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 import com.knowledgepixels.nanodash.Utils;
@@ -17,7 +18,7 @@ import java.util.Set;
  * The "About" tab body for a resource part: an "ℹ️ Info" table (the part's type,
  * owning resource, and defining nanopub), the presets assigned to the part's
  * owning resource, and that resource's configured view displays each flagged
- * (shown_here) for this specific part (issue #302). The presets and view displays
+ * (displayed_here) for this specific part (issue #302). The presets and view displays
  * are inherited from the owning resource (a part has none of its own); the view
  * displays are managed on the owning resource, where part-level views live.
  */
@@ -74,7 +75,7 @@ public class AboutPartPanel extends Panel {
         add(QueryResultTableBuilder.create("presets", new QueryRef(presetsView.getQuery().getQueryId(), "resource", context.getId()), new ViewDisplay(presetsView)).resourceWithProfile(context).id(context.getId()).contextId(context.getId()).build());
 
         // View displays: the owning resource's displays (resource = context, for the
-        // display set + admin/maintainer auth), with shown_here computed for THIS part
+        // display set + admin/maintainer auth), with displayed_here computed for THIS part
         // (partid + the part's classes). id = context so the view's "add view display"
         // action creates a display on the owning resource (where part-level views live,
         // and so the new display appears in this list).
@@ -85,7 +86,7 @@ public class AboutPartPanel extends Panel {
         for (IRI partClass : partClasses) {
             vdParams.put("partclass", partClass.stringValue());
         }
-        add(QueryResultTableBuilder.create("viewdisplays", new QueryRef(vdView.getQuery().getQueryId(), vdParams), new ViewDisplay(vdView)).resourceWithProfile(context).id(context.getId()).contextId(context.getId()).build());
+        add(QueryResultTableBuilder.create("viewdisplays", new QueryRef(QueryApiAccess.LIST_PART_VIEW_DISPLAYS, vdParams), new ViewDisplay(vdView)).resourceWithProfile(context).id(context.getId()).contextId(context.getId()).build());
     }
 
 }

--- a/src/main/java/com/knowledgepixels/nanodash/component/AboutResourcePanel.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/AboutResourcePanel.java
@@ -28,6 +28,13 @@ public class AboutResourcePanel extends Panel {
     public static final String MAINTAINED_RESOURCE_VIEW_DISPLAYS_VIEW = "https://w3id.org/np/RAZOxROZRaxSeoeO05iI0tKpDIy2mEN3jlUuVIo0uZN1I/view-displays-view";
 
     /**
+     * View listing the presets assigned to a maintained resource. Mirrors the space
+     * preset-assignments view but its "add preset" action links the maintained-resource-specific
+     * template (offering only presets that apply to maintained resources).
+     */
+    public static final String MAINTAINED_RESOURCE_PRESET_ASSIGNMENTS_VIEW = "https://w3id.org/np/RA-CRSYJrYf-uaw1fip7hr_kdPqVb7_6dENwTPYQpikRY/preset-assignments-view";
+
+    /**
      * @param id       the Wicket markup id
      * @param resource the maintained resource whose About listings to render
      */
@@ -38,7 +45,7 @@ public class AboutResourcePanel extends Panel {
         View infoView = View.get(MAINTAINED_RESOURCE_INFO_VIEW);
         add(QueryResultTableBuilder.create("info", new QueryRef(infoView.getQuery().getQueryId(), "resource", resource.getId()), new ViewDisplay(infoView)).resourceWithProfile(resource).id(resource.getId()).contextId(resource.getId()).build());
 
-        View presetsView = View.get(AboutSpacePanel.PRESET_ASSIGNMENTS_VIEW);
+        View presetsView = View.get(MAINTAINED_RESOURCE_PRESET_ASSIGNMENTS_VIEW);
         add(QueryResultTableBuilder.create("presets", new QueryRef(presetsView.getQuery().getQueryId(), "resource", resource.getId()), new ViewDisplay(presetsView)).resourceWithProfile(resource).id(resource.getId()).contextId(resource.getId()).build());
 
         View vdView = View.get(MAINTAINED_RESOURCE_VIEW_DISPLAYS_VIEW);

--- a/src/main/java/com/knowledgepixels/nanodash/component/AboutResourcePanel.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/AboutResourcePanel.java
@@ -1,5 +1,6 @@
 package com.knowledgepixels.nanodash.component;
 
+import com.knowledgepixels.nanodash.QueryApiAccess;
 import com.knowledgepixels.nanodash.View;
 import com.knowledgepixels.nanodash.ViewDisplay;
 import com.knowledgepixels.nanodash.domain.MaintainedResource;
@@ -49,7 +50,7 @@ public class AboutResourcePanel extends Panel {
         add(QueryResultTableBuilder.create("presets", new QueryRef(presetsView.getQuery().getQueryId(), "resource", resource.getId()), new ViewDisplay(presetsView)).resourceWithProfile(resource).id(resource.getId()).contextId(resource.getId()).build());
 
         View vdView = View.get(MAINTAINED_RESOURCE_VIEW_DISPLAYS_VIEW);
-        add(QueryResultTableBuilder.create("viewdisplays", new QueryRef(vdView.getQuery().getQueryId(), "resource", resource.getId()), new ViewDisplay(vdView)).resourceWithProfile(resource).id(resource.getId()).contextId(resource.getId()).build());
+        add(QueryResultTableBuilder.create("viewdisplays", new QueryRef(QueryApiAccess.LIST_VIEW_DISPLAYS, "resource", resource.getId()), new ViewDisplay(vdView)).resourceWithProfile(resource).id(resource.getId()).contextId(resource.getId()).build());
     }
 
 }

--- a/src/main/java/com/knowledgepixels/nanodash/component/AboutSpacePanel.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/AboutSpacePanel.java
@@ -36,7 +36,7 @@ public class AboutSpacePanel extends Panel {
     /**
      * View listing the presets assigned to a resource (issue #302).
      */
-    public static final String PRESET_ASSIGNMENTS_VIEW = "https://w3id.org/np/RA1kCQYXscKPY_qDvQ-WAKhoVomrTQLSt91JSD4Y03CKI/preset-assignments-view";
+    public static final String PRESET_ASSIGNMENTS_VIEW = "https://w3id.org/np/RAhYRi-oLmLALs9HYunZu73cQSh6Z-eLP6QGlUkLMwSL0/preset-assignments-view";
 
     /**
      * View listing a space's assigned roles as a table (role, schema:name, and a

--- a/src/main/java/com/knowledgepixels/nanodash/component/AboutSpacePanel.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/AboutSpacePanel.java
@@ -150,7 +150,7 @@ public class AboutSpacePanel extends Panel {
             vdParams.put("root_np", refRoot);
             vdQuery = new QueryRef(QueryApiAccess.LIST_VIEW_DISPLAYS_REF, vdParams);
         } else {
-            vdQuery = new QueryRef(vdView.getQuery().getQueryId(), "resource", space.getId());
+            vdQuery = new QueryRef(QueryApiAccess.LIST_VIEW_DISPLAYS, "resource", space.getId());
         }
         add(QueryResultTableBuilder.create("viewdisplays", vdQuery, new ViewDisplay(vdView)).resourceWithProfile(space).id(space.getId()).contextId(space.getId()).refRoot(refRoot).build());
 

--- a/src/main/java/com/knowledgepixels/nanodash/component/AboutUserPanel.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/AboutUserPanel.java
@@ -1,5 +1,6 @@
 package com.knowledgepixels.nanodash.component;
 
+import com.knowledgepixels.nanodash.QueryApiAccess;
 import com.knowledgepixels.nanodash.View;
 import com.knowledgepixels.nanodash.ViewDisplay;
 import com.knowledgepixels.nanodash.domain.IndividualAgent;
@@ -74,7 +75,7 @@ public class AboutUserPanel extends Panel {
         add(QueryResultTableBuilder.create("presets", new QueryRef(presetsView.getQuery().getQueryId(), "resource", userIriString), new ViewDisplay(presetsView)).resourceWithProfile(IndividualAgent.get(userIriString)).id(userIriString).contextId(userIriString).build());
 
         View vdView = View.get(USER_VIEW_DISPLAYS_VIEW);
-        add(QueryResultTableBuilder.create("viewdisplays", new QueryRef(vdView.getQuery().getQueryId(), "resource", userIriString), new ViewDisplay(vdView)).resourceWithProfile(IndividualAgent.get(userIriString)).id(userIriString).contextId(userIriString).build());
+        add(QueryResultTableBuilder.create("viewdisplays", new QueryRef(QueryApiAccess.LIST_VIEW_DISPLAYS, "resource", userIriString), new ViewDisplay(vdView)).resourceWithProfile(IndividualAgent.get(userIriString)).id(userIriString).contextId(userIriString).build());
     }
 
 }

--- a/src/main/java/com/knowledgepixels/nanodash/component/AboutUserPanel.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/AboutUserPanel.java
@@ -34,6 +34,13 @@ public class AboutUserPanel extends Panel {
     public static final String USER_VIEW_DISPLAYS_VIEW = "https://w3id.org/np/RA1d1qBF8Fk-ZWKtNB-wZd56HrV0wdtJkw0wp58sHxM0E/view-displays-view";
 
     /**
+     * View listing the presets assigned to a user. Mirrors the space preset-assignments view
+     * but its "add preset" action links the user-specific template (offering only presets that
+     * apply to users).
+     */
+    public static final String USER_PRESET_ASSIGNMENTS_VIEW = "https://w3id.org/np/RAd0UM_ll5a7Ewpg2VT5azZ7lh3S-K2ASCOIk2AgKfAJY/preset-assignments-view";
+
+    /**
      * @param id            the Wicket markup id
      * @param userIriString the user IRI
      */
@@ -63,7 +70,7 @@ public class AboutUserPanel extends Panel {
                 .contextId(userIriString)
                 .build());
 
-        View presetsView = View.get(AboutSpacePanel.PRESET_ASSIGNMENTS_VIEW);
+        View presetsView = View.get(USER_PRESET_ASSIGNMENTS_VIEW);
         add(QueryResultTableBuilder.create("presets", new QueryRef(presetsView.getQuery().getQueryId(), "resource", userIriString), new ViewDisplay(presetsView)).resourceWithProfile(IndividualAgent.get(userIriString)).id(userIriString).contextId(userIriString).build());
 
         View vdView = View.get(USER_VIEW_DISPLAYS_VIEW);

--- a/src/main/java/com/knowledgepixels/nanodash/page/ResourcePartPage.html
+++ b/src/main/java/com/knowledgepixels/nanodash/page/ResourcePartPage.html
@@ -15,8 +15,6 @@
     <div class="col-12 header">
       <h2><span wicket:id="name">ABC</span><span class="title-suffix" wicket:id="titlesuffix"></span></h2>
       <p><span wicket:id="id"></span></p>
-      <p wicket:id="description">Description...</p>
-      <p><a wicket:id="addviewdisplay" class="button">+ view display</a></p>
     </div>
   </div>
 

--- a/src/main/java/com/knowledgepixels/nanodash/page/ResourcePartPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/ResourcePartPage.java
@@ -3,13 +3,11 @@ package com.knowledgepixels.nanodash.page;
 import com.knowledgepixels.nanodash.ApiCache;
 import com.knowledgepixels.nanodash.NanodashPageRef;
 import com.knowledgepixels.nanodash.QueryApiAccess;
-import com.knowledgepixels.nanodash.SpaceMemberRole;
 import com.knowledgepixels.nanodash.Utils;
 import com.knowledgepixels.nanodash.component.*;
 import com.knowledgepixels.nanodash.domain.AbstractResourceWithProfile;
 import com.knowledgepixels.nanodash.domain.IndividualAgent;
 import com.knowledgepixels.nanodash.domain.MaintainedResource;
-import com.knowledgepixels.nanodash.domain.Space;
 import com.knowledgepixels.nanodash.domain.User;
 import com.knowledgepixels.nanodash.repository.MaintainedResourceRepository;
 import com.knowledgepixels.nanodash.repository.SpaceRepository;
@@ -23,10 +21,8 @@ import org.apache.wicket.request.mapper.parameter.PageParameters;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.util.Values;
-import org.eclipse.rdf4j.model.vocabulary.DCTERMS;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
-import org.eclipse.rdf4j.model.vocabulary.SKOS;
 import org.nanopub.Nanopub;
 import org.nanopub.extra.services.ApiResponse;
 import org.nanopub.extra.services.QueryRef;
@@ -66,7 +62,6 @@ public class ResourcePartPage extends NanodashPage {
         final String contextId = parameters.get("context").toString();
         final String nanopubId;
         String label = parameters.get("label").isEmpty() ? id.replaceFirst("^.*[#/]([^#/]+)$", "$1") : parameters.get("label").toString();
-        String description = null;
         Set<IRI> classes = new HashSet<>();
 
         resourceWithProfile = MaintainedResourceRepository.get().findById(contextId);
@@ -105,9 +100,6 @@ public class ResourcePartPage extends NanodashPage {
                 if (st.getPredicate().equals(RDFS.LABEL)) {
                     label = st.getObject().stringValue();
                 }
-                if (st.getPredicate().equals(SKOS.DEFINITION) || st.getPredicate().equals(DCTERMS.DESCRIPTION) || st.getPredicate().equals(RDFS.COMMENT)) {
-                    description = st.getObject().stringValue();
-                }
                 if (st.getPredicate().equals(RDF.TYPE) && st.getObject() instanceof IRI objIri) {
                     classes.add(objIri);
                 }
@@ -118,12 +110,6 @@ public class ResourcePartPage extends NanodashPage {
 //        if (getDefResp == null || getDefResp.getData().isEmpty()) {
 //            throw new RestartResponseException(ExplorePage.class, parameters);
 //        }
-
-        if (description != null) {
-            add(new Label("description", description));
-        } else {
-            add(new Label("description").setVisible(false));
-        }
 
         List<NanodashPageRef> breadCrumb;
         if (resourceWithProfile.getSpace() != null) {
@@ -149,24 +135,6 @@ public class ResourcePartPage extends NanodashPage {
         add(new Label("titlesuffix", ResourceTabs.titleSuffix(activeTab)));
         add(new ExternalLinkWithActionsPanel("id", Model.of(id), Model.of(label), nanopubId == null ? Values.iri(id) : Values.iri(nanopubId)));
 
-        boolean showButton = false;
-        if (resourceWithProfile instanceof IndividualAgent ia) {
-            showButton = ia.isCurrentUser();
-        } else if (resourceWithProfile.getSpace() != null) {
-            showButton = SpaceMemberRole.isCurrentUserAdmin(resourceWithProfile.getSpace());
-        } else if (resourceWithProfile instanceof Space s) {
-            showButton = SpaceMemberRole.isCurrentUserAdmin(s);
-        }
-        add(new AddViewDisplayButton("addviewdisplay",
-                "https://w3id.org/np/RAZg-r7oQjVZ3Ewy7pUzd9eINl6fCa3HGclTsDeRag5to",
-                "latest",
-                resourceWithProfile.getId(),
-                resourceWithProfile.getId(),
-                new PageParameters()
-                        .set("part", id)
-                        .set("refresh-upon-publish", resourceWithProfile.getId())
-        ).setVisible(showButton));
-
         final String nanopubRef = nanopubId == null ? "x:" : nanopubId;
         WebMarkupContainer contentContainer = new WebMarkupContainer("contentContainer");
         add(contentContainer);
@@ -176,7 +144,7 @@ public class ResourcePartPage extends NanodashPage {
             // aren't freshly cached, which would block the initial page render; the
             // view-id list must mirror the panel's View.get calls.
             add(LazyContentPanel.of("otherTab", markupId -> new AboutPartPanel(markupId, resourceWithProfile, id, classes),
-                    AboutPartPanel.PART_INFO_VIEW, AboutSpacePanel.PRESET_ASSIGNMENTS_VIEW, AboutPartPanel.PART_VIEW_DISPLAYS_VIEW));
+                    AboutPartPanel.PART_INFO_VIEW, AboutResourcePanel.MAINTAINED_RESOURCE_PRESET_ASSIGNMENTS_VIEW, AboutPartPanel.PART_VIEW_DISPLAYS_VIEW));
         } else if (activeTab == ResourceTabs.Tab.EXPLORE) {
             contentContainer.setVisible(false);
             // The panel constructor resolves a view nanopub over the network when


### PR DESCRIPTION
Full parity with the per-type view-display split, for **preset assignments**: the "➕ add preset" action on a Space / User / Maintained-resource About tab now offers only presets actually **designed for that entity type** (`gen:appliesToInstancesOf`).

### Mechanism
Mirrors how the view-display pickers filter views: a type-parameterized finder query feeds each per-type template's choice placeholder. Presets already declare `gen:appliesToInstancesOf` (e.g. `test-preset → gen:Space`), so the filtering is real.

### What's added
- **`find-presets`** query (clone of `find-views`, for `gen:Preset`), filtered by `appliedPresetClass` → the preset's `gen:appliesToInstancesOf`. `RASzbAAib…`
- **Three per-type add-preset templates** — preset picker → `find-presets?appliedPresetClass=<type>`; resource picker type-appropriate (Space/MaintainedResource `find-things`; User `AgentPlaceholder`). Also **fixes** the old single template, whose resource picker was hard-typed to `MaintainedResource` only. `RAI5NAX…` / `RAwpNZMM…` / `RAEKxVpk…`
- **Three per-type listing views** (own kind, correct `appliesToInstancesOf`, shared `list-preset-assignments` query), each linking its template, replacing the single multi-type view. `RAhYRi…` / `RA-CRSYJ…` / `RAd0UM…`
- Repoint `AboutSpacePanel.PRESET_ASSIGNMENTS_VIEW`; add `USER_…` / `MAINTAINED_RESOURCE_…` constants in the user/resource panels (which previously reused the space constant).

### Verified
`find-presets` returns type-appropriate results (Space→`test-preset`, MaintainedResource→`ontology-test-preset`) both directly and via the grlc API; published views resolve with correct templates and `appliesToInstancesOf`; compiles clean. All nanopubs published independently to the registry (the old multi-type view `RA1kCQYX` is left untouched → no deployed-behaviour change until rollout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Also in this PR — parts (the fourth case) + cleanup
Parts have no presets/views of their own (assigned at the maintained-resource level), but both tables show on a part's About tab. Their **add** actions now target the **owning maintained resource**: the presets table uses the maintained-resource preset view, and a new part-view-displays view (`RACcSq7R…`) adds an "➕ add view display" action → the maintained-resource view-display template (`targetField=resource`, pre-filling the owning resource IRI, not the part). Also **removed** the now-redundant top-of-part-page description field and "+ view display" button (the add affordance lives in the About-tab table now).
