### PR TITLE
fix: distinguish repeated local resources by index in form labels

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/component/IriItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/IriItem.java
@@ -13,6 +13,8 @@ import com.knowledgepixels.nanodash.template.UnificationException;
 import org.apache.wicket.behavior.AttributeAppender;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.link.ExternalLink;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.Model;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
@@ -77,7 +79,13 @@ public class IriItem extends AbstractContextComponent {
             // Capitalize first letter of label if at subject position:
             labelString = labelString.substring(0, 1).toUpperCase() + labelString.substring(1);
         }
+        boolean hadIndexPlaceholder = labelString.contains("%I%");
         labelString = labelString.replaceAll("%I%", "" + rg.getRepeatIndex());
+        // Auto-number repeated local resources so each expansion of a repeatable group is
+        // distinguishable (e.g. "the context-specific alias 1", "… 2"). Skip when the label
+        // already injects the index via %I%. The index/count are read lazily at render time
+        // (see the link model below) because they change as repetitions are added/removed.
+        final boolean autoNumber = template.isLocalResource(iri) && !hadIndexPlaceholder;
 
         String iriString = iri.stringValue();
         String description = "";
@@ -117,7 +125,21 @@ public class IriItem extends AbstractContextComponent {
         } else {
             href = NanodashLink.getPageUrl(iriString);
         }
-        ExternalLink linkComp = new ExternalLink("link", href, labelString.replaceFirst(" - .*$", ""));
+        final String linkLabelBase = labelString.replaceFirst(" - .*$", "");
+        IModel<String> linkLabelModel;
+        if (autoNumber) {
+            // Append the 1-based repetition index, but only once there is more than one
+            // repetition. Read lazily so the number stays correct as groups are added/removed.
+            linkLabelModel = (IModel<String>) () -> {
+                if (rg.getRepetitionCount() > 1) {
+                    return linkLabelBase + " " + (rg.getRepeatIndex() + 1);
+                }
+                return linkLabelBase;
+            };
+        } else {
+            linkLabelModel = Model.of(linkLabelBase);
+        }
+        ExternalLink linkComp = new ExternalLink("link", Model.of(href), linkLabelModel);
         if (iri.equals(NTEMPLATE.ASSERTION_PLACEHOLDER)) {
             linkComp.add(new AttributeAppender("class", " this-assertion "));
             iri = LocalUri.of("assertion");

--- a/src/main/java/com/knowledgepixels/nanodash/component/StatementItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/StatementItem.java
@@ -449,6 +449,15 @@ public class StatementItem extends Panel {
         }
 
         /**
+         * Returns the total number of repetition groups for this statement.
+         *
+         * @return the number of repetition groups
+         */
+        public int getRepetitionCount() {
+            return StatementItem.this.getRepetitionCount();
+        }
+
+        /**
          * Returns true if the repeat index if the first one.
          *
          * @return true if the repeat index is 0, false otherwise

--- a/src/main/java/com/knowledgepixels/nanodash/template/Template.java
+++ b/src/main/java/com/knowledgepixels/nanodash/template/Template.java
@@ -153,6 +153,7 @@ public class Template implements Serializable {
      * @return the transformed IRI, or the original IRI if no transformation is needed.
      */
     public IRI getFirstOccurrence(IRI iri) {
+        iri = transform(iri);
         for (IRI i : getStatementIris()) {
             if (statementMap.containsKey(i)) {
                 // grouped statement


### PR DESCRIPTION
## Problem

When a `nt:LocalResource` (e.g. a "context-specific alias") sits inside a **repeatable** statement group, every expansion showed the identical label — "the context-specific alias" — because `Template.getLabel` strips the `__N` repetition suffix before lookup.

A first attempt to auto-number them exposed two further bugs:
- The 2nd repetition showed **no number** while the 3rd showed "3" (and the base count was off).
- Repetitions past the first read "**the** context-specific alias" instead of "**a** context-specific alias".

## Causes & fixes

**1. Stale / missing number.** The label (and its appended index) was computed once in the `IriItem` constructor, which runs *before* the `RepetitionGroup` is added to `repetitionGroups`. So `getRepetitionCount()` was one too low at construction, and labels were never recomputed as repetitions were added — g0/g1 (built when count was 0/1) failed the `count > 1` gate, g2 (built at count 2) showed "3".

Fix: the 1-based index is now read **lazily at render time** via a dynamic `IModel` on the link label, reflecting the current `getRepeatIndex()`/`getRepetitionCount()` on every re-render (including after add/remove). Numbering only kicks in with more than one repetition, and the existing `%I%` author override is respected.

**2. "the" vs "a".** `getFirstOccurrence(contextalias__2)` compared the suffixed IRI against base IRIs, returned `null`, so the a→the rule always fired for repetitions ≥2. It now `transform()`s the IRI (stripping the suffix) before lookup, consistent with the other `Template` accessors.

## Changes
- `IriItem.java` — lazy index model; respects `%I%`; preserves the `" - description"` convention.
- `Template.java` — `getFirstOccurrence` transforms the IRI.
- `StatementItem.java` — public `RepetitionGroup.getRepetitionCount()` accessor.

Result: expansions render "a/the context-specific alias 1", "… 2", "… 3" correctly, updating live as groups are added or removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)