### PR TITLE
fix: simplify view-display authority gate to hasGoverningSpaceRef (#510)

### DIFF
--- a/docs/queries/get-view-displays-ref.trig
+++ b/docs/queries/get-view-displays-ref.trig
@@ -31,21 +31,19 @@ select distinct ?display ?view (coalesce(?viewKindOptional, ?view) as ?viewKind)
     graph npa:graph { npa:thisRepo npa:hasCurrentSpaceState ?stateG . }
     graph npa:spacesGraph { ?passedRef npa:rootNanopub ?_root_np_multi_iri . }
     {
+      # Authority gate (issue #130 / nanodash#510): a single mandatory hop through the
+      # governing space ref, which covers both a maintained resource and a space itself
+      # (the reflexive self-edge), keyed on the role tier materialized on the
+      # RoleInstantiation since #125. Replaces the old bare-IRI isMaintainedBy? hop and the
+      # dead RoleDeclaration maintainer join. Ref variant: the governing ref is pinned to
+      # ?passedRef (resolved from root_np), so authority cannot bleed across rival refs
+      # claiming the same space IRI.
       graph ?stateG {
-        ?_resource_multi_iri npa:isMaintainedBy? ?space .
-        ?ri a gen:RoleInstantiation ; npa:forSpace ?space ; npa:forSpaceRef ?passedRef ; npa:forAgent ?authAgent ;
-            (npa:inverseProperty|npa:regularProperty) ?roleProp .
+        ?_resource_multi_iri npa:hasGoverningSpaceRef ?passedRef .
+        ?ri a gen:RoleInstantiation ; npa:forSpaceRef ?passedRef ; npa:hasRoleType ?roleType ; npa:forAgent ?authAgent .
+        filter(?roleType = gen:AdminRole || ?roleType = gen:MaintainerRole)
         ?authAcct a npa:AccountState ; npa:agent ?authAgent ; npa:pubkey ?pubkey .
       }
-      optional {
-        graph npa:spacesGraph {
-          ?rd a npa:RoleDeclaration ; npa:forSpace ?space ;
-              npa:hasRoleType gen:MaintainerRole ;
-              (npa:inverseProperty|npa:regularProperty) ?roleProp .
-          bind(true as ?isMaintainer)
-        }
-      }
-      filter(?roleProp = gen:hasAdmin || bound(?isMaintainer))
     } union {
       graph ?stateG { ?selfAcct a npa:AccountState ; npa:agent ?_resource_multi_iri ; npa:pubkey ?pubkey . }
     }
@@ -131,5 +129,5 @@ order by desc(?date)""" .
 sub:provenance { sub:assertion prov:wasAttributedTo orcid:0000-0002-1267-0234 . }
 sub:pubinfo {
   orcid:0000-0002-1267-0234 foaf:name "Tobias Kuhn" .
-  this: dct:created "2026-06-19T07:32:09Z"^^xsd:dateTime; dct:creator orcid:0000-0002-1267-0234; dct:license <https://creativecommons.org/licenses/by/4.0/>; npx:embeds sub:get-view-displays; npx:supersedes <https://w3id.org/np/RA8iqtdTrZGOWX1Yf7w_8RgB9brG3COMw9wkbjfl6VeHc> .
+  this: dct:created "2026-06-25T16:05:53Z"^^xsd:dateTime; dct:creator orcid:0000-0002-1267-0234; dct:license <https://creativecommons.org/licenses/by/4.0/>; npx:embeds sub:get-view-displays; npx:supersedes <https://w3id.org/np/RAIpgHc6ckHcb2yBWM3QJ68xjghrgBdEOQRGFKCGseAcA> .
 }

--- a/docs/queries/get-view-displays.trig
+++ b/docs/queries/get-view-displays.trig
@@ -36,21 +36,18 @@ select distinct ?display ?view (coalesce(?viewKindOptional, ?view) as ?viewKind)
   service <https://w3id.org/np/l/nanopub-query-1.1/repo/spaces> {
     graph npa:graph { npa:thisRepo npa:hasCurrentSpaceState ?stateG . }
     {
+      # Authority gate (issue #130 / nanodash#510): a single mandatory hop through the
+      # governing space ref, which covers both a maintained resource and a space itself
+      # (the reflexive self-edge), keyed on the role tier materialized on the
+      # RoleInstantiation since #125. Replaces the old bare-IRI isMaintainedBy? hop and the
+      # dead RoleDeclaration maintainer join. Non-ref variant: any ref claiming the IRI, so
+      # authority merges across refs (the ref variant pins a single ?passedRef instead).
       graph ?stateG {
-        ?_resource_multi_iri npa:isMaintainedBy? ?space .
-        ?ri a gen:RoleInstantiation ; npa:forSpace ?space ; npa:forAgent ?authAgent ;
-            (npa:inverseProperty|npa:regularProperty) ?roleProp .
+        ?_resource_multi_iri npa:hasGoverningSpaceRef ?spaceRef .
+        ?ri a gen:RoleInstantiation ; npa:forSpaceRef ?spaceRef ; npa:hasRoleType ?roleType ; npa:forAgent ?authAgent .
+        filter(?roleType = gen:AdminRole || ?roleType = gen:MaintainerRole)
         ?authAcct a npa:AccountState ; npa:agent ?authAgent ; npa:pubkey ?pubkey .
       }
-      optional {
-        graph npa:spacesGraph {
-          ?rd a npa:RoleDeclaration ; npa:forSpace ?space ;
-              npa:hasRoleType gen:MaintainerRole ;
-              (npa:inverseProperty|npa:regularProperty) ?roleProp .
-          bind(true as ?isMaintainer)
-        }
-      }
-      filter(?roleProp = gen:hasAdmin || bound(?isMaintainer))
     } union {
       graph ?stateG { ?selfAcct a npa:AccountState ; npa:agent ?_resource_multi_iri ; npa:pubkey ?pubkey . }
     }
@@ -141,11 +138,11 @@ sub:provenance {
 sub:pubinfo {
   orcid:0000-0002-1267-0234 foaf:name "Tobias Kuhn" .
   
-  this: dct:created "2026-06-19T09:55:49Z"^^xsd:dateTime;
+  this: dct:created "2026-06-25T16:05:53Z"^^xsd:dateTime;
     dct:creator orcid:0000-0002-1267-0234;
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
     npx:embeds sub:get-view-displays;
-    npx:supersedes <https://w3id.org/np/RAyXaBuRHp2GaCRuKElnkg9bqFqayhoqZqGjpaBgd7DtU>;
+    npx:supersedes <https://w3id.org/np/RAd105Rjy3ZCTGxOqBuXlztyeRG50r7j_CF4dMzERyI00>;
     rdfs:label "Get view displays";
     nt:wasCreatedFromProvenanceTemplate <https://w3id.org/np/RA7lSq6MuK_TIC6JMSHvLtee3lpLoZDOqLJCLXevnrPoU>;
     nt:wasCreatedFromPubinfoTemplate <https://w3id.org/np/RA0J4vUn_dekg-U1kK3AOEt02p9mT2WO03uGxLDec1jLw>,

--- a/docs/queries/list-part-view-displays.trig
+++ b/docs/queries/list-part-view-displays.trig
@@ -30,6 +30,7 @@ prefix npx: <http://purl.org/nanopub/x/>
 prefix gen: <https://w3id.org/kpxl/gen/terms/>
 
 select ?view ?view_label ?displayed_here ?position
+       (substr(?position, 1, 3) as ?position_label)
        (if(?displayed_here = \"\", ?target_multi_iri_raw, \"\") as ?target_multi_iri)
        (if(?displayed_here = \"\", ?target_label_multi_raw, \"\") as ?target_label_multi)
        ?via_preset ?via_preset_label ?added_by ?date_added ?np ?np_label
@@ -59,21 +60,18 @@ where {
       service <https://w3id.org/np/l/nanopub-query-1.1/repo/spaces> {
         graph npa:graph { npa:thisRepo npa:hasCurrentSpaceState ?stateG . }
         {
+          # Authority gate (issue #130 / nanodash#510): a single mandatory hop through the
+          # governing space ref, which covers both a maintained resource and a space itself
+          # (the reflexive self-edge), keyed on the role tier materialized on the
+          # RoleInstantiation since #125. Replaces the old bare-IRI isMaintainedBy? hop and
+          # the dead RoleDeclaration maintainer join. Non-ref variant: any ref claiming the
+          # IRI, so authority merges across refs (the ref variant pins a single ?passedRef).
           graph ?stateG {
-            ?_resource_multi_iri npa:isMaintainedBy? ?space .
-            ?ri a gen:RoleInstantiation ; npa:forSpace ?space ; npa:forAgent ?authAgent ;
-                (npa:inverseProperty|npa:regularProperty) ?roleProp .
+            ?_resource_multi_iri npa:hasGoverningSpaceRef ?spaceRef .
+            ?ri a gen:RoleInstantiation ; npa:forSpaceRef ?spaceRef ; npa:hasRoleType ?roleType ; npa:forAgent ?authAgent .
+            filter(?roleType = gen:AdminRole || ?roleType = gen:MaintainerRole)
             ?authAcct a npa:AccountState ; npa:agent ?authAgent ; npa:pubkey ?pubkey .
           }
-          optional {
-            graph npa:spacesGraph {
-              ?rd a npa:RoleDeclaration ; npa:forSpace ?space ;
-                  npa:hasRoleType gen:MaintainerRole ;
-                  (npa:inverseProperty|npa:regularProperty) ?roleProp .
-              bind(true as ?isMaintainer)
-            }
-          }
-          filter(?roleProp = gen:hasAdmin || bound(?isMaintainer))
         } union {
           graph ?stateG { ?selfAcct a npa:AccountState ; npa:agent ?_resource_multi_iri ; npa:pubkey ?pubkey . }
         }
@@ -218,11 +216,11 @@ sub:provenance {
 sub:pubinfo {
   orcid:0000-0002-1267-0234 foaf:name "Tobias Kuhn" .
   
-  this: dct:created "2026-06-19T13:59:59Z"^^xsd:dateTime;
+  this: dct:created "2026-06-25T16:05:53Z"^^xsd:dateTime;
     dct:creator orcid:0000-0002-1267-0234;
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
     npx:embeds sub:list-part-view-displays;
-    npx:supersedes <https://w3id.org/np/RAPaHJiDMXHu8IAl21kd1b5uSXCRaLwCX9tRiVVlJFuHU>;
+    npx:supersedes <https://w3id.org/np/RA2LG9c54__RIltrdvJzvzK3RBx50MjUdU7mPbeuT0GiY>;
     rdfs:label "List part view displays" .
 }
 

--- a/docs/queries/list-view-displays-ref.trig
+++ b/docs/queries/list-view-displays-ref.trig
@@ -27,9 +27,11 @@ select ?view
        (sample(?view_label) as ?view_label)
        (sample(?displayed_here) as ?displayed_here)
        (sample(?position) as ?position)
+       (substr(sample(?position), 1, 3) as ?position_label)
        (sample(?via_preset) as ?via_preset)
        (sample(?via_preset_label) as ?via_preset_label)
        (sample(?added_by) as ?added_by)
+       (sample(?deactivateView) as ?deactivateView)
        (max(?date_added) as ?date_added)
        (iri(strafter(max(concat(str(?date_added), \"\\\\t\", str(?np))), \"\\\\t\")) as ?np)
        (\"^\" as ?np_label) where {
@@ -65,21 +67,19 @@ where {
         graph npa:graph { npa:thisRepo npa:hasCurrentSpaceState ?stateG . }
         graph npa:spacesGraph { ?passedRef npa:rootNanopub ?_root_np_multi_iri . }
         {
+          # Authority gate (issue #130 / nanodash#510): a single mandatory hop through the
+          # governing space ref, which covers both a maintained resource and a space itself
+          # (the reflexive self-edge), keyed on the role tier materialized on the
+          # RoleInstantiation since #125. Replaces the old bare-IRI isMaintainedBy? hop and
+          # the dead RoleDeclaration maintainer join. Ref variant: the governing ref is
+          # pinned to ?passedRef (resolved from root_np), so authority cannot bleed across
+          # rival refs claiming the same space IRI.
           graph ?stateG {
-            ?_resource_multi_iri npa:isMaintainedBy? ?space .
-            ?ri a gen:RoleInstantiation ; npa:forSpace ?space ; npa:forSpaceRef ?passedRef ; npa:forAgent ?authAgent ;
-                (npa:inverseProperty|npa:regularProperty) ?roleProp .
+            ?_resource_multi_iri npa:hasGoverningSpaceRef ?passedRef .
+            ?ri a gen:RoleInstantiation ; npa:forSpaceRef ?passedRef ; npa:hasRoleType ?roleType ; npa:forAgent ?authAgent .
+            filter(?roleType = gen:AdminRole || ?roleType = gen:MaintainerRole)
             ?authAcct a npa:AccountState ; npa:agent ?authAgent ; npa:pubkey ?pubkey .
           }
-          optional {
-            graph npa:spacesGraph {
-              ?rd a npa:RoleDeclaration ; npa:forSpace ?space ;
-                  npa:hasRoleType gen:MaintainerRole ;
-                  (npa:inverseProperty|npa:regularProperty) ?roleProp .
-              bind(true as ?isMaintainer)
-            }
-          }
-          filter(?roleProp = gen:hasAdmin || bound(?isMaintainer))
         } union {
           graph ?stateG { ?selfAcct a npa:AccountState ; npa:agent ?_resource_multi_iri ; npa:pubkey ?pubkey . }
         }
@@ -224,5 +224,5 @@ order by desc(?displayed_here) ?position""" .
 sub:provenance { sub:assertion prov:wasAttributedTo orcid:0000-0002-1267-0234 . }
 sub:pubinfo {
   orcid:0000-0002-1267-0234 foaf:name "Tobias Kuhn" .
-  this: dct:created "2026-06-19T13:58:40Z"^^xsd:dateTime; dct:creator orcid:0000-0002-1267-0234; dct:license <https://creativecommons.org/licenses/by/4.0/>; npx:embeds sub:list-view-displays; npx:supersedes <https://w3id.org/np/RAKfr2_TxPCXE-u-Ol0UDb2-8U8sej8aqKhD32EtDTob0> .
+  this: dct:created "2026-06-25T16:05:53Z"^^xsd:dateTime; dct:creator orcid:0000-0002-1267-0234; dct:license <https://creativecommons.org/licenses/by/4.0/>; npx:embeds sub:list-view-displays; npx:supersedes <https://w3id.org/np/RAE8SOXg7x9nreFldSIdcCku_fHMeIP1RnXizITBj2ggo> .
 }

--- a/docs/queries/list-view-displays.trig
+++ b/docs/queries/list-view-displays.trig
@@ -33,9 +33,11 @@ select ?view
        (sample(?view_label) as ?view_label)
        (sample(?displayed_here) as ?displayed_here)
        (sample(?position) as ?position)
+       (substr(sample(?position), 1, 3) as ?position_label)
        (sample(?via_preset) as ?via_preset)
        (sample(?via_preset_label) as ?via_preset_label)
        (sample(?added_by) as ?added_by)
+       (sample(?deactivateView) as ?deactivateView)
        (max(?date_added) as ?date_added)
        (iri(strafter(max(concat(str(?date_added), \"\\t\", str(?np))), \"\\t\")) as ?np)
        (\"^\" as ?np_label) where {
@@ -69,21 +71,18 @@ where {
       service <https://w3id.org/np/l/nanopub-query-1.1/repo/spaces> {
         graph npa:graph { npa:thisRepo npa:hasCurrentSpaceState ?stateG . }
         {
+          # Authority gate (issue #130 / nanodash#510): a single mandatory hop through the
+          # governing space ref, which covers both a maintained resource and a space itself
+          # (the reflexive self-edge), keyed on the role tier materialized on the
+          # RoleInstantiation since #125. Replaces the old bare-IRI isMaintainedBy? hop and
+          # the dead RoleDeclaration maintainer join. Non-ref variant: any ref claiming the
+          # IRI, so authority merges across refs (the ref variant pins a single ?passedRef).
           graph ?stateG {
-            ?_resource_multi_iri npa:isMaintainedBy? ?space .
-            ?ri a gen:RoleInstantiation ; npa:forSpace ?space ; npa:forAgent ?authAgent ;
-                (npa:inverseProperty|npa:regularProperty) ?roleProp .
+            ?_resource_multi_iri npa:hasGoverningSpaceRef ?spaceRef .
+            ?ri a gen:RoleInstantiation ; npa:forSpaceRef ?spaceRef ; npa:hasRoleType ?roleType ; npa:forAgent ?authAgent .
+            filter(?roleType = gen:AdminRole || ?roleType = gen:MaintainerRole)
             ?authAcct a npa:AccountState ; npa:agent ?authAgent ; npa:pubkey ?pubkey .
           }
-          optional {
-            graph npa:spacesGraph {
-              ?rd a npa:RoleDeclaration ; npa:forSpace ?space ;
-                  npa:hasRoleType gen:MaintainerRole ;
-                  (npa:inverseProperty|npa:regularProperty) ?roleProp .
-              bind(true as ?isMaintainer)
-            }
-          }
-          filter(?roleProp = gen:hasAdmin || bound(?isMaintainer))
         } union {
           graph ?stateG { ?selfAcct a npa:AccountState ; npa:agent ?_resource_multi_iri ; npa:pubkey ?pubkey . }
         }
@@ -233,11 +232,11 @@ sub:provenance {
 sub:pubinfo {
   orcid:0000-0002-1267-0234 foaf:name "Tobias Kuhn" .
   
-  this: dct:created "2026-06-19T14:01:16Z"^^xsd:dateTime;
+  this: dct:created "2026-06-25T16:05:53Z"^^xsd:dateTime;
     dct:creator orcid:0000-0002-1267-0234;
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
     npx:embeds sub:list-view-displays;
-    npx:supersedes <https://w3id.org/np/RAdWeDNFHaMMxJ5RVKtSPdj_0wQHfdicHd0YDnX1X7nSM>;
+    npx:supersedes <https://w3id.org/np/RAUiNhjuycdEOsElNOK13ot7rOqr5Jt4NRkXWveoCvIVg>;
     rdfs:label "List view displays" .
 }
 

--- a/docs/queries/maintained-resource-view-displays-view.trig
+++ b/docs/queries/maintained-resource-view-displays-view.trig
@@ -3,6 +3,7 @@
 @prefix gen: <https://w3id.org/kpxl/gen/terms/> .
 @prefix np: <http://www.nanopub.org/nschema#> .
 @prefix dct: <http://purl.org/dc/terms/> .
+@prefix nt: <https://w3id.org/np/o/ntemplate/> .
 @prefix npx: <http://purl.org/nanopub/x/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@@ -25,7 +26,7 @@ sub:assertion {
     gen:hasActionTemplateQueryMapping "void";
     gen:hasActionTemplateTargetField "resource";
     gen:isVisibleTo gen:MaintainerRole .
-
+  
   sub:deactivate-action a gen:ViewEntryAction;
     rdfs:label "deactivate";
     gen:hasActionTemplate <https://w3id.org/np/RAZ47_4JquvEXk30HYnVeSgFRcQqHtpdibcfBOeqHI2j4>;
@@ -33,15 +34,15 @@ sub:assertion {
     gen:hasActionTemplateQueryMapping "deactivateView:view";
     gen:hasActionTemplateTargetField "resource";
     gen:isVisibleTo gen:MaintainerRole .
-
+  
   sub:view-displays-view a gen:ResourceView, gen:TabularView;
-    dct:isVersionOf sub:maintained-resource-view-displays-view-kind;
+    dct:isVersionOf <https://w3id.org/np/RAZOxROZRaxSeoeO05iI0tKpDIy2mEN3jlUuVIo0uZN1I/maintained-resource-view-displays-view-kind>;
     dct:title "🖵 View displays";
     rdfs:label "View displays view (Maintained resource)";
     gen:appliesToInstancesOf gen:MaintainedResource;
     gen:hasStructuralPosition "5.5.viewDisplays";
     gen:hasViewAction sub:add-view-display-action, sub:deactivate-action;
-    gen:hasViewQuery <https://w3id.org/np/RAe63temfrauWIRVIpGa5booRJgioepZSg8t54lgMxmNo/list-view-displays>;
+    gen:hasViewQuery <https://w3id.org/np/RAfGpyfUX8qjSMN5-aRWOPeVqHajs3f6zUzcnMuRibk1g/list-view-displays>;
     gen:hasViewQueryTargetField "resource" .
 }
 
@@ -51,11 +52,16 @@ sub:provenance {
 
 sub:pubinfo {
   orcid:0000-0002-1267-0234 foaf:name "Tobias Kuhn" .
-
-  this: dct:created "2026-06-19T11:12:10Z"^^xsd:dateTime;
+  
+  this: dct:created "2026-06-25T16:12:02Z"^^xsd:dateTime;
     dct:creator orcid:0000-0002-1267-0234;
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
     npx:embeds sub:view-displays-view;
-    npx:introduces sub:maintained-resource-view-displays-view-kind;
-    rdfs:label "View displays view (Maintained resource)" .
+    npx:introduces <https://w3id.org/np/RAZOxROZRaxSeoeO05iI0tKpDIy2mEN3jlUuVIo0uZN1I/maintained-resource-view-displays-view-kind>;
+    npx:supersedes <https://w3id.org/np/RAYgOvKdvtMDs5NIvP0KvJu0jyCtAG6HslBoQwstjmDOI>;
+    rdfs:label "View displays view (Maintained resource)";
+    nt:wasCreatedFromProvenanceTemplate <https://w3id.org/np/RA7lSq6MuK_TIC6JMSHvLtee3lpLoZDOqLJCLXevnrPoU>;
+    nt:wasCreatedFromPubinfoTemplate <https://w3id.org/np/RACJ58Gvyn91LqCKIO9zu1eijDQIeEff28iyDrJgjSJF8>,
+      <https://w3id.org/np/RAoTD7udB2KtUuOuAe74tJi1t3VzK0DyWS7rYVAq1GRvw>, <https://w3id.org/np/RAukAcWHRDlkqxk7H2XNSegc1WnHI569INvNr-xdptDGI>;
+    nt:wasCreatedFromTemplate <https://w3id.org/np/RA8_hijwsfGCryMYtjtEpec21ZSNY68-qmL0bHRWR0sWM> .
 }

--- a/docs/queries/space-view-displays-view.trig
+++ b/docs/queries/space-view-displays-view.trig
@@ -3,6 +3,7 @@
 @prefix gen: <https://w3id.org/kpxl/gen/terms/> .
 @prefix np: <http://www.nanopub.org/nschema#> .
 @prefix dct: <http://purl.org/dc/terms/> .
+@prefix nt: <https://w3id.org/np/o/ntemplate/> .
 @prefix npx: <http://purl.org/nanopub/x/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@@ -25,7 +26,7 @@ sub:assertion {
     gen:hasActionTemplateQueryMapping "void";
     gen:hasActionTemplateTargetField "resource";
     gen:isVisibleTo gen:MaintainerRole .
-
+  
   sub:deactivate-action a gen:ViewEntryAction;
     rdfs:label "deactivate";
     gen:hasActionTemplate <https://w3id.org/np/RAZ47_4JquvEXk30HYnVeSgFRcQqHtpdibcfBOeqHI2j4>;
@@ -33,15 +34,15 @@ sub:assertion {
     gen:hasActionTemplateQueryMapping "deactivateView:view";
     gen:hasActionTemplateTargetField "resource";
     gen:isVisibleTo gen:MaintainerRole .
-
+  
   sub:view-displays-view a gen:ResourceView, gen:TabularView;
-    dct:isVersionOf sub:space-view-displays-view-kind;
+    dct:isVersionOf <https://w3id.org/np/RAiNrals9m7glgRFdu1i4pygixr5VGfA1ERoA_DpwdT0A/space-view-displays-view-kind>;
     dct:title "🖵 View displays";
     rdfs:label "View displays view (space)";
     gen:appliesToInstancesOf gen:Space;
     gen:hasStructuralPosition "5.5.viewDisplays";
     gen:hasViewAction sub:add-view-display-action, sub:deactivate-action;
-    gen:hasViewQuery <https://w3id.org/np/RAe63temfrauWIRVIpGa5booRJgioepZSg8t54lgMxmNo/list-view-displays>;
+    gen:hasViewQuery <https://w3id.org/np/RAfGpyfUX8qjSMN5-aRWOPeVqHajs3f6zUzcnMuRibk1g/list-view-displays>;
     gen:hasViewQueryTargetField "resource" .
 }
 
@@ -51,11 +52,15 @@ sub:provenance {
 
 sub:pubinfo {
   orcid:0000-0002-1267-0234 foaf:name "Tobias Kuhn" .
-
-  this: dct:created "2026-06-19T11:12:10Z"^^xsd:dateTime;
+  
+  this: dct:created "2026-06-25T16:12:02Z"^^xsd:dateTime;
     dct:creator orcid:0000-0002-1267-0234;
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
     npx:embeds sub:view-displays-view;
-    npx:introduces sub:space-view-displays-view-kind;
-    rdfs:label "View displays view (space)" .
+    npx:introduces <https://w3id.org/np/RAiNrals9m7glgRFdu1i4pygixr5VGfA1ERoA_DpwdT0A/space-view-displays-view-kind>;
+    npx:supersedes <https://w3id.org/np/RAiNrals9m7glgRFdu1i4pygixr5VGfA1ERoA_DpwdT0A>;
+    rdfs:label "View displays view (space)";
+    nt:wasCreatedFromProvenanceTemplate <https://w3id.org/np/RA7lSq6MuK_TIC6JMSHvLtee3lpLoZDOqLJCLXevnrPoU>;
+    nt:wasCreatedFromPubinfoTemplate <https://w3id.org/np/RACJ58Gvyn91LqCKIO9zu1eijDQIeEff28iyDrJgjSJF8>;
+    nt:wasCreatedFromTemplate <https://w3id.org/np/RA8_hijwsfGCryMYtjtEpec21ZSNY68-qmL0bHRWR0sWM> .
 }

--- a/docs/queries/user-view-displays-view.trig
+++ b/docs/queries/user-view-displays-view.trig
@@ -3,6 +3,7 @@
 @prefix gen: <https://w3id.org/kpxl/gen/terms/> .
 @prefix np: <http://www.nanopub.org/nschema#> .
 @prefix dct: <http://purl.org/dc/terms/> .
+@prefix nt: <https://w3id.org/np/o/ntemplate/> .
 @prefix npx: <http://purl.org/nanopub/x/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@@ -25,7 +26,7 @@ sub:assertion {
     gen:hasActionTemplateQueryMapping "void";
     gen:hasActionTemplateTargetField "resource";
     gen:isVisibleTo gen:MaintainerRole .
-
+  
   sub:deactivate-action a gen:ViewEntryAction;
     rdfs:label "deactivate";
     gen:hasActionTemplate <https://w3id.org/np/RAZ47_4JquvEXk30HYnVeSgFRcQqHtpdibcfBOeqHI2j4>;
@@ -33,14 +34,14 @@ sub:assertion {
     gen:hasActionTemplateQueryMapping "deactivateView:view";
     gen:hasActionTemplateTargetField "resource";
     gen:isVisibleTo gen:MaintainerRole .
-
+  
   sub:view-displays-view a gen:ResourceView, gen:TabularView;
-    dct:isVersionOf sub:user-view-displays-view-kind;
+    dct:isVersionOf <https://w3id.org/np/RA1d1qBF8Fk-ZWKtNB-wZd56HrV0wdtJkw0wp58sHxM0E/user-view-displays-view-kind>;
     dct:title "🖵 View displays";
     rdfs:label "View displays view (User)";
     gen:hasStructuralPosition "5.5.viewDisplays";
     gen:hasViewAction sub:add-view-display-action, sub:deactivate-action;
-    gen:hasViewQuery <https://w3id.org/np/RAe63temfrauWIRVIpGa5booRJgioepZSg8t54lgMxmNo/list-view-displays>;
+    gen:hasViewQuery <https://w3id.org/np/RAF4bDQmpjbUZK_fA2UBzpUAiwm-7WK3BCpOqOfgr0zd4/list-view-displays>;
     gen:hasViewQueryTargetField "resource" .
 }
 
@@ -50,11 +51,16 @@ sub:provenance {
 
 sub:pubinfo {
   orcid:0000-0002-1267-0234 foaf:name "Tobias Kuhn" .
-
-  this: dct:created "2026-06-19T11:12:10Z"^^xsd:dateTime;
+  
+  this: dct:created "2026-06-25T16:12:02Z"^^xsd:dateTime;
     dct:creator orcid:0000-0002-1267-0234;
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
     npx:embeds sub:view-displays-view;
-    npx:introduces sub:user-view-displays-view-kind;
-    rdfs:label "View displays view (User)" .
+    npx:introduces <https://w3id.org/np/RA1d1qBF8Fk-ZWKtNB-wZd56HrV0wdtJkw0wp58sHxM0E/user-view-displays-view-kind>;
+    npx:supersedes <https://w3id.org/np/RA-4lD6SrcEplUkOuCs2G-pCe3gSyuMg2qmH5uuTIDzls>;
+    rdfs:label "View displays view (User)";
+    nt:wasCreatedFromProvenanceTemplate <https://w3id.org/np/RA7lSq6MuK_TIC6JMSHvLtee3lpLoZDOqLJCLXevnrPoU>;
+    nt:wasCreatedFromPubinfoTemplate <https://w3id.org/np/RACJ58Gvyn91LqCKIO9zu1eijDQIeEff28iyDrJgjSJF8>,
+      <https://w3id.org/np/RAoTD7udB2KtUuOuAe74tJi1t3VzK0DyWS7rYVAq1GRvw>, <https://w3id.org/np/RAukAcWHRDlkqxk7H2XNSegc1WnHI569INvNr-xdptDGI>;
+    nt:wasCreatedFromTemplate <https://w3id.org/np/RA8_hijwsfGCryMYtjtEpec21ZSNY68-qmL0bHRWR0sWM> .
 }

--- a/src/main/java/com/knowledgepixels/nanodash/QueryApiAccess.java
+++ b/src/main/java/com/knowledgepixels/nanodash/QueryApiAccess.java
@@ -79,7 +79,11 @@ public class QueryApiAccess {
     // slash on the sub: prefix) gates the view-version-resolution npx:invalidates filters on the
     // version nanopub's own signing pubkey (issue #487); no-regression verified across resources
     // incl. a 45-display user page.
-    public static final String GET_VIEW_DISPLAYS = "RAlOsra-TR9Wh-GEnt2HcFpMc6Hb7QcA3r2bdD81_B_GA/get-view-displays";
+    // RA4TGV_z (supersedes RAd105Rj) replaces the bare-IRI isMaintainedBy? authority hop and the
+    // dead RoleDeclaration maintainer arm with a single npa:hasGoverningSpaceRef gate keyed on the
+    // materialized npa:hasRoleType (nanopub-query#130 / issue #510); fixes maintainer visibility and
+    // cross-ref bleed. No-regression verified against RAd105Rj across resources.
+    public static final String GET_VIEW_DISPLAYS = "RA4TGV_zGtvVPjvffGF6OTbNV-ZmjwIdcZ3-JNYdEhpoE/get-view-displays";
     // Ref-scoped get-view-displays (the Content-tab renderer query): takes the space IRI (resource)
     // AND the ref's root nanopub (root_np) as two concrete params, gating the authorised signers on
     // that ref's admins/maintainers (npa:forSpaceRef) instead of the IRI merged across refs, so the
@@ -89,7 +93,9 @@ public class QueryApiAccess {
     // RAny-yPb (supersedes RA8iqtd) gates the view-version-resolution npx:invalidates filters on
     // the version nanopub's own signing pubkey (issue #487; the row-level filters were already
     // gated). No-regression verified against RA8iqtd across spaces.
-    public static final String GET_VIEW_DISPLAYS_REF = "RAny-yPbLANY44GhO7fAjEShY-k5D_DTQhyHaVz3ZRxQo/get-view-displays";
+    // RAtZbUry (supersedes RAIpgHc6): same hasGoverningSpaceRef gate as get-view-displays, with the
+    // governing ref pinned to ?passedRef so authority cannot bleed across rival refs (issue #510).
+    public static final String GET_VIEW_DISPLAYS_REF = "RAtZbUry42si1BZpBoRBkgbzGweNzfPmOludNIoJYT2VM/get-view-displays";
 
     // Spaces-repo queries (endpoint: nanopub-query .../repo/spaces)
     // v2: IRI-keyed get-spaces. Prior client head, retained for reference; deployments up
@@ -218,7 +224,9 @@ public class QueryApiAccess {
     // ?shown_here → ?displayed_here). RAFkUf3A (derived from RAMy6Nu) adds a ?position_label column
     // (first 3 chars of the structural position) so the position cell shows e.g. "1.1" with the full
     // literal on hover.
-    public static final String LIST_PART_VIEW_DISPLAYS = "RAFkUf3AduxwZOfFBz0lVil_2IS2dM83-WAkEjkY3UTYQ/list-part-view-displays";
+    // RAs9S7c9 (supersedes RA2LG9c5) swaps the authority gate to the npa:hasGoverningSpaceRef gate
+    // keyed on materialized npa:hasRoleType (issue #510), preserving the ?position_label column.
+    public static final String LIST_PART_VIEW_DISPLAYS = "RAs9S7c9wdasz2c745f-mBg53JSQ1q20vLLHkmnXCmX2w/list-part-view-displays";
 
     // Ref-scoped preset-assignment listing (root_np): reads the server-materialised
     // npa:PresetAssignment rows scoped by npa:forSpaceRef from the validated current space-state


### PR DESCRIPTION
Resolves #510 (consumer side). Depends on knowledgepixels/nanopub-query#130 (`hasGoverningSpaceRef` materialization), which is merged, re-ingested, and live on all fleet instances.

## What

Replaces the view-display authority gate — the bare-IRI `isMaintainedBy? ?space` hop plus the dead `RoleDeclaration` maintainer join — with a single `npa:hasGoverningSpaceRef` gate keyed on the materialized `npa:hasRoleType`:

```sparql
?resource npa:hasGoverningSpaceRef ?ref .          # ref variant pins ?ref = ?passedRef
?ri a gen:RoleInstantiation ; npa:forSpaceRef ?ref ; npa:hasRoleType ?rt ; npa:forAgent ?a .
filter(?rt = gen:AdminRole || ?rt = gen:MaintainerRole)
```

This fixes both bugs in #510:
- **#2 cross-ref bleed** — ref variants pin the governing ref to `?passedRef`, so authority cannot leak across rival refs claiming one space IRI.
- **#3 dead maintainer arm** — maintainers (not only admins) now resolve, read straight off the RoleInstantiation's tier.

## Published live (this PR records the sources)

5 query nanopubs superseded (supersedes → new head): get-view-displays `RAd105Rj→RA4TGV_z`, get-view-displays-ref `RAIpgHc6→RAtZbUry`, list-view-displays `RAUiNhjuy→RAF4bDQm`, list-view-displays-ref `RAE8SOXg→RAfGpyfU`, list-part-view-displays `RA2LG9c5→RAs9S7c9`.

3 About-tab view nanopubs superseded to repoint `hasViewQuery` at the new list queries (user `RAB2FGuKd`, space `RAGI8jubi`, maintained `RA6myMO8`).

## Code

`QueryApiAccess`: the 3 **pinned** query constants updated (`GET_VIEW_DISPLAYS`, `GET_VIEW_DISPLAYS_REF`, `LIST_PART_VIEW_DISPLAYS`). The view Java constants are left at their original IRIs — `View.get` auto-resolves to the latest head.

## Notes

- The live query heads had drifted ahead of the repo `.trig` (live-only `position_label` truncation and the 2026-06-22 `deactivateView` projection fix). The gate change was merged **onto the live heads**, not the stale repo files, preserving those columns. The 5 query sources and the 3 view sources are resynced to the published versions.
- Caught + fixed the space view's `sub:`-relative view-kind (anchored to its head IRI) so the supersede didn't mint a new view-kind.
- No-regression verified against the prior published queries (29/29, 17/17, 6/6, 0/0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)