### PR TITLE
fix: map expanded ~~~ARTIFACTCODE~~~ IRIs back to template form for lookups

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/template/Template.java
+++ b/src/main/java/com/knowledgepixels/nanodash/template/Template.java
@@ -1019,11 +1019,21 @@ public class Template implements Serializable {
     }
 
     private IRI transform(IRI iri) {
-        if (iri.stringValue().matches(".*__[0-9]+")) {
-            // TODO: Check that this double-underscore pattern isn't used otherwise:
-            return vf.createIRI(iri.stringValue().replaceFirst("__[0-9]+$", ""));
+        String s = iri.stringValue();
+        // Map a rendered IRI back to its template form for map lookups (label, type,
+        // datatype, …). RepetitionGroup.transform expands the template's "~~ARTIFACTCODE~~"
+        // placeholder to the target-namespace "~~~ARTIFACTCODE~~~" form and appends a "__N"
+        // repetition suffix; both must be undone here or the lookup keyed on the template
+        // form (e.g. an attached rdfs:label) is missed.
+        if (s.contains("~~~ARTIFACTCODE~~~")) {
+            s = s.replace("~~~ARTIFACTCODE~~~", "~~ARTIFACTCODE~~");
         }
-        return iri;
+        if (s.matches(".*__[0-9]+")) {
+            // TODO: Check that this double-underscore pattern isn't used otherwise:
+            s = s.replaceFirst("__[0-9]+$", "");
+        }
+        if (s.equals(iri.stringValue())) return iri;
+        return vf.createIRI(s);
     }
 
     private StatementComparator statementComparator = new StatementComparator();


### PR DESCRIPTION
## Problem

A template IRI containing the `~~ARTIFACTCODE~~` placeholder is expanded to the target-namespace `~~~ARTIFACTCODE~~~` form by `RepetitionGroup.transform` when the form is rendered. But the template's `labelMap` — along with `typeMap`, `datatypeMap`, etc. — is keyed by the original **double**-tilde template form. So when `IriItem` looks up an attached label via `template.getLabel(iri)` with the expanded **triple**-tilde IRI, the lookup missed and the label was lost (likewise for type/datatype lookups).

## Fix

`Template.transform` — the shared normalizer that every map accessor (`getLabel`, `isLocalResource`, `getDatatype`, …) runs the IRI through — now also maps `~~~ARTIFACTCODE~~~` back to `~~ARTIFACTCODE~~`, mirroring the existing `__N` repetition-suffix stripping. Both normalizations are applied in order, so an IRI carrying both (`…~~~ARTIFACTCODE~~~…__1`) resolves to its template key.

Only map lookups are affected; the displayed/published IRI string keeps its expanded `~~~ARTIFACTCODE~~~` form, which is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)