### PR TITLE
fix: pretty-print dates in multi-valued table cells and list-view output

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultItemList.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultItemList.java
@@ -110,6 +110,10 @@ public class QueryResultItemList extends QueryResult {
                         String html = "<span class=\"tooltip\"><span class=\"tooltiptext tooltiptext-auto\">" + Strings.escapeMarkup(value) + "</span>" + Strings.escapeMarkup(entryLabel) + "</span>";
                         item.add(new Label("listItem", html).setEscapeModelStrings(false));
                         return;
+                    } else if (Utils.isDateTimeLiteral(value)) {
+                        // Show a friendly relative time (client-side); raw ISO value stays as no-script fallback.
+                        item.add(new Label("listItem", Utils.friendlyDateHtml(value, value)).setEscapeModelStrings(false));
+                        return;
                     } else {
                         item.add(new Label("listItem", value));
                         return;

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultTable.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultTable.java
@@ -362,13 +362,20 @@ public class QueryResultTable extends QueryResult {
                                 components.add(new NanodashLink("component", part, null, null, label, contextId));
                             } else {
                                 String label = truncateLabel(rawLabel);
-                                String display = label != null ? label : Utils.unescapeMultiValue(part);
-                                if (Utils.looksLikeHtml(display)) {
-                                    components.add(new Label("component", Utils.sanitizeHtml(display))
-                                            .setEscapeModelStrings(false)
-                                            .add(new AttributeAppender("class", "cell-data-html")));
+                                String unescaped = Utils.unescapeMultiValue(part);
+                                if (label == null && Utils.isDateTimeLiteral(unescaped)) {
+                                    // Friendly relative time, matching single-value cells.
+                                    components.add(new Label("component", Utils.friendlyDateHtml(unescaped, unescaped))
+                                            .setEscapeModelStrings(false));
                                 } else {
-                                    components.add(new Label("component", display));
+                                    String display = label != null ? label : unescaped;
+                                    if (Utils.looksLikeHtml(display)) {
+                                        components.add(new Label("component", Utils.sanitizeHtml(display))
+                                                .setEscapeModelStrings(false)
+                                                .add(new AttributeAppender("class", "cell-data-html")));
+                                    } else {
+                                        components.add(new Label("component", display));
+                                    }
                                 }
                             }
                         }
@@ -380,13 +387,13 @@ public class QueryResultTable extends QueryResult {
                         String[] labels = labelValue != null ? labelValue.split("\n", -1) : null;
                         List<Component> components = new ArrayList<>();
                         for (int i = 0; i < parts.length; i++) {
-                            String display;
-                            if (labels != null && i < labels.length && !labels[i].isBlank()) {
-                                display = Utils.unescapeMultiValue(labels[i]);
-                            } else {
-                                display = Utils.unescapeMultiValue(parts[i]);
-                            }
-                            if (Utils.looksLikeHtml(display)) {
+                            boolean hasLabel = labels != null && i < labels.length && !labels[i].isBlank();
+                            String display = hasLabel ? Utils.unescapeMultiValue(labels[i]) : Utils.unescapeMultiValue(parts[i]);
+                            if (!hasLabel && Utils.isDateTimeLiteral(display)) {
+                                // Friendly relative time, matching single-value cells.
+                                components.add(new Label("component", Utils.friendlyDateHtml(display, display))
+                                        .setEscapeModelStrings(false));
+                            } else if (Utils.looksLikeHtml(display)) {
                                 components.add(new Label("component", Utils.sanitizeHtml(display))
                                         .setEscapeModelStrings(false)
                                         .add(new AttributeAppender("class", "cell-data-html")));


### PR DESCRIPTION
## Problem

Date pretty-printing (friendly relative time, e.g. "10 minutes ago") was not working when a date appeared in a **multi-valued table cell** or as **list-view output** — those rendered the raw ISO timestamp instead.

## Cause

The friendly-date wrapping (`Utils.friendlyDateHtml`, emitting a `<time class="friendly-date">` element that `nanodash.js` rewrites client-side) was only applied in the **single-valued literal** branch of `QueryResultTable.populateItem`. The multi-value branches (`_multi`, `_multi_val`) and the separate `QueryResultItemList` component build their own `Label`s and short-circuit before that check, so they never consulted `isDateTimeLiteral`.

## Fix

Add the same `Utils.isDateTimeLiteral(...) → Utils.friendlyDateHtml(...)` check to:

1. `QueryResultTable` `_multi_val` literal sub-branch
2. `QueryResultTable` `_multi` branch
3. `QueryResultItemList` literal fallback

In all cases the friendly formatting only applies when there is no explicit display label (matching single-value priority); otherwise it falls through to the existing HTML/plain rendering. Bare `xsd:date` values (no time component) are unaffected, consistent with existing single-value behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)