### PR TITLE
feat: drive view-displays tables by the view's query, ref-scope maintained resources

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/QueryApiAccess.java
+++ b/src/main/java/com/knowledgepixels/nanodash/QueryApiAccess.java
@@ -194,39 +194,11 @@ public class QueryApiAccess {
     public static final String LIST_SUB_SPACES_REF = "RA-j0DFqkNUHxF_WIds8wWJix6DkDFBmUBWmKXfG24XYQ/list-sub-spaces";
     public static final String LIST_MAINTAINED_RESOURCES_REF = "RAPthUMRDXiJeD2BrOsZigTsbA0LktBc-HC4alDSfVNKM/list-maintained-resources";
 
-    // Ref-scoped view displays for a space. Unlike the LIST_*_REF above this is NOT a single-param
-    // root_np query: view displays aren't materialised into the spaces repo, so the query is a
-    // 4-SERVICE federated join, and federation only propagates CONCRETE (VALUES) bindings into the
-    // sub-services. A single auto-detecting param fails (a service-derived resource IRI doesn't push
-    // into the branches → 0 rows). So this takes TWO concrete params — the space IRI (resource) and
-    // the ref's root nanopub (root_np) — and resolves the ref + scopes the authority gate to
-    // npa:forSpaceRef INSIDE the /repo/spaces service. Column-identical to list-view-displays (its
-    // spaces-only companion), so it drives the existing view-displays view unchanged. Used by
-    // AboutSpacePanel with both params; falls back to the IRI-keyed query when the ref root is
-    // unknown. Source at docs/queries/list-view-displays-ref.trig (regenerate from the latest
-    // list-view-displays by adding the root_np VALUES + ?passedRef resolution + forSpaceRef gate).
-    // RAPTW1r (supersedes RAKfr2) renames the ?shown_here column to ?displayed_here.
-    // RABbLjtr (derived from RAPTW1r) adds a ?position_label column (first 3 chars of the
-    // structural position) so the position cell shows e.g. "1.1" with the full literal on hover.
-    // RA7kxCE (derived from RABbLjtr) re-projects the ?deactivateView column through the outer
-    // aggregation, which RABbLjtr dropped — without it the per-row "deactivate" action's
-    // deactivateView:view mapping is empty and the action is hidden on every row.
-    public static final String LIST_VIEW_DISPLAYS_REF = "RA7kxCEthFUOWjpJzZAN3b1edSOnQScmsZxfU6_wkKvZU/list-view-displays";
-
-    // IRI-keyed view-displays listing (resource param), used for users / maintained resources and
-    // the space ref-less fallback. Like LIST_VIEW_DISPLAYS_REF it carries a ?displayed_here flag
-    // (✓ when the display applies to the resource itself, blank for part-level displays).
-    // RAxKzcn supersedes the list-view-displays head RAdWeDNF (renames ?shown_here → ?displayed_here).
-    // RAnAZ-HU (derived from RAxKzcn) adds a ?position_label column (first 3 chars of the structural
-    // position) so the position cell shows e.g. "1.1" with the full literal on hover. Now also the
-    // query backing the user/maintained view-displays views (gen:hasViewQuery), driven there as a
-    // proper view; still used directly here for the space ref-less fallback.
-    // RAUeYda (derived from RAnAZ-HU) re-projects the ?deactivateView column through the outer
-    // aggregation, which RAnAZ-HU dropped — without it the per-row "deactivate" action's
-    // deactivateView:view mapping is empty and the action is hidden on every row. The user and
-    // maintained-resource view nanopubs are superseded in lockstep to point their gen:hasViewQuery
-    // at this version (RAqqGNrE / RAm3FCo1).
-    public static final String LIST_VIEW_DISPLAYS = "RAUeYdadBYw_WNsIIQhjUMjKgw8sKVrM_QaLI6J-FuDhw/list-view-displays";
+    // View-displays listing queries are no longer referenced here: the About-tab view-displays
+    // tables are view-driven (gen:hasViewQuery on the space/user/maintained view nanopubs), and the
+    // panels pass the resource + (for spaces/maintained) the ref's root nanopub as params. The
+    // ref-scoped query requires root_np; the IRI-keyed variant backs the users' view. See
+    // docs/queries/list-view-displays{,-ref}.trig.
 
     // Part view-displays listing (resource + partid + partclass): the owning resource's displays,
     // each ?displayed_here-flagged for the specific part. RAMy6Nu supersedes RAPaHJiD (renames

--- a/src/main/java/com/knowledgepixels/nanodash/component/AboutResourcePanel.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/AboutResourcePanel.java
@@ -1,5 +1,7 @@
 package com.knowledgepixels.nanodash.component;
 
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
 import com.knowledgepixels.nanodash.View;
 import com.knowledgepixels.nanodash.ViewDisplay;
 import com.knowledgepixels.nanodash.domain.MaintainedResource;
@@ -48,8 +50,16 @@ public class AboutResourcePanel extends Panel {
         View presetsView = View.get(MAINTAINED_RESOURCE_PRESET_ASSIGNMENTS_VIEW);
         add(QueryResultTableBuilder.create("presets", new QueryRef(presetsView.getQuery().getQueryId(), "resource", resource.getId()), new ViewDisplay(presetsView)).resourceWithProfile(resource).id(resource.getId()).contextId(resource.getId()).build());
 
+        // The view nanopub's hasViewQuery is the ref-scoped list-view-displays query; supply the
+        // owning space's representative ref as root_np so authority (who may add/deactivate displays)
+        // is read from that ref, consistent with space pages — the query resolves the maintained
+        // resource to its space via npa:isMaintainedBy.
         View vdView = View.get(MAINTAINED_RESOURCE_VIEW_DISPLAYS_VIEW);
-        add(QueryResultTableBuilder.create("viewdisplays", new QueryRef(vdView.getQuery().getQueryId(), "resource", resource.getId()), new ViewDisplay(vdView)).resourceWithProfile(resource).id(resource.getId()).contextId(resource.getId()).build());
+        String refRoot = resource.getSpace() != null ? resource.getSpace().getRefRootId() : null;
+        Multimap<String, String> vdParams = ArrayListMultimap.create();
+        vdParams.put("resource", resource.getId());
+        if (refRoot != null && !refRoot.isEmpty()) vdParams.put("root_np", refRoot);
+        add(QueryResultTableBuilder.create("viewdisplays", new QueryRef(vdView.getQuery().getQueryId(), vdParams), new ViewDisplay(vdView)).resourceWithProfile(resource).id(resource.getId()).contextId(resource.getId()).refRoot(refRoot).build());
     }
 
 }

--- a/src/main/java/com/knowledgepixels/nanodash/component/AboutSpacePanel.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/AboutSpacePanel.java
@@ -137,22 +137,15 @@ public class AboutSpacePanel extends Panel {
                 : new QueryRef(rolesView.getQuery().getQueryId(), "space", space.getId());
         add(QueryResultTableBuilder.create("roles", rolesQuery, new ViewDisplay(rolesView)).resourceWithProfile(space).id(space.getId()).contextId(space.getId()).postPublishTab("about").refRoot(refRoot).build());
 
-        // View displays aren't materialised into the spaces repo, so the ref-scoped variant is a
-        // federated join taking two concrete params — the space IRI and the ref's root nanopub —
-        // and gating the authorised signers on the ref's admins/maintainers (npa:forSpaceRef). Falls
-        // back to the IRI-keyed query (admins merged across refs) when the ref root is unknown. The
-        // view nanopub is left untouched.
+        // The view nanopub's hasViewQuery is the ref-scoped list-view-displays query (a federated
+        // join gating authorised signers on the ref's admins/maintainers via npa:forSpaceRef); supply
+        // the pinned-or-representative ref as root_np. View displays aren't materialised into the
+        // spaces repo, so this stays a federated join rather than a local lookup.
         View vdView = View.get(VIEW_DISPLAYS_VIEW);
-        QueryRef vdQuery;
-        if (refRoot != null && !refRoot.isEmpty()) {
-            Multimap<String, String> vdParams = ArrayListMultimap.create();
-            vdParams.put("resource", space.getId());
-            vdParams.put("root_np", refRoot);
-            vdQuery = new QueryRef(QueryApiAccess.LIST_VIEW_DISPLAYS_REF, vdParams);
-        } else {
-            vdQuery = new QueryRef(QueryApiAccess.LIST_VIEW_DISPLAYS, "resource", space.getId());
-        }
-        add(QueryResultTableBuilder.create("viewdisplays", vdQuery, new ViewDisplay(vdView)).resourceWithProfile(space).id(space.getId()).contextId(space.getId()).refRoot(refRoot).build());
+        Multimap<String, String> vdParams = ArrayListMultimap.create();
+        vdParams.put("resource", space.getId());
+        if (refRoot != null && !refRoot.isEmpty()) vdParams.put("root_np", refRoot);
+        add(QueryResultTableBuilder.create("viewdisplays", new QueryRef(vdView.getQuery().getQueryId(), vdParams), new ViewDisplay(vdView)).resourceWithProfile(space).id(space.getId()).contextId(space.getId()).refRoot(refRoot).build());
 
         // "Users" section: admins/maintainers/members, then observers.
 

--- a/src/main/java/com/knowledgepixels/nanodash/component/ViewList.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/ViewList.java
@@ -125,6 +125,15 @@ public class ViewList extends Panel {
                                 } else {
                                     queryRefParams.put(view.getQueryField() + "Np", npId);
                                 }
+                            } else if (paramName.equals("root_np")) {
+                                // Auto-fill the ref scope (root nanopub) from the page's effective ref,
+                                // the same way the resource IRI above is filled, so a content-tab view
+                                // whose query opts into ref-scoping is scoped without the panel threading
+                                // it. Left empty when no ref is known (an optional placeholder tolerates
+                                // the empty VALUES; the ref-scoped query then yields its no-ref result).
+                                if (refRoot != null && !refRoot.isEmpty()) {
+                                    queryRefParams.put("root_np", refRoot);
+                                }
                             } else if (!QueryTemplate.isOptionalPlaceholder(p)) {
                                 item.add(new Label("view", "<span class=\"negative\">Error: Query has non-optional parameter</span>").setEscapeModelStrings(false));
                                 logger.error("Error: Query has non-optional parameter: {} {}", view.getQuery().getQueryId(), p);


### PR DESCRIPTION
## What

The About-tab **view-displays** tables now take their query from each view nanopub's `gen:hasViewQuery` instead of a hardcoded `QueryApiAccess` constant. Both panels just resolve `vdView.getQuery()` and supply the params.

- **Spaces** and **maintained resources** → the **ref-scoped** `list-view-displays` query (`root_np`), supplying the pinned-or-representative ref. Maintained resources resolve to their owning space via `npa:isMaintainedBy`, so they're now ref-scoped (previously IRI-keyed).
- **Users** → stay on the IRI-keyed query (no space ref; a user's displays go through the query's self-account branch).
- The pre-v3 no-ref fallback is **dropped** (v3 data always has a ref).
- `ViewList` gains a `root_np` auto-fill branch (from its `refRoot`), parallel to the `resource`/`…Np` fills, so a content-tab view whose query opts into ref-scoping is scoped without the panel threading it.
- The now-unused `LIST_VIEW_DISPLAYS` / `LIST_VIEW_DISPLAYS_REF` constants are removed — query identity lives in the view nanopubs.

## Why not a single unified query

A single dual-mode (ref/IRI) query was attempted and **times out** on grlc: the role gate runs inside a federated `SERVICE`, and an absent ref turns `forSpaceRef` into a global scan (the REF query's `root_np` is also a *required* placeholder, so grlc rejects an empty call). The fix is to **always supply a ref** so the fast REF query serves everything that has one.

## Published nanopubs (live)

The space and maintained view nanopubs were superseded to point `hasViewQuery` at the REF query `RAE8SOXg…`:
- space view → `RAiNrals9m7glgRFdu1i4pygixr5VGfA1ERoA_DpwdT0A`
- maintained view → `RAYgOvKdvtMDs5NIvP0KvJu0jyCtAG6HslBoQwstjmDOI`

Both single-head supersedes (no forks), correctly signed (`orcid:0000-0002-1267-0234`) with template links preserved. `View.get` resolution confirmed.

## ⚠️ Deploy coupling

The maintained view now points at the **required-`root_np`** REF query. This PR's code supplies `root_np`; **without it, maintained-resource About pages 400** (`Missing value for non-optional placeholder`). Deploy this together with / promptly after the view supersede. Spaces are unaffected pre-deploy (old code uses the constant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)