### PR TITLE
fix: don't abort the whole template fill on one unification failure

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/component/StatementItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/StatementItem.java
@@ -258,11 +258,28 @@ public class StatementItem extends Panel {
         if (!isRepeatable()) return;
         while (true) {
             Set<IRI> modelsBefore = new HashSet<>(context.getComponentModels().keySet());
+            List<Statement> statementsBefore = new ArrayList<>(statements);
             RepetitionGroup newGroup = new RepetitionGroup();
+            boolean filled;
             if (newGroup.matches(statements)) {
-                newGroup.fill(statements);
-                addRepetitionGroup(newGroup);
+                try {
+                    newGroup.fill(statements);
+                    filled = true;
+                } catch (UnificationException ex) {
+                    // matches() validates unifiability statelessly, but fill() mutates shared
+                    // placeholder models via unifyWith as it goes, so binding an earlier part can
+                    // make a later one non-unifiable ("seemed to work but then didn't"). Treat this
+                    // like end-of-repetitions rather than letting it abort the whole template fill:
+                    // roll back the partial statement consumption and discard the trial group.
+                    logger.warn("Repetition fill failed after matches() succeeded for {}; stopping repetitions of this statement", statementId, ex);
+                    statements.clear();
+                    statements.addAll(statementsBefore);
+                    filled = false;
+                }
             } else {
+                filled = false;
+            }
+            if (!filled) {
                 newGroup.disconnect();
                 // The trial group's constructor registered fresh (empty) component
                 // models for its narrow-scope placeholders (e.g. public-key__N). If
@@ -273,6 +290,7 @@ public class StatementItem extends Panel {
                 context.getComponentModels().keySet().retainAll(modelsBefore);
                 return;
             }
+            addRepetitionGroup(newGroup);
         }
     }
 

--- a/src/main/java/com/knowledgepixels/nanodash/template/TemplateContext.java
+++ b/src/main/java/com/knowledgepixels/nanodash/template/TemplateContext.java
@@ -28,6 +28,7 @@ import java.util.*;
  */
 public class TemplateContext implements Serializable {
 
+    private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TemplateContext.class);
     private static final ValueFactory vf = SimpleValueFactory.getInstance();
 
     private final ContextType contextType;
@@ -472,7 +473,17 @@ public class TemplateContext implements Serializable {
      */
     public void fill(List<Statement> statements) throws UnificationException {
         for (StatementItem si : statementItems) {
-            si.fill(statements);
+            // Isolate each statement: a unification failure on one must not abort the rest,
+            // otherwise every later template statement is left unmatched. Roll back any partial
+            // statement consumption so the next statement sees an intact pool.
+            List<Statement> statementsBefore = new ArrayList<>(statements);
+            try {
+                si.fill(statements);
+            } catch (UnificationException ex) {
+                logger.warn("Could not fill statement; continuing with the remaining statements", ex);
+                statements.clear();
+                statements.addAll(statementsBefore);
+            }
         }
         for (StatementItem si : statementItems) {
             si.fillFinished();


### PR DESCRIPTION
## Problem

When the viewer renders a nanopub via the template it was created from (`nt:wasCreatedFromTemplate`), each template statement is unified against the nanopub's triples. `RepetitionGroup.matches()` validates unifiability **statelessly**, but `RepetitionGroup.fill()` **mutates** shared placeholder models via `unifyWith` as it processes parts. So binding an earlier part can make a later one non-unifiable, and `fill()` throws `UnificationException("Unification seemed to work but then didn't")` even though `matches()` had just succeeded.

That exception propagated through `TemplateContext.fill` (no per-statement isolation) and was swallowed by `ValueFiller.fill`, **aborting the entire match**. Every template statement *after* the one that threw was left unmatched and rendered as raw "unused" triples.

This is especially severe for a self-referential template — viewing a template nanopub via its meta-template. On the "Defining a biochementity" template it dropped almost everything: all `rdf:type` declarations, all `rdfs:label` annotations, and all placeholder definitions rendered raw.

Root cause was confirmed by driving the real matcher in a harness:
```
ERROR ValueFiller - Could not fill template context
UnificationException: Unification seemed to work but then didn't
    at StatementItem$RepetitionGroup.fill(StatementItem.java:683)
    at StatementItem.fill(StatementItem.java:264)   ← the repeatable-group loop
```

## Fix (containment — issue #1 of 2)

Two complementary layers:

1. **`StatementItem.fill` repeatable loop** — if a trial repetition's `fill()` throws, roll back the partial statement consumption, discard the trial group (reusing the existing component-model cleanup), and stop adding repetitions, instead of letting the exception escape.
2. **`TemplateContext.fill`** — isolate each statement item: a `UnificationException` is logged and the statement pool is restored, so the remaining statements still match.

## Result

On the biochementity template the unmatched-statement count drops from **87 → 15**, and matched template statements go from 5 → 12. The residual 15 are the grouped sub-statement (`st9a`–`st9e`) reifications — a separate `matches()`/`fill()` consistency bug (the deeper "issue #2" fix). No behavior change for templates that unify cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)