### PR TITLE
fix: backtracking matcher so grouped shared-placeholder statements unify (#505)

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/component/StatementItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/StatementItem.java
@@ -654,25 +654,16 @@ public class StatementItem extends Panel {
          */
         public boolean matches(List<Statement> statements) {
             if (filled) return false;
-            List<Statement> st = new ArrayList<>(statements);
-            for (StatementPartItem p : statementParts) {
-                Statement matchedStatement = null;
-                for (Statement s : st) {
-                    if (
-                            p.getPredicate().isUnifiableWith(s.getPredicate()) &&  // checking predicate first optimizes performance
-                            p.getSubject().isUnifiableWith(s.getSubject()) &&
-                            p.getObject().isUnifiableWith(s.getObject())) {
-                        matchedStatement = s;
-                        break;
-                    }
-                }
-                if (matchedStatement == null) {
-                    return false;
-                } else {
-                    st.remove(matchedStatement);
-                }
+            // matches() must agree with fill(): because fill() binds shared placeholder models as it
+            // goes, a valid assignment can only be confirmed by actually simulating those bindings.
+            // We do exactly that (with backtracking) but on a copy and then restore the models, so
+            // matches() stays side-effect free.
+            Map<IRI, Object> snapshot = snapshotModels();
+            try {
+                return assignParts(0, new ArrayList<>(statements));
+            } finally {
+                restoreModels(snapshot);
             }
-            return true;
         }
 
         /**
@@ -683,26 +674,80 @@ public class StatementItem extends Panel {
          */
         public void fill(List<Statement> statements) throws UnificationException {
             if (filled) throw new UnificationException("Already filled");
-            for (StatementPartItem p : statementParts) {
-                Statement matchedStatement = null;
-                for (Statement s : statements) {
-                    if (
-                            p.getPredicate().isUnifiableWith(s.getPredicate()) &&  // checking predicate first optimizes performance
-                            p.getSubject().isUnifiableWith(s.getSubject()) &&
-                            p.getObject().isUnifiableWith(s.getObject())) {
-                        p.getPredicate().unifyWith(s.getPredicate());
-                        p.getSubject().unifyWith(s.getSubject());
-                        p.getObject().unifyWith(s.getObject());
-                        matchedStatement = s;
-                        break;
-                    }
+            // Backtracking assignment: a greedy first-match can bind a shared placeholder in a way
+            // that blocks a later part even though a consistent assignment exists. assignParts tries
+            // alternatives and rolls back the model bindings between attempts. On success the matched
+            // statements are removed from the list and the winning bindings are kept.
+            if (!assignParts(0, statements)) {
+                throw new UnificationException("Unification seemed to work but then didn't");
+            }
+            filled = true;
+        }
+
+        /**
+         * Tries to assign each remaining statement part (from index {@code partIndex} on) to a distinct
+         * statement in {@code available} such that all bindings of shared placeholder models are mutually
+         * consistent. Uses backtracking: on a failed branch the model bindings are restored and the next
+         * candidate is tried. On success the chosen statements are removed from {@code available} and the
+         * winning bindings remain applied to the component models.
+         *
+         * @param partIndex the index of the next statement part to assign
+         * @param available the statements still available for assignment (mutated in place)
+         * @return true if all remaining parts could be assigned consistently
+         */
+        private boolean assignParts(int partIndex, List<Statement> available) {
+            if (partIndex == statementParts.size()) return true;
+            StatementPartItem p = statementParts.get(partIndex);
+            for (int i = 0; i < available.size(); i++) {
+                Statement s = available.get(i);
+                Map<IRI, Object> snapshot = snapshotModels();
+                if (unifyPart(p.getPredicate(), s.getPredicate())  // checking predicate first optimizes performance
+                        && unifyPart(p.getSubject(), s.getSubject())
+                        && unifyPart(p.getObject(), s.getObject())) {
+                    available.remove(i);
+                    if (assignParts(partIndex + 1, available)) return true;
+                    available.add(i, s);
                 }
-                if (matchedStatement == null) {
-                    throw new UnificationException("Unification seemed to work but then didn't");
-                } else {
-                    statements.remove(matchedStatement);
-                }
-                filled = true;
+                restoreModels(snapshot);
+            }
+            return false;
+        }
+
+        /**
+         * Checks unifiability and, if unifiable, applies the binding. Returns false instead of throwing,
+         * so the caller can backtrack. (A partial binding left behind here is rolled back by the caller's
+         * model snapshot.)
+         */
+        private boolean unifyPart(ValueItem item, Value v) {
+            if (!item.isUnifiableWith(v)) return false;
+            try {
+                item.unifyWith(v);
+                return true;
+            } catch (UnificationException ex) {
+                return false;
+            }
+        }
+
+        /**
+         * Snapshots the current values of all shared component models, so a trial binding can be rolled back.
+         */
+        private Map<IRI, Object> snapshotModels() {
+            Map<IRI, Object> snapshot = new HashMap<>();
+            for (Map.Entry<IRI, IModel<?>> e : context.getComponentModels().entrySet()) {
+                snapshot.put(e.getKey(), e.getValue().getObject());
+            }
+            return snapshot;
+        }
+
+        /**
+         * Restores component model values captured by {@link #snapshotModels()}.
+         */
+        @SuppressWarnings("unchecked")
+        private void restoreModels(Map<IRI, Object> snapshot) {
+            Map<IRI, IModel<?>> models = context.getComponentModels();
+            for (Map.Entry<IRI, Object> e : snapshot.entrySet()) {
+                IModel<?> m = models.get(e.getKey());
+                if (m != null) ((IModel<Object>) m).setObject(e.getValue());
             }
         }
 

--- a/src/test/java/com/knowledgepixels/nanodash/template/GroupedSharedPlaceholderFillTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/template/GroupedSharedPlaceholderFillTest.java
@@ -1,0 +1,67 @@
+package com.knowledgepixels.nanodash.template;
+
+import com.knowledgepixels.nanodash.Utils;
+import com.knowledgepixels.nanodash.WicketApplication;
+import org.apache.wicket.util.tester.WicketTester;
+import org.eclipse.rdf4j.model.Statement;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.nanopub.Nanopub;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Regression test for issue #505: {@code RepetitionGroup.matches()} and
+ * {@code RepetitionGroup.fill()} used to disagree for grouped statements whose
+ * sub-statements share a placeholder/local resource. {@code fill()} binds those
+ * shared models greedily as it walks the parts, so an early binding could block a
+ * later part even though a consistent assignment existed — leaving the grouped
+ * statement's reification triples in the "unused" section.
+ *
+ * <p>Fixture: the published "Defining a biochementity" template nanopub, viewed via
+ * its meta-template "Defining an assertion template". Its {@code st9a}–{@code st9e}
+ * grouped sub-statements share the {@code contextalias} local resource and the
+ * introduced {@code ~~ARTIFACTCODE~~} resource. Before the fix those reification
+ * triples remained unused; after it, they are matched into the form.
+ */
+class GroupedSharedPlaceholderFillTest {
+
+    // "Defining an assertion template" — the meta-template the fixture was created from.
+    private static final String META_TEMPLATE = "https://w3id.org/np/RAM3Mma65yu2b7JmKhw6GYcMVc2LWdgcqkZD3FGJbCIo4";
+    // The "Defining a biochementity" template nanopub (a template definition, viewed via the meta-template).
+    private static final String FIXTURE = "https://w3id.org/np/RAhSlIuuw5YqmMoyyvmy5GL3qIhs7sp14i6x2y3DCOhXM";
+
+    @BeforeEach
+    void setUp() {
+        new WicketTester(new WicketApplication());
+    }
+
+    @Test
+    void groupedSubStatementsWithSharedPlaceholderGetMatched() {
+        Nanopub fixture = Utils.getNanopub(FIXTURE);
+        assertNotNull(fixture, "fixture nanopub should be fetchable from the registry");
+
+        // Mirror the viewer flow (NanopubItem.populateStatementItemList): read-only context built
+        // from the meta-template, fed the fixture's assertion triples.
+        ValueFiller filler = new ValueFiller(fixture, ContextType.ASSERTION, false);
+        TemplateContext context = new TemplateContext(ContextType.ASSERTION, META_TEMPLATE, "assertion-statement", fixture);
+        context.initStatements();
+        filler.fill(context);
+
+        List<Statement> unused = filler.getUnusedStatements();
+        // The previously-failing triples are the contextalias grouped sub-statement reifications.
+        List<Statement> unusedContextAlias = unused.stream()
+                .filter(st -> {
+                    String s = st.toString();
+                    return s.contains("ContextAlias") || s.contains("contextalias");
+                })
+                .collect(Collectors.toList());
+
+        assertTrue(unusedContextAlias.isEmpty(),
+                "grouped contextalias sub-statements should be matched, but these stayed unused:\n"
+                        + unusedContextAlias.stream().map(Object::toString).collect(Collectors.joining("\n")));
+    }
+}


### PR DESCRIPTION
Fixes #505. **Stacked on #504** — base branch is `fix/template-fill-no-abort-on-unification-failure`; review/merge #504 first.

## Problem

`RepetitionGroup.matches()` and `fill()` could disagree. `matches()` validated unifiability **statelessly**, but `fill()` **bound** shared placeholder component-models via `unifyWith` as it walked the statement parts. With a grouped statement whose sub-statements share a placeholder/local resource, a greedy early binding could lock that shared model to a value that blocks a later part — even though a consistent assignment existed. `fill()` then threw `"Unification seemed to work but then didn't"`, and the grouped statement's reification triples were left in the "unused" section.

Where #504 stopped one such failure from aborting the whole template fill, this is the correctness counterpart so the affected statements actually match.

## Fix

Replace both greedy loops with a single shared **backtracking** matcher, `assignParts()`:

- Try each candidate statement for a part, apply the binding, recurse; on a dead-end branch **roll back** the model bindings (`snapshotModels()` / `restoreModels()`) and try the next candidate — so a bad early binding can no longer wrongly block a valid assignment.
- `fill()` keeps the winning bindings and removes the matched statements (same contract as before).
- `matches()` runs the **same** backtracking on a copy and then restores all models, so it stays side-effect-free **and** agrees with `fill()` exactly.
- `unifyPart()` returns `false` instead of throwing, also guarding the pre-existing latent case where two parts of one triple share a placeholder.

## Verification

New regression test `GroupedSharedPlaceholderFillTest` mirrors the viewer flow on the published "Defining a biochementity" template (`RAhSlIuuw5YqmMoyyvmy5GL3qIhs7sp14i6x2y3DCOhXM`) viewed via its meta-template (`RAM3Mma65yu2b7JmKhw6GYcMVc2LWdgcqkZD3FGJbCIo4`):

- **Without** this fix (baseline = #504 only): fails, leaving exactly the 7 `st9a`–`st9e` contextalias reification triples unused.
- **With** this fix: passes (those triples are matched into the form).

No regressions: `DeriveAppendKeyFillTest`, `IntroActionFillTest`, `ValueFillerTest`, `ComponentParamSeedTest`, `RestrictedChoiceTest`, `TemplateContextTest` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)