### PR TITLE
Read role tier off the RoleInstantiation in member/observer listings

### DIFF
--- a/docs/queries/list-space-members-ref.trig
+++ b/docs/queries/list-space-members-ref.trig
@@ -4,6 +4,7 @@
 @prefix grlc: <https://w3id.org/kpxl/grlc/> .
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix npx: <http://purl.org/nanopub/x/> .
+@prefix nt: <https://w3id.org/np/o/ntemplate/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix orcid: <https://orcid.org/> .
@@ -19,7 +20,7 @@ sub:Head {
 
 sub:assertion {
   sub:list-space-members a grlc:grlc-query;
-    dct:description "Lists the members of a given space ref (space IRI + root definition) together with their highest role tier (admin, maintainer, or member, in that order) and links to the role-assignment nanopubs (labelled by the specific role name, preferring schema:name). Observer-tier roles are excluded. When the same role is assigned to the same person by multiple nanopubs, only the latest one is linked. Pass the ref's root nanopub (root_np); the query resolves the ref via npa:rootNanopub and scopes the role instantiations by npa:forSpaceRef, so it shows only the members of that one ref rather than merging all refs claiming the IRI. Ref-scoped variant of list-space-members (which is IRI-keyed via npa:forSpace).";
+    dct:description "Lists the members (admin/maintainer/member tier) of a space ref with their highest tier and role-assignment links. Reads tier directly off each validated gen:RoleInstantiation (npa:hasRoleType / gen:hasRole) in the current space state; observer-tier excluded. Published as RApyKS9D (nanodash#498).";
     dct:license <http://www.apache.org/licenses/LICENSE-2.0>;
     rdfs:label "List space members (ref-scoped)";
     grlc:endpoint <https://w3id.org/np/l/nanopub-query-1.1/repo/spaces>;
@@ -29,7 +30,6 @@ prefix np: <http://www.nanopub.org/nschema#>
 prefix npa: <http://purl.org/nanopub/admin/>
 prefix gen: <https://w3id.org/kpxl/gen/terms/>
 prefix schema: <http://schema.org/>
-
 select ?member ?tier ?role_assignments_multi_iri ?role_assignments_label_multi where {
   {
     select ?member
@@ -39,7 +39,7 @@ select ?member ?tier ?role_assignments_multi_iri ?role_assignments_label_multi w
            (group_concat(?roleLabel; separator=\"\\n\") as ?role_assignments_label_multi)
     where {
       {
-        select ?member ?roleProp
+        select ?member ?role
                (min(?rank0) as ?rank)
                (sample(?roleLabel0) as ?roleLabel)
                (strafter(max(concat(coalesce(str(?dateNp),\"\"), \" \", str(?grantNp))), \" \") as ?latestNp)
@@ -48,29 +48,25 @@ select ?member ?tier ?role_assignments_multi_iri ?role_assignments_label_multi w
           graph npa:spacesGraph { ?spaceRef npa:rootNanopub ?_root_np_multi_iri . }
           graph npa:graph { npa:thisRepo npa:hasCurrentSpaceState ?g . }
           graph ?g {
-            ?ri a gen:RoleInstantiation ; npa:forSpaceRef ?spaceRef ; npa:forAgent ?member ; npa:viaNanopub ?grantNp .
+            ?ri a gen:RoleInstantiation ; npa:forSpaceRef ?spaceRef ; npa:forAgent ?member ;
+                npa:viaNanopub ?grantNp ; npa:hasRoleType ?rt .
           }
-          bind(exists { graph ?g { ?ri npa:inverseProperty gen:hasAdmin } } as ?isAdmin)
-          optional { graph npa:spacesGraph { ?ri (npa:regularProperty|npa:inverseProperty) ?ropExt } }
-          optional { graph ?g { ?ri (npa:regularProperty|npa:inverseProperty) ?ropState } }
-          bind(coalesce(?ropExt,?ropState) as ?roleProp)
-          bind(exists { graph npa:spacesGraph { ?rd a npa:RoleDeclaration ; npa:hasRoleType gen:MaintainerRole ; (gen:hasRegularProperty|gen:hasInverseProperty) ?roleProp } } as ?isMaintainer)
-          bind(exists { graph npa:spacesGraph { ?rd a npa:RoleDeclaration ; npa:hasRoleType gen:MemberRole ; (gen:hasRegularProperty|gen:hasInverseProperty) ?roleProp } } as ?isMember)
-          bind(if(?isAdmin,1,if(?isMaintainer,2,if(?isMember,3,0))) as ?rank0)
+          bind(if(?rt=gen:AdminRole,1,if(?rt=gen:MaintainerRole,2,if(?rt=gen:MemberRole,3,0))) as ?rank0)
+          filter(?rank0 > 0)
           optional { graph npa:graph { ?grantNp dct:created ?dateNp } }
           optional {
-            graph npa:spacesGraph { ?rd2 a npa:RoleDeclaration ; (gen:hasRegularProperty|gen:hasInverseProperty) ?roleProp ; npa:viaNanopub ?roleNp ; npa:role ?role . }
+            graph ?g { ?ri gen:hasRole ?role . }
+            graph npa:spacesGraph { ?rd npa:role ?role ; npa:viaNanopub ?roleNp . }
             graph npa:graph { ?roleNp np:hasAssertion ?role_a . }
             optional { graph ?role_a { ?role schema:name ?rlS } }
             optional { graph ?role_a { ?role rdfs:label ?rlA } }
             optional { graph ?role_a { ?role dct:title ?rlB } }
             bind(coalesce(?rlS,?rlA,?rlB) as ?rl)
           }
-          bind(if(?isAdmin,coalesce(?rl,\"admin\"),coalesce(?rl,\"role\")) as ?roleLabel0)
+          bind(if(?rt=gen:AdminRole,\"admin\",coalesce(?rl,\"role\")) as ?roleLabel0)
         }
-        group by ?member ?roleProp
+        group by ?member ?role
       }
-      filter(?rank > 0)
     }
     group by ?member
   }
@@ -85,7 +81,7 @@ sub:provenance {
 sub:pubinfo {
   orcid:0000-0002-1267-0234 foaf:name "Tobias Kuhn" .
 
-  this: dct:created "2026-06-17T06:44:57Z"^^xsd:dateTime;
+  this: dct:created "2026-06-23T19:50:34Z"^^xsd:dateTime;
     dct:creator orcid:0000-0002-1267-0234;
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
     npx:embeds sub:list-space-members .

--- a/docs/queries/list-space-observers-ref.trig
+++ b/docs/queries/list-space-observers-ref.trig
@@ -4,6 +4,7 @@
 @prefix grlc: <https://w3id.org/kpxl/grlc/> .
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix npx: <http://purl.org/nanopub/x/> .
+@prefix nt: <https://w3id.org/np/o/ntemplate/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix orcid: <https://orcid.org/> .
@@ -19,9 +20,9 @@ sub:Head {
 
 sub:assertion {
   sub:list-space-observers a grlc:grlc-query;
-    dct:description "Lists the observers of a given space ref (space IRI + root definition): agents holding an observer-tier role and no validated admin/maintainer/member role. Pass the ref's root nanopub (root_np). Per (member, role) only the latest role-instantiation nanopub is returned (by dct:created), so a role re-asserted several times shows once. Unlike list-space-observers (validated-only), this also includes self-declared observers whose key is not trust-validated (no accepted introduction), flagging them in the headerless ?unverified_noheader column. The role label is pinned to the role the space actually assigned (RoleAssignment), correct even when several declarations share a property. Ref-scoped; shows un-introduced observers rather than hiding them.";
+    dct:description "Lists every observer-tier role association of a space ref (validated plus un-introduced self-declared, flagged via the headerless column). Excludes a member only when they hold a VALIDATED higher tier read off a gen:RoleInstantiation (npa:hasRoleType) in the current space state. Published as RAoW4pMA (nanodash#498).";
     dct:license <http://www.apache.org/licenses/LICENSE-2.0>;
-    rdfs:label "List space observers (ref-scoped, with validation flag)";
+    rdfs:label "List space observers (ref-scoped, all observer-tier associations, with validation flag)";
     grlc:endpoint <https://w3id.org/np/l/nanopub-query-1.1/repo/spaces>;
     grlc:sparql """prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 prefix dct: <http://purl.org/dc/terms/>
@@ -46,17 +47,15 @@ where {
       graph npa:spacesGraph { ?ref npa:rootNanopub ?_root_np_multi_iri ; npa:spaceIri ?spaceIri . }
       graph npa:graph { npa:thisRepo npa:hasCurrentSpaceState ?g . }
       graph npa:spacesGraph {
-        ?ri a gen:RoleInstantiation ; npa:forSpace ?spaceIri ; npa:forAgent ?member ; npa:viaNanopub ?grantNp ;
+        ?ri a gen:RoleInstantiation ; npa:forSpace ?inSpace ; npa:forAgent ?member ; npa:viaNanopub ?grantNp ;
             (npa:regularProperty|npa:inverseProperty) ?roleProp .
       }
+      filter( ?inSpace = ?spaceIri || exists { graph ?g { ?inSpace npa:sameAsSpace ?ref } } )
       filter exists { graph npa:spacesGraph { ?rdf a npa:RoleDeclaration ; npa:hasRoleType gen:ObserverRole ; (gen:hasRegularProperty|gen:hasInverseProperty) ?roleProp } }
-      filter not exists { graph npa:graph { ?invNp npx:invalidates ?grantNp . } }
-      filter not exists {
-        graph ?g { ?hri npa:forSpaceRef ?ref ; npa:forAgent ?member ; (npa:regularProperty|npa:inverseProperty) ?hp . }
-        graph npa:spacesGraph { ?hrd a npa:RoleDeclaration ; (gen:hasRegularProperty|gen:hasInverseProperty) ?hp .
-          { ?hrd npa:hasRoleType gen:MemberRole } union { ?hrd npa:hasRoleType gen:MaintainerRole } }
-      }
-      filter not exists { graph ?g { ?ari npa:forSpaceRef ?ref ; npa:forAgent ?member ; npa:inverseProperty gen:hasAdmin . } }
+      filter(?roleProp != gen:hasAdmin)
+      filter not exists { graph ?g { ?vriH a gen:RoleInstantiation ; npa:forSpaceRef ?ref ; npa:forAgent ?member .
+        { ?vriH npa:hasRoleType gen:AdminRole } union { ?vriH npa:hasRoleType gen:MaintainerRole } union { ?vriH npa:hasRoleType gen:MemberRole } } }
+      filter not exists { graph npa:graph { ?invNp npx:invalidates ?grantNp ; npa:hasValidSignatureForPublicKeyHash ?invpk . ?grantNp npa:hasValidSignatureForPublicKeyHash ?invpk . } }
       bind(if(exists { graph ?g { ?vri npa:forSpaceRef ?ref ; npa:forAgent ?member ; npa:viaNanopub ?grantNp } }, 1, 0) as ?val0)
       optional { graph npa:graph { ?grantNp dct:created ?dateNp } }
       optional {
@@ -84,7 +83,7 @@ sub:provenance {
 sub:pubinfo {
   orcid:0000-0002-1267-0234 foaf:name "Tobias Kuhn" .
 
-  this: dct:created "2026-06-16T12:42:36Z"^^xsd:dateTime;
+  this: dct:created "2026-06-23T19:50:34Z"^^xsd:dateTime;
     dct:creator orcid:0000-0002-1267-0234;
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
     npx:embeds sub:list-space-observers .

--- a/src/main/java/com/knowledgepixels/nanodash/QueryApiAccess.java
+++ b/src/main/java/com/knowledgepixels/nanodash/QueryApiAccess.java
@@ -157,7 +157,13 @@ public class QueryApiAccess {
     // the query returned ZERO observers for every space. Replaced with a non-union
     // `filter( ?inSpace = ?spaceIri || exists { ... sameAsSpace ... } )`. Source at
     // docs/queries/list-space-observers-ref-v5.trig.
-    public static final String LIST_SPACE_OBSERVERS_REF = "RAUQdhb2lwrSA6Vqv96ERyISUhO9U9eOFNWsSe9NMwiWE/list-space-observers";
+    // Latest (RAoW4pMA, nanodash#498): a member is excluded from the observers list only when they
+    // hold a VALIDATED higher tier, read directly off a gen:RoleInstantiation (npa:hasRoleType in
+    // {AdminRole,MaintainerRole,MemberRole}) in the current space state — replacing the global
+    // RoleDeclaration matching that mis-excluded observers whose predicate was declared at a higher
+    // tier by another space (which had returned ZERO observers for spaces like vu/ucds). Enabled by
+    // nanopub-query persisting tier on the instantiation (nanopub-query#125 + #127).
+    public static final String LIST_SPACE_OBSERVERS_REF = "RAoW4pMAwNjx_DZOUGD-2UEioMSDuD_leg3T4SceMiMbA/list-space-observers";
 
     // Ref-scoped non-approved role claims (root_np): agents holding a higher-tier role
     // instantiation (admin/maintainer/member) that is NOT in the validated state — a
@@ -189,7 +195,12 @@ public class QueryApiAccess {
     // by AboutSpacePanel with an IRI-keyed fallback when the ref root is unknown. Published
     // independently (no npx:supersedes). Sources at docs/queries/list-*-ref.trig. See
     // docs/space-ref-identity.md.
-    public static final String LIST_SPACE_MEMBERS_REF = "RAXhi9zBXJ2mZVmjBm_MZk1xM6OCxxVyr5B3xNYdy6boQ/list-space-members";
+    // v3 (RApyKS9D): reads each membership's tier directly off the materialized gen:RoleInstantiation
+    // (npa:hasRoleType) and its role (gen:hasRole) in the current space state, now that nanopub-query
+    // persists tier on the instantiation (nanopub-query#125 + #127). Simplifies away the earlier
+    // RoleAssignment-scoping workaround and the global RoleDeclaration matching that leaked observer-tier
+    // members into the Approved listing. See nanodash#498.
+    public static final String LIST_SPACE_MEMBERS_REF = "RApyKS9DSuA7LusWLrpURfmxQuEg-dbB-MqrneYRxLOOU/list-space-members";
     public static final String LIST_SPACE_ROLES_REF = "RAYrSRARuWV2iTWVe6tKDgkaED8ztlr1q5Z5QBIDV4a-Q/list-space-roles";
     public static final String LIST_SUB_SPACES_REF = "RA-j0DFqkNUHxF_WIds8wWJix6DkDFBmUBWmKXfG24XYQ/list-sub-spaces";
     public static final String LIST_MAINTAINED_RESOURCES_REF = "RAPthUMRDXiJeD2BrOsZigTsbA0LktBc-HC4alDSfVNKM/list-maintained-resources";


### PR DESCRIPTION
Now that nanopub-query persists `npa:hasRoleType` + `gen:hasRole` on validated `gen:RoleInstantiation`s (knowledgepixels/nanopub-query#125 + #127, deployed and re-materialized on all instances), the space role listings read tier directly off the RI instead of re-deriving it by matching the role predicate against **all global** `RoleDeclaration`s.

### Why
The global predicate match meant a predicate declared at a different tier by another space leaked the wrong tier in. Concretely:
- **Approved Admins/Maintainers/Members** listed observer-tier members (e.g. `gen:hasTeamMember`, declared `MemberRole` by another space).
- **Self-Assigned/Observers** returned **0 rows** for spaces like `vu/ucds` (the same global match tripped the higher-tier exclusion).

### What changed
- `LIST_SPACE_MEMBERS_REF` → `RApyKS9D` — node-read tier; now lists *all* admin/maintainer/member roles a person holds (the prior workaround under-reported).
- `LIST_SPACE_OBSERVERS_REF` → `RAoW4pMA` — excludes a member only on a **validated** higher tier read off the RI; the ⚠️ unverified-observer flag is preserved.
- `docs/queries/list-space-{members,observers}-ref.trig` synced to the published sources.

The IRI-keyed twins and the two view nanopubs (Approved / Self-Assigned-Observers) were already superseded + repointed at the new queries, so the **view-driven path is live now**; this PR wires the **constant-driven path** (needs the usual deploy).

Verified against the freshly-materialized live state: `vu/ucds` → 4 admins / its 2 real observers; `knowledgepixels` → admins (now correctly also showing their member-tier roles) / 0 observers.

Pending Admins/Maintainers/Members was reviewed and left as-is (operates on unvalidated claims; works in practice; latent global-tier-match edge case noted in #498).

Closes #498.

🤖 Generated with [Claude Code](https://claude.com/claude-code)