### PR TITLE
fix: restore ref-scoped observers & non-approved lists (RDF4J BIND-in-UNION bug)

### DIFF
--- a/docs/queries/list-space-non-approved-ref-v5.trig
+++ b/docs/queries/list-space-non-approved-ref-v5.trig
@@ -1,0 +1,100 @@
+@prefix this: <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
+@prefix sub: <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
+@prefix np: <http://www.nanopub.org/nschema#> .
+@prefix grlc: <https://w3id.org/kpxl/grlc/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix npx: <http://purl.org/nanopub/x/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix orcid: <https://orcid.org/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+sub:Head {
+  this: a np:Nanopublication;
+    np:hasAssertion sub:assertion;
+    np:hasProvenance sub:provenance;
+    np:hasPublicationInfo sub:pubinfo .
+}
+
+sub:assertion {
+  sub:list-space-non-approved a grlc:grlc-query;
+    dct:description "Lists the non-approved role claims of a given space ref (space IRI + root definition): agents who hold a higher-tier role instantiation (admin/maintainer/member) that is NOT in the trust-validated current state, i.e. a self-assigned or otherwise ungranted claim awaiting approval by an equal-or-higher-tier member. Pass the ref's root nanopub (root_np). Observer-tier roles are excluded: they are self-assignable, so a self-declared observer needs no approval and is shown by list-space-observers instead. The higher-tier test is generic — the built-in admin property (gen:hasAdmin) OR a RoleDeclaration whose npa:hasRoleType is gen:AdminRole/gen:MaintainerRole/gen:MemberRole — but because the live spaces repo currently materialises every declaration as gen:ObserverRole, only admin claims are detectable today; maintainer/member claims appear automatically once real tier subclasses exist. Per (member, role) only the latest role-instantiation nanopub is returned (by dct:created). Returns the claimed tier, the role-assignment grant nanopub(s) with the claimed role's label (role_assignments_multi_iri + role_assignments_label_multi), and the role-assignment template (for the approve action, which re-asserts the same triple), plus a hidden agent_iri column the approve action maps into the template's agent placeholder. v2: adds the role_assignments columns. v3: resolves owl:sameAs space aliases (via the ref's validated npa:sameAsSpace edges in the current-state graph), so a higher-tier claim made against an alias IRI of the space is detected. v4: the invalidation filter now honours an npx:invalidates edge only when the invalidating nanopub shares a signing pubkey (npa:hasValidSignatureForPublicKeyHash) with the grant it targets, so a foreign-key retraction can no longer suppress another agent's claim (issue #487 / same gate as the materializer's #112). v5: BUGFIX — the v3/v4 space-alias resolution used a `{ bind(?spaceIri as ?inSpace) } union { ... npa:sameAsSpace ... }` pattern, but RDF4J does not propagate the outer ?spaceIri into a BIND inside a UNION branch, so ?inSpace was left unbound and the query returned ZERO rows for every space (no pending claim could ever surface). Replaced with a non-union `filter( ?inSpace = ?spaceIri || exists { ... npa:sameAsSpace ... } )` that binds ?inSpace from the role-instantiation triple, restoring detection while keeping alias resolution.";
+    dct:license <http://www.apache.org/licenses/LICENSE-2.0>;
+    rdfs:label "List space non-approved role claims (ref-scoped)";
+    grlc:endpoint <https://w3id.org/np/l/nanopub-query-1.1/repo/spaces>;
+    grlc:sparql """prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix dct: <http://purl.org/dc/terms/>
+prefix np: <http://www.nanopub.org/nschema#>
+prefix npa: <http://purl.org/nanopub/admin/>
+prefix npx: <http://purl.org/nanopub/x/>
+prefix gen: <https://w3id.org/kpxl/gen/terms/>
+prefix schema: <http://schema.org/>
+
+select ?member
+       (sample(?agentX) as ?agent_iri)
+       (sample(?tierX) as ?tier)
+       (group_concat(distinct ?latestNp; separator=\" \") as ?role_assignments_multi_iri)
+       (group_concat(distinct ?roleLabel; separator=\"\\n\") as ?role_assignments_label_multi)
+       (sample(?rtmplX) as ?roleAssignmentTemplate)
+where {
+  {
+    select ?member ?roleProp
+           (max(?val0) as ?val)
+           (strafter(max(concat(coalesce(str(?dateNp),\"\"), \" \", str(?grantNp))), \" \") as ?latestNp)
+           (sample(?member) as ?agentX)
+           (sample(?tier0) as ?tierX)
+           (sample(?rtmpl0) as ?rtmplX)
+           (sample(?rl) as ?rlRaw)
+    where {
+      values ?_root_np_multi_iri {}
+      graph npa:spacesGraph { ?ref npa:rootNanopub ?_root_np_multi_iri ; npa:spaceIri ?spaceIri . }
+      graph npa:graph { npa:thisRepo npa:hasCurrentSpaceState ?g . }
+      graph npa:spacesGraph {
+        ?ri a gen:RoleInstantiation ; npa:forSpace ?inSpace ; npa:forAgent ?member ; npa:viaNanopub ?grantNp ;
+            (npa:regularProperty|npa:inverseProperty) ?roleProp .
+      }
+      filter( ?inSpace = ?spaceIri || exists { graph ?g { ?inSpace npa:sameAsSpace ?ref } } )
+      bind(?roleProp = gen:hasAdmin as ?isAdminProp)
+      bind(exists { graph npa:spacesGraph { ?rdA a npa:RoleDeclaration ; npa:hasRoleType gen:AdminRole ; (gen:hasRegularProperty|gen:hasInverseProperty) ?roleProp } } as ?isAdminDecl)
+      bind(exists { graph npa:spacesGraph { ?rdM a npa:RoleDeclaration ; npa:hasRoleType gen:MaintainerRole ; (gen:hasRegularProperty|gen:hasInverseProperty) ?roleProp } } as ?isMaint)
+      bind(exists { graph npa:spacesGraph { ?rdMe a npa:RoleDeclaration ; npa:hasRoleType gen:MemberRole ; (gen:hasRegularProperty|gen:hasInverseProperty) ?roleProp } } as ?isMemb)
+      filter(?isAdminProp || ?isAdminDecl || ?isMaint || ?isMemb)
+      filter not exists { graph npa:graph { ?invNp npx:invalidates ?grantNp ; npa:hasValidSignatureForPublicKeyHash ?invpk . ?grantNp npa:hasValidSignatureForPublicKeyHash ?invpk . } }
+      bind(if(exists { graph ?g { ?vri npa:forSpaceRef ?ref ; npa:forAgent ?member ; (npa:regularProperty|npa:inverseProperty) ?roleProp } }, 1, 0) as ?val0)
+      optional { graph npa:graph { ?grantNp dct:created ?dateNp } }
+      bind(if(?isAdminProp || ?isAdminDecl, \"Admin\", if(?isMaint, \"Maintainer\", \"Member\")) as ?tier0)
+      bind(if(?isAdminProp, <https://w3id.org/np/RAsOQ7k3GNnuUqZuLm57PWwWopQJR_4onnCpNR457CZg8>, ?undefTmpl) as ?rtmpl0)
+      optional {
+        graph ?g { ?raRole a gen:RoleAssignment ; npa:forSpaceRef ?ref ; gen:hasRole ?role . }
+        graph npa:spacesGraph { ?rd2 a npa:RoleDeclaration ; npa:role ?role ; (gen:hasRegularProperty|gen:hasInverseProperty) ?roleProp ; npa:viaNanopub ?roleNp . }
+        graph npa:graph { ?roleNp np:hasAssertion ?role_a . }
+        optional { graph ?role_a { ?role schema:name ?rlS } }
+        optional { graph ?role_a { ?role rdfs:label ?rlA } }
+        optional { graph ?role_a { ?role dct:title ?rlB } }
+        bind(coalesce(?rlS, ?rlA, ?rlB) as ?rlResolved)
+      }
+      bind(if(?isAdminProp, \"admin\", ?rlResolved) as ?rl)
+    }
+    group by ?member ?roleProp
+    having (max(?val0) = 0)
+  }
+  bind(coalesce(?rlRaw, \"role\") as ?roleLabel)
+}
+group by ?member
+order by ?member""" .
+}
+
+sub:provenance {
+  sub:assertion prov:wasAttributedTo orcid:0000-0002-1267-0234 .
+}
+
+sub:pubinfo {
+  orcid:0000-0002-1267-0234 foaf:name "Tobias Kuhn" .
+
+  this: dct:created "2026-06-22T06:43:15Z"^^xsd:dateTime;
+    dct:creator orcid:0000-0002-1267-0234;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    npx:embeds sub:list-space-non-approved;
+    npx:supersedes <https://w3id.org/np/RAwv7GRcjaiG3tcrtWiayQdwqOS2qeatEh4qiOGvB7pNg> .
+}

--- a/docs/queries/list-space-observers-ref-v5.trig
+++ b/docs/queries/list-space-observers-ref-v5.trig
@@ -1,0 +1,90 @@
+@prefix this: <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
+@prefix sub: <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
+@prefix np: <http://www.nanopub.org/nschema#> .
+@prefix grlc: <https://w3id.org/kpxl/grlc/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix npx: <http://purl.org/nanopub/x/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix orcid: <https://orcid.org/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+sub:Head {
+  this: a np:Nanopublication;
+    np:hasAssertion sub:assertion;
+    np:hasProvenance sub:provenance;
+    np:hasPublicationInfo sub:pubinfo .
+}
+
+sub:assertion {
+  sub:list-space-observers a grlc:grlc-query;
+    dct:description "Lists every observer-tier role association of a given space ref (space IRI + root definition): each agent holding a role whose declaration's npa:hasRoleType is gen:ObserverRole. Pass the ref's root nanopub (root_np). Per (member, role) only the latest role-instantiation nanopub is returned (by dct:created), so a role re-asserted several times shows once. Unlike list-space-observers (validated-only), this also includes self-declared observers whose key is not trust-validated (no accepted introduction), flagging them in the headerless ?unverified_noheader column. The role label is pinned to the role the space actually assigned (RoleAssignment), correct even when several declarations share a property. Ref-scoped; shows un-introduced observers rather than hiding them. v3: (a) resolves owl:sameAs space aliases (via the ref's validated npa:sameAsSpace edges in the current-state graph), so an observer role declared against an alias IRI of the space is included; (b) no longer hides users who also hold a higher-tier (admin/maintainer/member) role — every observer-tier association is listed, so an admin who is also a participant appears here for that participant role. The built-in admin property gen:hasAdmin is still excluded (it is not an observer-tier association), as are roles whose declaration is itself admin/maintainer/member-tier; non-approved higher-tier claims belong in list-space-non-approved. v4: the invalidation filter now honours an npx:invalidates edge only when the invalidating nanopub shares a signing pubkey (npa:hasValidSignatureForPublicKeyHash) with the grant it targets, so a foreign-key retraction can no longer erase another agent's observer association (issue #487 / same gate as the materializer's #112). v5: BUGFIX — the v3/v4 space-alias resolution used a `{ bind(?spaceIri as ?inSpace) } union { ... npa:sameAsSpace ... }` pattern, but RDF4J does not propagate the outer ?spaceIri into a BIND inside a UNION branch, so ?inSpace was left unbound and the query returned ZERO observers for every space. Replaced with a non-union `filter( ?inSpace = ?spaceIri || exists { ... npa:sameAsSpace ... } )` that binds ?inSpace from the role-instantiation triple, restoring the observer list while keeping alias resolution.";
+    dct:license <http://www.apache.org/licenses/LICENSE-2.0>;
+    rdfs:label "List space observers (ref-scoped, all observer-tier associations, with validation flag)";
+    grlc:endpoint <https://w3id.org/np/l/nanopub-query-1.1/repo/spaces>;
+    grlc:sparql """prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix dct: <http://purl.org/dc/terms/>
+prefix np: <http://www.nanopub.org/nschema#>
+prefix npa: <http://purl.org/nanopub/admin/>
+prefix npx: <http://purl.org/nanopub/x/>
+prefix gen: <https://w3id.org/kpxl/gen/terms/>
+prefix schema: <http://schema.org/>
+
+select ?member
+       (group_concat(distinct ?latestNp; separator=\" \") as ?role_assignments_multi_iri)
+       (group_concat(distinct ?roleLabel; separator=\"\\n\") as ?role_assignments_label_multi)
+       (if(max(?val) = 0, \"⚠️\", \"\") as ?unverified_noheader)
+where {
+  {
+    select ?member ?roleProp
+           (max(?val0) as ?val)
+           (strafter(max(concat(coalesce(str(?dateNp),\"\"), \" \", str(?grantNp))), \" \") as ?latestNp)
+           (sample(?rl) as ?rlRaw)
+    where {
+      values ?_root_np_multi_iri {}
+      graph npa:spacesGraph { ?ref npa:rootNanopub ?_root_np_multi_iri ; npa:spaceIri ?spaceIri . }
+      graph npa:graph { npa:thisRepo npa:hasCurrentSpaceState ?g . }
+      graph npa:spacesGraph {
+        ?ri a gen:RoleInstantiation ; npa:forSpace ?inSpace ; npa:forAgent ?member ; npa:viaNanopub ?grantNp ;
+            (npa:regularProperty|npa:inverseProperty) ?roleProp .
+      }
+      filter( ?inSpace = ?spaceIri || exists { graph ?g { ?inSpace npa:sameAsSpace ?ref } } )
+      filter exists { graph npa:spacesGraph { ?rdf a npa:RoleDeclaration ; npa:hasRoleType gen:ObserverRole ; (gen:hasRegularProperty|gen:hasInverseProperty) ?roleProp } }
+      filter(?roleProp != gen:hasAdmin)
+      filter not exists { graph npa:spacesGraph { ?rdh a npa:RoleDeclaration ; (gen:hasRegularProperty|gen:hasInverseProperty) ?roleProp .
+        { ?rdh npa:hasRoleType gen:AdminRole } union { ?rdh npa:hasRoleType gen:MaintainerRole } union { ?rdh npa:hasRoleType gen:MemberRole } } }
+      filter not exists { graph npa:graph { ?invNp npx:invalidates ?grantNp ; npa:hasValidSignatureForPublicKeyHash ?invpk . ?grantNp npa:hasValidSignatureForPublicKeyHash ?invpk . } }
+      bind(if(exists { graph ?g { ?vri npa:forSpaceRef ?ref ; npa:forAgent ?member ; npa:viaNanopub ?grantNp } }, 1, 0) as ?val0)
+      optional { graph npa:graph { ?grantNp dct:created ?dateNp } }
+      optional {
+        graph ?g { ?raRole a gen:RoleAssignment ; npa:forSpaceRef ?ref ; gen:hasRole ?role . }
+        graph npa:spacesGraph { ?rd2 a npa:RoleDeclaration ; npa:role ?role ; (gen:hasRegularProperty|gen:hasInverseProperty) ?roleProp ; npa:viaNanopub ?roleNp . }
+        graph npa:graph { ?roleNp np:hasAssertion ?role_a . }
+        optional { graph ?role_a { ?role schema:name ?rlS } }
+        optional { graph ?role_a { ?role rdfs:label ?rlA } }
+        optional { graph ?role_a { ?role dct:title ?rlB } }
+        bind(coalesce(?rlS, ?rlA, ?rlB) as ?rl)
+      }
+    }
+    group by ?member ?roleProp
+  }
+  bind(coalesce(?rlRaw, \"role\") as ?roleLabel)
+}
+group by ?member
+order by ?unverified_noheader ?member""" .
+}
+
+sub:provenance {
+  sub:assertion prov:wasAttributedTo orcid:0000-0002-1267-0234 .
+}
+
+sub:pubinfo {
+  orcid:0000-0002-1267-0234 foaf:name "Tobias Kuhn" .
+
+  this: dct:created "2026-06-22T06:43:15Z"^^xsd:dateTime;
+    dct:creator orcid:0000-0002-1267-0234;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    npx:embeds sub:list-space-observers;
+    npx:supersedes <https://w3id.org/np/RAobkcQijd4C02lIu-NRz-dhlp8MzPKFau3EO7r3-7hSo> .
+}

--- a/src/main/java/com/knowledgepixels/nanodash/QueryApiAccess.java
+++ b/src/main/java/com/knowledgepixels/nanodash/QueryApiAccess.java
@@ -150,9 +150,14 @@ public class QueryApiAccess {
     // go to LIST_SPACE_NON_APPROVED_REF. v4 (RAobkcQi, supersedes RAZ41V9K) gates the
     // npx:invalidates filter on a shared signing pubkey (npa:hasValidSignatureForPublicKeyHash)
     // between invalidator and target, so a foreign-key retraction can no longer hide an observer
-    // (issue #487; mirrors the materializer's #112 same-publisher gate). Source at
-    // docs/queries/list-space-observers-ref-v4.trig.
-    public static final String LIST_SPACE_OBSERVERS_REF = "RAobkcQijd4C02lIu-NRz-dhlp8MzPKFau3EO7r3-7hSo/list-space-observers";
+    // (issue #487; mirrors the materializer's #112 same-publisher gate). v5 (RAUQdhb2, supersedes
+    // RAobkcQi) fixes a regression introduced in v3: the space-alias resolution used a
+    // `{ bind(?spaceIri as ?inSpace) } union { ... sameAsSpace ... }` pattern, but RDF4J does not
+    // propagate the outer ?spaceIri into a BIND inside a UNION branch, leaving ?inSpace unbound so
+    // the query returned ZERO observers for every space. Replaced with a non-union
+    // `filter( ?inSpace = ?spaceIri || exists { ... sameAsSpace ... } )`. Source at
+    // docs/queries/list-space-observers-ref-v5.trig.
+    public static final String LIST_SPACE_OBSERVERS_REF = "RAUQdhb2lwrSA6Vqv96ERyISUhO9U9eOFNWsSe9NMwiWE/list-space-observers";
 
     // Ref-scoped non-approved role claims (root_np): agents holding a higher-tier role
     // instantiation (admin/maintainer/member) that is NOT in the validated state — a
@@ -165,9 +170,14 @@ public class QueryApiAccess {
     // against an alias IRI of the space is detected. v4 (RAwv7GRc, supersedes RA2BnCGv) gates the
     // npx:invalidates filter on a shared signing pubkey between invalidator and target, so a
     // foreign-key retraction can no longer suppress a pending claim (issue #487; mirrors the
-    // materializer's #112 same-publisher gate). Source at
-    // docs/queries/list-space-non-approved-ref-v4.trig.
-    public static final String LIST_SPACE_NON_APPROVED_REF = "RAwv7GRcjaiG3tcrtWiayQdwqOS2qeatEh4qiOGvB7pNg/list-space-non-approved";
+    // materializer's #112 same-publisher gate). v5 (RAtSaYBH, supersedes RAwv7GRc) fixes the same
+    // v3 regression as the observers query: the `{ bind(?spaceIri as ?inSpace) } union { ...
+    // sameAsSpace ... }` alias pattern left ?inSpace unbound on RDF4J (BIND in a UNION branch does
+    // not see the outer ?spaceIri), so the query returned ZERO rows for every space (no pending
+    // claim could ever surface). Replaced with a non-union
+    // `filter( ?inSpace = ?spaceIri || exists { ... sameAsSpace ... } )`. Source at
+    // docs/queries/list-space-non-approved-ref-v5.trig.
+    public static final String LIST_SPACE_NON_APPROVED_REF = "RAtSaYBHpb2iG6dwlHRHVfUpygNAKS-3bUa1iV5YNqk3w/list-space-non-approved";
 
     // Ref-scoped variants of the four About-tab *view* display queries (distinct from the
     // GET_SPACE_*_REF client-authority queries above). Each takes the ref's root nanopub


### PR DESCRIPTION
## Problem

On nanodash 5.0.0 the About-tab **Self-Assigned/Observers** section was empty on every space — e.g. [session32](https://nanodash.net/space?7&id=https://w3id.org/spaces/nanopub/nanosessions/session32&tab=about), which has many participants/speakers/planned attendants visible on the previous instance. The **Pending Admins/Maintainers/Members** section was likewise always empty.

## Root cause

The v3 space-alias resolution added to the ref-scoped observers and non-approved queries used:

```sparql
{ bind(?spaceIri as ?inSpace) } union { graph ?g { ?inSpace npa:sameAsSpace ?ref } }
... ?ri npa:forSpace ?inSpace ...
```

On the spaces RDF4J store, **a `BIND` inside a `UNION` branch does not see a variable bound before the `UNION`** — `?inSpace` came back unbound, so the `npa:forSpace ?inSpace` join matched nothing and the queries returned **zero rows** for every space. Verified empirically: `npa:forSpace ?spaceIri` → 23 rows; the union form → 0.

The identical broken pattern was in both `list-space-observers` (v4 `RAobkcQi`) and `list-space-non-approved` (v4 `RAwv7GRc`).

## Fix

Replace the union with an equivalent non-union form that binds `?inSpace` from the data triple, keeping alias resolution:

```sparql
... ?ri npa:forSpace ?inSpace ...
filter( ?inSpace = ?spaceIri || exists { graph ?g { ?inSpace npa:sameAsSpace ?ref } } )
```

Published v5 of each query (superseding v4) and repointed the `QueryApiAccess` constants at the new artifact codes (grlc serves by exact artifact code, so a supersede alone doesn't redirect the endpoint):

- observers v5 `RAUQdhb2…` (supersedes `RAobkcQi`)
- non-approved v5 `RAtSaYBH…` (supersedes `RAwv7GRc`)

New query sources: `docs/queries/list-space-{observers,non-approved}-ref-v5.trig`.

## Verification

- Observers query now returns the full list live (session32: 10 observers with participant/speaker/planned-attendant labels).
- Full sweep of **all 117 spaces** comparing the new instance to the previous one: **no users dropped**, and **sub-spaces / maintained resources identical** on every space.

🤖 Generated with [Claude Code](https://claude.com/claude-code)