### PR TITLE
fix: restore per-row deactivate action on view-displays tables

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/QueryApiAccess.java
+++ b/src/main/java/com/knowledgepixels/nanodash/QueryApiAccess.java
@@ -208,7 +208,10 @@ public class QueryApiAccess {
     // RAPTW1r (supersedes RAKfr2) renames the ?shown_here column to ?displayed_here.
     // RABbLjtr (derived from RAPTW1r) adds a ?position_label column (first 3 chars of the
     // structural position) so the position cell shows e.g. "1.1" with the full literal on hover.
-    public static final String LIST_VIEW_DISPLAYS_REF = "RABbLjtr5cnacM86zWTW4L9lAnuMn2CgYd2SIBn72o-q4/list-view-displays";
+    // RA7kxCE (derived from RABbLjtr) re-projects the ?deactivateView column through the outer
+    // aggregation, which RABbLjtr dropped — without it the per-row "deactivate" action's
+    // deactivateView:view mapping is empty and the action is hidden on every row.
+    public static final String LIST_VIEW_DISPLAYS_REF = "RA7kxCEthFUOWjpJzZAN3b1edSOnQScmsZxfU6_wkKvZU/list-view-displays";
 
     // IRI-keyed view-displays listing (resource param), used for users / maintained resources and
     // the space ref-less fallback. Like LIST_VIEW_DISPLAYS_REF it carries a ?displayed_here flag
@@ -218,7 +221,12 @@ public class QueryApiAccess {
     // position) so the position cell shows e.g. "1.1" with the full literal on hover. Now also the
     // query backing the user/maintained view-displays views (gen:hasViewQuery), driven there as a
     // proper view; still used directly here for the space ref-less fallback.
-    public static final String LIST_VIEW_DISPLAYS = "RAnAZ-HUtuG-Maw5vf7-4UNisl-1D3NugOIyvz-4yN6F8/list-view-displays";
+    // RAUeYda (derived from RAnAZ-HU) re-projects the ?deactivateView column through the outer
+    // aggregation, which RAnAZ-HU dropped — without it the per-row "deactivate" action's
+    // deactivateView:view mapping is empty and the action is hidden on every row. The user and
+    // maintained-resource view nanopubs are superseded in lockstep to point their gen:hasViewQuery
+    // at this version (RAqqGNrE / RAm3FCo1).
+    public static final String LIST_VIEW_DISPLAYS = "RAUeYdadBYw_WNsIIQhjUMjKgw8sKVrM_QaLI6J-FuDhw/list-view-displays";
 
     // Part view-displays listing (resource + partid + partclass): the owning resource's displays,
     // each ?displayed_here-flagged for the specific part. RAMy6Nu supersedes RAPaHJiD (renames


### PR DESCRIPTION
## Problem

The per-row **deactivate** action disappeared from the View-displays tables on **user**, **space**, and **maintained-resource** About pages (part pages are read-only by design and unaffected).

The action is a `gen:ViewEntryAction` with query mapping `deactivateView:view` — it reads each row's `?deactivateView` column, and an empty required mapped value hides the action (`ViewActionMappings.applyEntryMappings`). The `list-view-displays` queries are 4-level nested aggregations that compute `?deactivateView` (= `str(?viewRef)`) in their inner selects but **dropped it in the outermost `group by ?view` aggregation**. So the mapping read an empty value and the action was hidden on every row. Regression slipped in when those queries were superseded for the `position_label` / "displayed here" changes.

## Fix

Point `LIST_VIEW_DISPLAYS` / `LIST_VIEW_DISPLAYS_REF` at superseding queries that re-project `?deactivateView` through the outer aggregation (`(sample(?deactivateView) as ?deactivateView)`).

Because the user and maintained-resource tables are view-driven (`vdView.getQuery()`, and `GrlcQuery.get` pins the exact `gen:hasViewQuery` IRI), their **view nanopubs were superseded in lockstep** to reference the new query. Those resolve via `View.get`'s supersedes-chain lookup, so no view-constant change is needed in code. Space (refless + ref) uses the constants directly, hence the two updated here.

## Published nanopubs (live)

| Artifact | New ID |
|---|---|
| `LIST_VIEW_DISPLAYS` query | `RAUeYdadBYw_WNsIIQhjUMjKgw8sKVrM_QaLI6J-FuDhw` |
| `LIST_VIEW_DISPLAYS_REF` query | `RA7kxCEthFUOWjpJzZAN3b1edSOnQScmsZxfU6_wkKvZU` |
| User view (→ new query) | `RAqqGNrE_qLEQR_0AbQZ4B6zjvaQrGrSHygYz6lkldUPk` |
| Maintained-resource view (→ new query) | `RAm3FCo1kEX2Dcj4yiV-OrOKEUZkR9WZbVJdONbm5XiUM` |

## Verification

Query-layer verified live via grlc: `deactivateView` column present and populated (17 rows for a user ORCID, 3 rows for the knowledgepixels space). View version-chains resolve to the new views. Render-verification in the running app still pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)