### PR TITLE
Show general-info fallback on unconfigured space/resource pages

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/page/MaintainedResourcePage.html
+++ b/src/main/java/com/knowledgepixels/nanodash/page/MaintainedResourcePage.html
@@ -20,6 +20,14 @@
 
   <wicket:container wicket:id="contentContainer">
     <div wicket:id="views"></div>
+
+    <div class="row-section" wicket:id="unconfigured-notice">
+      <div class="col-12">
+        <p><em>This maintained resource page hasn't been configured yet. Below you find some general information.</em></p>
+      </div>
+    </div>
+
+    <div wicket:id="generalinfoview"></div>
   </wicket:container>
   <div wicket:id="otherTab"></div>
 

--- a/src/main/java/com/knowledgepixels/nanodash/page/MaintainedResourcePage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/MaintainedResourcePage.java
@@ -2,12 +2,15 @@ package com.knowledgepixels.nanodash.page;
 
 import com.knowledgepixels.nanodash.NanodashPageRef;
 import com.knowledgepixels.nanodash.SpaceMemberRole;
+import com.knowledgepixels.nanodash.View;
+import com.knowledgepixels.nanodash.ViewDisplay;
 import com.knowledgepixels.nanodash.component.*;
 import com.knowledgepixels.nanodash.domain.AbstractResourceWithProfile;
 import com.knowledgepixels.nanodash.domain.MaintainedResource;
 import com.knowledgepixels.nanodash.domain.Space;
 import com.knowledgepixels.nanodash.repository.MaintainedResourceRepository;
 import org.apache.wicket.Component;
+import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.extensions.ajax.markup.html.AjaxLazyLoadPanel;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
@@ -19,6 +22,7 @@ import org.apache.wicket.request.mapper.parameter.PageParameters;
 import org.eclipse.rdf4j.model.util.Values;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * This class represents a page for a maintained resource.
@@ -83,8 +87,26 @@ public class MaintainedResourcePage extends NanodashPage {
         if (activeTab == ResourceTabs.Tab.CONTENT) {
             add(new EmptyPanel("otherTab").setVisible(false));
             if (resource.isDataInitialized()) {
-                contentContainer.add(new ViewList("views", resource));
+                boolean empty = resource.getTopLevelViewDisplays().isEmpty();
+                if (empty) {
+                    contentContainer.add(new WebMarkupContainer("views").setVisible(false));
+                } else {
+                    contentContainer.add(new ViewList("views", resource));
+                }
+                addUnconfiguredFallback(contentContainer, resource, empty);
             } else {
+                // Data not yet loaded: render the views lazily, then reveal the unconfigured
+                // notice + general-info fallback once we know whether any views exist.
+                final WebMarkupContainer unconfiguredNotice = new WebMarkupContainer("unconfigured-notice");
+                unconfiguredNotice.setVisible(false);
+                unconfiguredNotice.setOutputMarkupPlaceholderTag(true);
+                contentContainer.add(unconfiguredNotice);
+
+                final ViewList generalInfoView = new ViewList("generalinfoview", resource, List.of(generalInfoViewDisplay()));
+                generalInfoView.setVisible(false);
+                generalInfoView.setOutputMarkupPlaceholderTag(true);
+                contentContainer.add(generalInfoView);
+
                 contentContainer.add(new AjaxLazyLoadPanel<Component>("views") {
 
                     @Override
@@ -100,6 +122,21 @@ public class MaintainedResourcePage extends NanodashPage {
                     @Override
                     public Component getLoadingComponent(String id) {
                         return new Label(id, "<div class=\"row-section\"><div class=\"col-12\">" + ResultComponent.getWaitIconHtml() + "</div></div>").setEscapeModelStrings(false);
+                    }
+
+                    @Override
+                    protected void onContentLoaded(Component content, Optional<AjaxRequestTarget> target) {
+                        super.onContentLoaded(content, target);
+                        target.ifPresent(t -> {
+                            boolean isEmpty = resourceModel.getObject().getTopLevelViewDisplays().isEmpty();
+                            if (isEmpty) {
+                                t.appendJavaScript("document.getElementById('" + getMarkupId() + "').remove();");
+                            }
+                            unconfiguredNotice.setVisible(isEmpty);
+                            t.add(unconfiguredNotice);
+                            generalInfoView.setVisible(isEmpty);
+                            t.add(generalInfoView);
+                        });
                     }
 
                 });
@@ -118,6 +155,29 @@ public class MaintainedResourcePage extends NanodashPage {
             } else {
                 add(new DownloadRdfLinks("otherTab", "resource", resource.getId()));
             }
+        }
+    }
+
+    /**
+     * View shown as a general-information fallback on pages that have no view displays
+     * configured yet.
+     */
+    private static final String GENERAL_INFO_VIEW = "https://w3id.org/np/RA9FKwtTWqknnDrFz1vMNeUdWpYYVQp7sznigpaXlBrU8/resource-info-view";
+
+    private static ViewDisplay generalInfoViewDisplay() {
+        return new ViewDisplay(View.get(GENERAL_INFO_VIEW));
+    }
+
+    /**
+     * Adds the "page not configured yet" notice and the general-information fallback view,
+     * both visible only when the resource has no view displays.
+     */
+    private void addUnconfiguredFallback(WebMarkupContainer contentContainer, AbstractResourceWithProfile resource, boolean empty) {
+        contentContainer.add(new WebMarkupContainer("unconfigured-notice").setVisible(empty));
+        if (empty) {
+            contentContainer.add(new ViewList("generalinfoview", resource, List.of(generalInfoViewDisplay())));
+        } else {
+            contentContainer.add(new EmptyPanel("generalinfoview").setVisible(false));
         }
     }
 

--- a/src/main/java/com/knowledgepixels/nanodash/page/SpacePage.html
+++ b/src/main/java/com/knowledgepixels/nanodash/page/SpacePage.html
@@ -24,6 +24,14 @@
 
   <wicket:container wicket:id="contentContainer">
   <div wicket:id="views"></div>
+
+  <div class="row-section" wicket:id="unconfigured-notice">
+    <div class="col-12">
+      <p><em>This space page hasn't been configured yet. Below you find some general information.</em></p>
+    </div>
+  </div>
+
+  <div wicket:id="generalinfoview"></div>
   </wicket:container>
   <div wicket:id="otherTab"></div>
 

--- a/src/main/java/com/knowledgepixels/nanodash/page/SpacePage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/SpacePage.java
@@ -1,6 +1,8 @@
 package com.knowledgepixels.nanodash.page;
 
 import com.knowledgepixels.nanodash.NanodashPageRef;
+import com.knowledgepixels.nanodash.View;
+import com.knowledgepixels.nanodash.ViewDisplay;
 import com.knowledgepixels.nanodash.component.*;
 import com.knowledgepixels.nanodash.domain.AbstractResourceWithProfile;
 import com.knowledgepixels.nanodash.domain.MaintainedResource;
@@ -9,6 +11,7 @@ import com.knowledgepixels.nanodash.repository.MaintainedResourceRepository;
 import com.knowledgepixels.nanodash.repository.SpaceRepository;
 import org.apache.wicket.Component;
 import org.apache.wicket.RestartResponseException;
+import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.extensions.ajax.markup.html.AjaxLazyLoadPanel;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
@@ -19,6 +22,7 @@ import org.apache.wicket.model.Model;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * The SpacePage class represents a space page in the Nanodash application.
@@ -141,10 +145,35 @@ public class SpacePage extends NanodashPage {
             // Pinned to a specific claimant: render that ref's view displays, not the
             // representative ref's (the IRI-keyed singleton). Fetched on demand. See
             // docs/space-ref-identity.md.
-            contentContainer.add(new ViewList("views", space, space.getTopLevelViewDisplays(effectiveRoot), effectiveRoot));
+            List<ViewDisplay> viewDisplays = space.getTopLevelViewDisplays(effectiveRoot);
+            boolean empty = viewDisplays.isEmpty();
+            if (empty) {
+                contentContainer.add(new WebMarkupContainer("views").setVisible(false));
+            } else {
+                contentContainer.add(new ViewList("views", space, viewDisplays, effectiveRoot));
+            }
+            addUnconfiguredFallback(contentContainer, space, empty);
         } else if (space.isDataInitialized()) {
-            contentContainer.add(new ViewList("views", space));
+            boolean empty = space.getTopLevelViewDisplays().isEmpty();
+            if (empty) {
+                contentContainer.add(new WebMarkupContainer("views").setVisible(false));
+            } else {
+                contentContainer.add(new ViewList("views", space));
+            }
+            addUnconfiguredFallback(contentContainer, space, empty);
         } else {
+            // Data not yet loaded: render the views lazily, then reveal the unconfigured
+            // notice + general-info fallback once we know whether any views exist.
+            final WebMarkupContainer unconfiguredNotice = new WebMarkupContainer("unconfigured-notice");
+            unconfiguredNotice.setVisible(false);
+            unconfiguredNotice.setOutputMarkupPlaceholderTag(true);
+            contentContainer.add(unconfiguredNotice);
+
+            final ViewList generalInfoView = new ViewList("generalinfoview", space, List.of(generalInfoViewDisplay()));
+            generalInfoView.setVisible(false);
+            generalInfoView.setOutputMarkupPlaceholderTag(true);
+            contentContainer.add(generalInfoView);
+
             contentContainer.add(new AjaxLazyLoadPanel<Component>("views") {
 
                 @Override
@@ -162,9 +191,47 @@ public class SpacePage extends NanodashPage {
                     return new Label(id, "<div class=\"row-section\"><div class=\"col-12\">" + ResultComponent.getWaitIconHtml() + "</div></div>").setEscapeModelStrings(false);
                 }
 
+                @Override
+                protected void onContentLoaded(Component content, Optional<AjaxRequestTarget> target) {
+                    super.onContentLoaded(content, target);
+                    target.ifPresent(t -> {
+                        boolean isEmpty = spaceModel.getObject().getTopLevelViewDisplays().isEmpty();
+                        if (isEmpty) {
+                            t.appendJavaScript("document.getElementById('" + getMarkupId() + "').remove();");
+                        }
+                        unconfiguredNotice.setVisible(isEmpty);
+                        t.add(unconfiguredNotice);
+                        generalInfoView.setVisible(isEmpty);
+                        t.add(generalInfoView);
+                    });
+                }
+
             });
         }
 
+    }
+
+    /**
+     * View shown as a general-information fallback on pages that have no view displays
+     * configured yet.
+     */
+    private static final String GENERAL_INFO_VIEW = "https://w3id.org/np/RA9FKwtTWqknnDrFz1vMNeUdWpYYVQp7sznigpaXlBrU8/resource-info-view";
+
+    private static ViewDisplay generalInfoViewDisplay() {
+        return new ViewDisplay(View.get(GENERAL_INFO_VIEW));
+    }
+
+    /**
+     * Adds the "page not configured yet" notice and the general-information fallback view,
+     * both visible only when the resource has no view displays.
+     */
+    private void addUnconfiguredFallback(WebMarkupContainer contentContainer, AbstractResourceWithProfile resource, boolean empty) {
+        contentContainer.add(new WebMarkupContainer("unconfigured-notice").setVisible(empty));
+        if (empty) {
+            contentContainer.add(new ViewList("generalinfoview", resource, List.of(generalInfoViewDisplay())));
+        } else {
+            contentContainer.add(new EmptyPanel("generalinfoview").setVisible(false));
+        }
     }
 
     /**

--- a/src/main/java/com/knowledgepixels/nanodash/page/UserPage.html
+++ b/src/main/java/com/knowledgepixels/nanodash/page/UserPage.html
@@ -24,7 +24,7 @@
     <div wicket:id="views"></div>
 
     <div class="row-section" wicket:id="unconfigured-notice">
-      <div class="col-6">
+      <div class="col-12">
         <p><em>This user hasn't configured their profile yet, but below you can find their latest nanopublications.</em>
         </p>
       </div>


### PR DESCRIPTION
## Summary
- Widens the user-page "This user hasn't configured their profile yet…" notice from `col-6` to `col-12`.
- Adds an equivalent "not configured yet" notice plus a general-information fallback view to **space** and **maintained-resource** pages that have no view displays configured yet.
- The fallback renders the "Resource info view" (`https://w3id.org/np/RA9FKwtTWqknnDrFz1vMNeUdWpYYVQp7sznigpaXlBrU8/resource-info-view`), mirroring how `UserPage` shows the latest-nanopubs view as a fallback.

## Details
- Notice text: *"This space page hasn't been configured yet. Below you find some general information."* (and the maintained-resource equivalent).
- Emptiness is handled across all view branches — pinned-ref (`?root=`), data-initialized, and the lazy/AJAX branch (notice + fallback revealed in `onContentLoaded` once emptiness is known, exactly as `UserPage` does).
- The fallback view IRI is the embedded view IRI (`…/resource-info-view`), not the bare nanopub IRI, so `View.get` resolves it correctly.

## Testing
- `mvn compile` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)