### PR TITLE
feat: position-column tooltip labels on view-displays tables

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/QueryApiAccess.java
+++ b/src/main/java/com/knowledgepixels/nanodash/QueryApiAccess.java
@@ -206,18 +206,26 @@ public class QueryApiAccess {
     // unknown. Source at docs/queries/list-view-displays-ref.trig (regenerate from the latest
     // list-view-displays by adding the root_np VALUES + ?passedRef resolution + forSpaceRef gate).
     // RAPTW1r (supersedes RAKfr2) renames the ?shown_here column to ?displayed_here.
-    public static final String LIST_VIEW_DISPLAYS_REF = "RAPTW1rmsOd0XOYdYO1cXU0aXGaxFYsSJykJWSoDf1uqw/list-view-displays";
+    // RABbLjtr (derived from RAPTW1r) adds a ?position_label column (first 3 chars of the
+    // structural position) so the position cell shows e.g. "1.1" with the full literal on hover.
+    public static final String LIST_VIEW_DISPLAYS_REF = "RABbLjtr5cnacM86zWTW4L9lAnuMn2CgYd2SIBn72o-q4/list-view-displays";
 
     // IRI-keyed view-displays listing (resource param), used for users / maintained resources and
     // the space ref-less fallback. Like LIST_VIEW_DISPLAYS_REF it carries a ?displayed_here flag
     // (✓ when the display applies to the resource itself, blank for part-level displays).
     // RAxKzcn supersedes the list-view-displays head RAdWeDNF (renames ?shown_here → ?displayed_here).
-    public static final String LIST_VIEW_DISPLAYS = "RAxKzcnWKNa_ufbAR_v2P8_eefeOIoEmRzKuEA9sm0IIQ/list-view-displays";
+    // RAnAZ-HU (derived from RAxKzcn) adds a ?position_label column (first 3 chars of the structural
+    // position) so the position cell shows e.g. "1.1" with the full literal on hover. Now also the
+    // query backing the user/maintained view-displays views (gen:hasViewQuery), driven there as a
+    // proper view; still used directly here for the space ref-less fallback.
+    public static final String LIST_VIEW_DISPLAYS = "RAnAZ-HUtuG-Maw5vf7-4UNisl-1D3NugOIyvz-4yN6F8/list-view-displays";
 
     // Part view-displays listing (resource + partid + partclass): the owning resource's displays,
     // each ?displayed_here-flagged for the specific part. RAMy6Nu supersedes RAPaHJiD (renames
-    // ?shown_here → ?displayed_here).
-    public static final String LIST_PART_VIEW_DISPLAYS = "RAMy6Nufw1pXjtI4SuxFNxLl_6s7-18rFi5jyJ1no5a5A/list-part-view-displays";
+    // ?shown_here → ?displayed_here). RAFkUf3A (derived from RAMy6Nu) adds a ?position_label column
+    // (first 3 chars of the structural position) so the position cell shows e.g. "1.1" with the full
+    // literal on hover.
+    public static final String LIST_PART_VIEW_DISPLAYS = "RAFkUf3AduxwZOfFBz0lVil_2IS2dM83-WAkEjkY3UTYQ/list-part-view-displays";
 
     // Ref-scoped preset-assignment listing (root_np): reads the server-materialised
     // npa:PresetAssignment rows scoped by npa:forSpaceRef from the validated current space-state

--- a/src/main/java/com/knowledgepixels/nanodash/component/AboutResourcePanel.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/AboutResourcePanel.java
@@ -1,6 +1,5 @@
 package com.knowledgepixels.nanodash.component;
 
-import com.knowledgepixels.nanodash.QueryApiAccess;
 import com.knowledgepixels.nanodash.View;
 import com.knowledgepixels.nanodash.ViewDisplay;
 import com.knowledgepixels.nanodash.domain.MaintainedResource;
@@ -50,7 +49,7 @@ public class AboutResourcePanel extends Panel {
         add(QueryResultTableBuilder.create("presets", new QueryRef(presetsView.getQuery().getQueryId(), "resource", resource.getId()), new ViewDisplay(presetsView)).resourceWithProfile(resource).id(resource.getId()).contextId(resource.getId()).build());
 
         View vdView = View.get(MAINTAINED_RESOURCE_VIEW_DISPLAYS_VIEW);
-        add(QueryResultTableBuilder.create("viewdisplays", new QueryRef(QueryApiAccess.LIST_VIEW_DISPLAYS, "resource", resource.getId()), new ViewDisplay(vdView)).resourceWithProfile(resource).id(resource.getId()).contextId(resource.getId()).build());
+        add(QueryResultTableBuilder.create("viewdisplays", new QueryRef(vdView.getQuery().getQueryId(), "resource", resource.getId()), new ViewDisplay(vdView)).resourceWithProfile(resource).id(resource.getId()).contextId(resource.getId()).build());
     }
 
 }

--- a/src/main/java/com/knowledgepixels/nanodash/component/AboutUserPanel.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/AboutUserPanel.java
@@ -1,6 +1,5 @@
 package com.knowledgepixels.nanodash.component;
 
-import com.knowledgepixels.nanodash.QueryApiAccess;
 import com.knowledgepixels.nanodash.View;
 import com.knowledgepixels.nanodash.ViewDisplay;
 import com.knowledgepixels.nanodash.domain.IndividualAgent;
@@ -75,7 +74,7 @@ public class AboutUserPanel extends Panel {
         add(QueryResultTableBuilder.create("presets", new QueryRef(presetsView.getQuery().getQueryId(), "resource", userIriString), new ViewDisplay(presetsView)).resourceWithProfile(IndividualAgent.get(userIriString)).id(userIriString).contextId(userIriString).build());
 
         View vdView = View.get(USER_VIEW_DISPLAYS_VIEW);
-        add(QueryResultTableBuilder.create("viewdisplays", new QueryRef(QueryApiAccess.LIST_VIEW_DISPLAYS, "resource", userIriString), new ViewDisplay(vdView)).resourceWithProfile(IndividualAgent.get(userIriString)).id(userIriString).contextId(userIriString).build());
+        add(QueryResultTableBuilder.create("viewdisplays", new QueryRef(vdView.getQuery().getQueryId(), "resource", userIriString), new ViewDisplay(vdView)).resourceWithProfile(IndividualAgent.get(userIriString)).id(userIriString).contextId(userIriString).build());
     }
 
 }

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultItemList.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultItemList.java
@@ -104,6 +104,12 @@ public class QueryResultItemList extends QueryResult {
                     } else if (value.matches("https?://.*")) {
                         item.add(new NanodashLink("listItem", value, null, null, entryLabel, contextId));
                         return;
+                    } else if (entryLabel != null && !entryLabel.isBlank() && !entryLabel.equals(value)) {
+                        // Separate display label for a (non-IRI) literal value; the full
+                        // literal is shown on hover via the standard styled tooltip.
+                        String html = "<span class=\"tooltip\"><span class=\"tooltiptext tooltiptext-auto\">" + Strings.escapeMarkup(value) + "</span>" + Strings.escapeMarkup(entryLabel) + "</span>";
+                        item.add(new Label("listItem", html).setEscapeModelStrings(false));
+                        return;
                     } else {
                         item.add(new Label("listItem", value));
                         return;

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultList.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultList.java
@@ -210,10 +210,20 @@ public class QueryResultList extends QueryResult {
                                 components.add(new NanodashLink("component", entryValue, null, null, entryLabel, contextId));
                             }
                         } else {
-                            if (Utils.looksLikeHtml(entryValue)) {
-                                entryValue = Utils.sanitizeHtml(entryValue);
+                            String entryLabel = entry.get(key + "_label");
+                            boolean hasLabel = entryLabel != null && !entryLabel.isBlank() && !entryLabel.equals(entryValue);
+                            String display = hasLabel ? entryLabel : entryValue;
+                            if (Utils.looksLikeHtml(display)) {
+                                display = Utils.sanitizeHtml(display);
+                            } else if (hasLabel) {
+                                display = Strings.escapeMarkup(display).toString();
                             }
-                            components.add(new Label("component", entryValue).setEscapeModelStrings(false));
+                            if (hasLabel) {
+                                // Separate display label for a (non-IRI) literal value; the full
+                                // literal is shown on hover via the standard styled tooltip.
+                                display = "<span class=\"tooltip\"><span class=\"tooltiptext tooltiptext-auto\">" + Strings.escapeMarkup(entryValue) + "</span>" + display + "</span>";
+                            }
+                            components.add(new Label("component", display).setEscapeModelStrings(false));
                         }
                     }
                 }

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultTable.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultTable.java
@@ -405,7 +405,14 @@ public class QueryResultTable extends QueryResult {
                         String label = truncateLabel(rowModel.getObject().get(key + "_label"));
                         cellItem.add(new NanodashLink(componentId, value, null, null, label, contextId));
                     } else {
-                        if (key.startsWith("pubkey")) {
+                        String litLabel = rowModel.getObject().get(key + "_label");
+                        if (litLabel != null && !litLabel.isBlank() && !litLabel.equals(value)) {
+                            // Separate display label for a (non-IRI) literal value; the full
+                            // literal is shown on hover via the standard styled tooltip.
+                            String labelHtml = Utils.looksLikeHtml(litLabel) ? Utils.sanitizeHtml(litLabel) : Strings.escapeMarkup(litLabel).toString();
+                            String html = "<span class=\"tooltip\"><span class=\"tooltiptext tooltiptext-auto\">" + Strings.escapeMarkup(value) + "</span>" + labelHtml + "</span>";
+                            cellItem.add(new Label(componentId, html).setEscapeModelStrings(false));
+                        } else if (key.startsWith("pubkey")) {
                             cellItem.add(new Label(componentId, value).add(new AttributeAppender("style", "overflow-wrap: anywhere;")));
                         } else if (Utils.isDateTimeLiteral(value)) {
                             // Show a friendly relative time (client-side); raw ISO value stays as no-script fallback.

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -1591,6 +1591,15 @@ span.nanopub-assertion, span.nanopub-provenance, span.nanopub-pubinfo {
   top: 100%;
 }
 
+/* Auto-width variant (e.g. literal-value label tooltips): box hugs its content
+   up to a max instead of a fixed min-width, so short values don't show empty space. */
+.tooltip .tooltiptext.tooltiptext-auto {
+  min-width: 0;
+  width: max-content;
+  max-width: 500px;
+  white-space: normal;
+}
+
 a.tooltiptext {
   font-family: "Noto Emoji", Martian, monaco, monospace !important;
 }


### PR DESCRIPTION
## What

Adds a short display label with a hover tooltip to the structural-position column of every view-displays table (About tabs for users, maintained resources, spaces, and parts). The cell shows e.g. **`1.1`** and the full literal **`1.1.about`** appears on hover.

## Why

Result tables already supported a separate `x_label` companion column for **IRI** values, but not for plain literals — so a literal column could only ever render its raw value. This generalises the convention to single non-IRI literals and uses it to keep the position column compact while preserving the full value on hover.

## Changes

**Rendering (code):**
- `QueryResultTable`, `QueryResultList`, `QueryResultItemList`: a single non-IRI literal column now honours its `x_label` companion — renders the label and wraps the full literal in the standard `.tooltip`/`.tooltiptext` styled tooltip. A label equal to the value is treated as "no label". Both halves are HTML-escaped.
- `style.css`: new scoped `.tooltiptext-auto` variant (`min-width:0; width:max-content; max-width:500px`) so short literals don't render an empty 500px box. Existing URI tooltips keep their fixed width.

**Proper-view fix (code):**
- `AboutUserPanel` / `AboutResourcePanel`: the view-displays table hard-coded `LIST_VIEW_DISPLAYS` while the panels' other three tables (introductions/profile/presets) use `view.getQuery()`. They are now proper views driven by their view nanopub's `hasViewQuery`, matching the siblings. Spaces/parts stay query-driven (their ref/part params can't go through the generic view mechanism).

**Query constants (`QueryApiAccess`):**
- `LIST_VIEW_DISPLAYS` → `RAnAZ-HU…`, `LIST_VIEW_DISPLAYS_REF` → `RABbLjtr…`, `LIST_PART_VIEW_DISPLAYS` → `RAFkUf3A…` — each a `position_label` (first-3-chars) variant of the original, published independently (`prov:wasDerivedFrom`, originals untouched).

## Verification

Rendered live against the dev jetty for user, maintained, and space About tabs (truncated positions + tooltip markup confirmed); part query verified via the query API. All position-label query variants are published live.

## Notes

- Branch name reflects an earlier fix that's already on `master`; this PR contains only the tooltip-feature commit.
- The feature needs both the code (this PR) **and** the published nanopubs (already live) to render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)