### PR TITLE
fix: prevent cold-cache race that breaks the home page

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/ApiCache.java
+++ b/src/main/java/com/knowledgepixels/nanodash/ApiCache.java
@@ -41,6 +41,12 @@ public class ApiCache {
     // fresh fetch. Acts as the stale-data fallback during API outages.
     private static final long MAX_CACHE_AGE_MS = 24 * 60 * 60 * 1000;
 
+    // Upper bound a synchronous caller waits for an in-flight refresh started by
+    // another thread when it has nothing cached yet. Without this wait the caller
+    // returns null, letting repositories memoise an empty snapshot (see
+    // retrieveResponseSync).
+    private static final long SYNC_WAIT_FOR_INFLIGHT_MS = 10 * 1000;
+
     private static final Cache<String, ApiResponse> cachedResponses = CacheBuilder.newBuilder()
         .maximumSize(MAX_CACHE_ENTRIES)
         .expireAfterAccess(24, TimeUnit.HOURS)
@@ -185,6 +191,23 @@ public class ApiCache {
                 lastRefresh.put(cacheId, System.currentTimeMillis());
             } finally {
                 refreshStart.remove(cacheId);
+            }
+        } else if (cachedResponses.getIfPresent(cacheId) == null && isRunning(cacheId)) {
+            // Another thread is doing the first fetch of this query and we have
+            // nothing cached yet. Wait for it rather than returning null: a null
+            // here lets a caller (e.g. SpaceRepository) memoise an EMPTY snapshot,
+            // which then poisons MaintainedResourceRepository.build() and breaks
+            // the home page until the next refresh. This adds no new work; it only
+            // waits on the refresh already in flight.
+            try {
+                long deadline = timeNow + SYNC_WAIT_FOR_INFLIGHT_MS;
+                while (isRunning(cacheId)
+                        && cachedResponses.getIfPresent(cacheId) == null
+                        && System.currentTimeMillis() < deadline) {
+                    Thread.sleep(50);
+                }
+            } catch (InterruptedException ex) {
+                Thread.currentThread().interrupt();
             }
         }
         return cachedResponses.getIfPresent(cacheId);

--- a/src/main/java/com/knowledgepixels/nanodash/repository/MaintainedResourceRepository.java
+++ b/src/main/java/com/knowledgepixels/nanodash/repository/MaintainedResourceRepository.java
@@ -69,6 +69,13 @@ public class MaintainedResourceRepository {
                 return snapshot;
             }
             Snapshot built = build(resp);
+            if (built == null) {
+                // Spaces weren't loaded yet, so every resource would have been
+                // dropped (each row's space resolved to null). Don't latch this
+                // empty result against the current response identity — return what
+                // we have and rebuild on the next access, once spaces are warm.
+                return snapshot;
+            }
             snapshot = built;
             cachedFor = resp;
             return built;
@@ -87,13 +94,20 @@ public class MaintainedResourceRepository {
         Map<String, MaintainedResource> byNamespace = new HashMap<>();
         Map<Space, List<MaintainedResource>> bySpace = new HashMap<>();
         Set<String> seenResources = new HashSet<>();
+        boolean droppedForMissingSpace = false;
         for (ApiResponseEntry r : resp.getData()) {
             String resourceId = r.get("resource");
             if (resourceId == null || resourceId.isEmpty()) continue;
             if (!seenResources.add(resourceId)) continue; // first row (newest date) wins
             String spaceId = r.get("space");
             Space space = SpaceRepository.get().findById(spaceId);
-            if (space == null) continue;
+            if (space == null) {
+                // Space not (yet) loaded — likely a cold/racing SpaceRepository
+                // rather than a genuinely unknown space. Track it so current()
+                // can avoid latching an under-built snapshot.
+                if (spaceId != null && !spaceId.isEmpty()) droppedForMissingSpace = true;
+                continue;
+            }
             ApiResponseEntry entry = new ApiResponseEntry();
             entry.add("resource", resourceId);
             entry.add("np", r.get("np"));
@@ -108,6 +122,12 @@ public class MaintainedResourceRepository {
                 // TODO Handle conflicts when two resources claim the same namespace:
                 byNamespace.put(resource.getNamespace(), resource);
             }
+        }
+        if (byId.isEmpty() && droppedForMissingSpace) {
+            // Every resource was dropped because its space wasn't resolvable, yet
+            // the response did contain rows — SpaceRepository is cold. Signal "not
+            // ready" so current() doesn't memoise this empty result.
+            return null;
         }
         MaintainedResourceFactory.removeStale(byId.keySet());
         return new Snapshot(byId, byNamespace, bySpace);


### PR DESCRIPTION
## Problem

On a fresh start, the home page intermittently shows a red **"Configured home resource `…` could not be found"** error. It clears only after visiting a space page (e.g. *Knowledge Pixels › Nanodash › Nanodash Home*), after which the home page renders correctly too.

## Root cause

A concurrent cold-cache race across two repositories:

1. `HomePage` → `MaintainedResourceRepository.findById()` → `build()`.
2. `build()` resolves each row's space via `SpaceRepository.findById()`; when a space is `null` it **silently skips** the resource.
3. On a cold cache with a refresh already in flight on another thread, `ApiCache.retrieveResponseSync` **returned `null`** (it skipped the fetch because `isRunning` was true and nothing was cached yet).
4. `SpaceRepository` therefore handed back its `EMPTY` snapshot → every maintained resource was dropped → `build()` produced an empty map.
5. That empty map got **memoised** against the maintained-resources `ApiResponse` identity and served for up to ~60s — so the error persisted, not just for one render.

Visiting a space page warms `SpaceRepository` (via `resolveSpace()`), so the next maintained-resources rebuild finds the spaces and succeeds.

## Fix

- **`ApiCache.retrieveResponseSync`** now waits (bounded to 10s) for an in-flight refresh when it has nothing cached yet, instead of returning `null`. This restores the "sync" contract — a caller gets data rather than letting a repository memoise an empty snapshot. It submits no new work; it only polls the refresh already running.
- **`MaintainedResourceRepository.build()`** now returns `null` (and `current()` declines to latch it) when the response had rows but every one was dropped for an unresolvable space — the tell-tale of a cold `SpaceRepository`. A genuinely empty resource list still caches normally.

Together these close the race that produced the empty build and ensure an under-built snapshot can never get cached.

## Testing

Compiles cleanly. This is a concurrency race best confirmed under cold-start/load rather than a single local reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)