### PR TITLE
refactor: read role labels from schema:name only in member/observer listings

### DIFF
--- a/docs/queries/list-space-members-ref.trig
+++ b/docs/queries/list-space-members-ref.trig
@@ -20,7 +20,7 @@ sub:Head {
 
 sub:assertion {
   sub:list-space-members a grlc:grlc-query;
-    dct:description "Lists the members (admin/maintainer/member tier) of a space ref with their highest tier and role-assignment links. Reads tier directly off each validated gen:RoleInstantiation (npa:hasRoleType / gen:hasRole) in the current space state; observer-tier excluded. Published as RApyKS9D (nanodash#498).";
+    dct:description "Lists the members (admin/maintainer/member tier) of a space ref with their highest tier and role-assignment links. Reads tier directly off each validated gen:RoleInstantiation (npa:hasRoleType / gen:hasRole) in the current space state; observer-tier excluded. Role labels read from schema:name only. Published as RA7E54m5 (supersedes RApyKS9D; nanodash#498).";
     dct:license <http://www.apache.org/licenses/LICENSE-2.0>;
     rdfs:label "List space members (ref-scoped)";
     grlc:endpoint <https://w3id.org/np/l/nanopub-query-1.1/repo/spaces>;
@@ -58,10 +58,7 @@ select ?member ?tier ?role_assignments_multi_iri ?role_assignments_label_multi w
             graph ?g { ?ri gen:hasRole ?role . }
             graph npa:spacesGraph { ?rd npa:role ?role ; npa:viaNanopub ?roleNp . }
             graph npa:graph { ?roleNp np:hasAssertion ?role_a . }
-            optional { graph ?role_a { ?role schema:name ?rlS } }
-            optional { graph ?role_a { ?role rdfs:label ?rlA } }
-            optional { graph ?role_a { ?role dct:title ?rlB } }
-            bind(coalesce(?rlS,?rlA,?rlB) as ?rl)
+            optional { graph ?role_a { ?role schema:name ?rl } }
           }
           bind(if(?rt=gen:AdminRole,\"admin\",coalesce(?rl,\"role\")) as ?roleLabel0)
         }

--- a/docs/queries/list-space-observers-ref.trig
+++ b/docs/queries/list-space-observers-ref.trig
@@ -20,7 +20,7 @@ sub:Head {
 
 sub:assertion {
   sub:list-space-observers a grlc:grlc-query;
-    dct:description "Lists every observer-tier role association of a space ref (validated plus un-introduced self-declared, flagged via the headerless column). Excludes a member only when they hold a VALIDATED higher tier read off a gen:RoleInstantiation (npa:hasRoleType) in the current space state. Published as RAoW4pMA (nanodash#498).";
+    dct:description "Lists every observer-tier role association of a space ref (validated plus un-introduced self-declared, flagged via the headerless column). Excludes a member only when they hold a VALIDATED higher tier read off a gen:RoleInstantiation (npa:hasRoleType) in the current space state. Role labels read from schema:name only. Published as RAZNHDFQ (supersedes RAoW4pMA; nanodash#498).";
     dct:license <http://www.apache.org/licenses/LICENSE-2.0>;
     rdfs:label "List space observers (ref-scoped, all observer-tier associations, with validation flag)";
     grlc:endpoint <https://w3id.org/np/l/nanopub-query-1.1/repo/spaces>;
@@ -62,10 +62,7 @@ where {
         graph ?g { ?raRole a gen:RoleAssignment ; npa:forSpaceRef ?ref ; gen:hasRole ?role . }
         graph npa:spacesGraph { ?rd2 a npa:RoleDeclaration ; npa:role ?role ; (gen:hasRegularProperty|gen:hasInverseProperty) ?roleProp ; npa:viaNanopub ?roleNp . }
         graph npa:graph { ?roleNp np:hasAssertion ?role_a . }
-        optional { graph ?role_a { ?role schema:name ?rlS } }
-        optional { graph ?role_a { ?role rdfs:label ?rlA } }
-        optional { graph ?role_a { ?role dct:title ?rlB } }
-        bind(coalesce(?rlS, ?rlA, ?rlB) as ?rl)
+        optional { graph ?role_a { ?role schema:name ?rl } }
       }
     }
     group by ?member ?roleProp

--- a/src/main/java/com/knowledgepixels/nanodash/QueryApiAccess.java
+++ b/src/main/java/com/knowledgepixels/nanodash/QueryApiAccess.java
@@ -162,8 +162,9 @@ public class QueryApiAccess {
     // {AdminRole,MaintainerRole,MemberRole}) in the current space state — replacing the global
     // RoleDeclaration matching that mis-excluded observers whose predicate was declared at a higher
     // tier by another space (which had returned ZERO observers for spaces like vu/ucds). Enabled by
-    // nanopub-query persisting tier on the instantiation (nanopub-query#125 + #127).
-    public static final String LIST_SPACE_OBSERVERS_REF = "RAoW4pMAwNjx_DZOUGD-2UEioMSDuD_leg3T4SceMiMbA/list-space-observers";
+    // nanopub-query persisting tier on the instantiation (nanopub-query#125 + #127). Latest
+    // (RAZNHDFQ, supersedes RAoW4pMA) drops the role-label coalesce to read schema:name only.
+    public static final String LIST_SPACE_OBSERVERS_REF = "RAZNHDFQj9EUF6d3MJtKhFpd6cip5EcRiS-jjMNRyNMMg/list-space-observers";
 
     // Ref-scoped non-approved role claims (root_np): agents holding a higher-tier role
     // instantiation (admin/maintainer/member) that is NOT in the validated state — a
@@ -199,8 +200,9 @@ public class QueryApiAccess {
     // (npa:hasRoleType) and its role (gen:hasRole) in the current space state, now that nanopub-query
     // persists tier on the instantiation (nanopub-query#125 + #127). Simplifies away the earlier
     // RoleAssignment-scoping workaround and the global RoleDeclaration matching that leaked observer-tier
-    // members into the Approved listing. See nanodash#498.
-    public static final String LIST_SPACE_MEMBERS_REF = "RApyKS9DSuA7LusWLrpURfmxQuEg-dbB-MqrneYRxLOOU/list-space-members";
+    // members into the Approved listing. See nanodash#498. Latest (RA7E54m5, supersedes RApyKS9D)
+    // drops the role-label coalesce to read schema:name only.
+    public static final String LIST_SPACE_MEMBERS_REF = "RA7E54m5Hb413Ud-0T9HEiH9wnxlJXBkcUT701NDaUGQk/list-space-members";
     public static final String LIST_SPACE_ROLES_REF = "RAYrSRARuWV2iTWVe6tKDgkaED8ztlr1q5Z5QBIDV4a-Q/list-space-roles";
     public static final String LIST_SUB_SPACES_REF = "RA-j0DFqkNUHxF_WIds8wWJix6DkDFBmUBWmKXfG24XYQ/list-sub-spaces";
     public static final String LIST_MAINTAINED_RESOURCES_REF = "RAPthUMRDXiJeD2BrOsZigTsbA0LktBc-HC4alDSfVNKM/list-maintained-resources";


### PR DESCRIPTION
## What

Simplifies the role **label** lookup in the four space member/observer listing queries from `coalesce(schema:name, rdfs:label, dct:title)` down to `schema:name` only. Roles are canonically labelled with `schema:name` (the assigned-roles view already reads it), so the `rdfs:label`/`dct:title` fallbacks were dead branches.

Follow-up to #499 (which moved tier classification onto the materialized `gen:RoleInstantiation`).

## Why it's safe

Verified a **no-op** against the live `spaces` repo:

- A global audit found exactly two roles lacking `schema:name` — `…/memberRole` ("Members") and `…/participantRole` ("Participants"), both WikiData-based — and **neither is instantiated** in any validated state.
- Old-vs-new query output is **byte-identical** on `vu/ucds` and `knowledgepixels/incubator/project1`; named labels (`team member`, `project lead`, `admin`) render unchanged.

Caveat: if either label-less role is ever granted, its label would show the generic "role" until it gains a `schema:name`.

## Published live (supersedes)

| query | old → new |
|---|---|
| members ref | `RApyKS9D` → `RA7E54m5` |
| observers ref | `RAoW4pMA` → `RAZNHDFQ` |
| members IRI | `RA31qGZj` → `RAxASd13` (view `RAdcgJ7k` → `RAjg1etF`) |
| observers IRI | `RAT1mruQ` → `RA3xiGd-` (view `RAJO93aO` → `RAeO10jI`) |

This PR updates the two ref-query constants (`LIST_SPACE_MEMBERS_REF`, `LIST_SPACE_OBSERVERS_REF`) and the local `.trig` mirrors. The IRI queries are repointed via their view nanopubs, whose constants resolve to the latest version automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)