### PR TITLE
Strip parent/child word overlap in breadcrumb labels

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/component/TitleBar.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/TitleBar.java
@@ -97,7 +97,7 @@ public class TitleBar extends Panel {
     }
 
     /**
-     * Flattens a breadcrumb path into the segments to render. Two transforms are
+     * Flattens a breadcrumb path into the segments to render. Three transforms are
      * applied to each ref's label:
      * <ul>
      *   <li>For each non-root crumb, the part it shares with its parent label
@@ -107,6 +107,12 @@ public class TitleBar extends Panel {
      *       (almost) all of the parent and ends on a non-letter/digit boundary
      *       in the child — this also catches singular/plural variations like
      *       parent "Nano Sessions", child "Nano Session #30" → "#30".</li>
+     *   <li>For each non-root crumb, a word-level overlap where the child's
+     *       leading word(s) restate the parent's trailing word(s) is stripped
+     *       (e.g. parent "Abc Def Ghi", child "Ghi Jkl" renders as "Jkl"). The
+     *       longest such parent-suffix/child-prefix overlap wins, matched on
+     *       whole words case-insensitively, and never strips the whole child
+     *       away.</li>
      *   <li>Only the leading segment of the remaining label is kept — the part
      *       before the first list/title separator ({@code ,}, {@code :},
      *       {@code ;}, {@code |}, or a spaced {@code -}) — so each path level
@@ -125,7 +131,9 @@ public class TitleBar extends Panel {
                 continue;
             }
             if (i > 0) {
-                label = stripParentPrefix(pathRefs[i - 1].getLabel(), label);
+                String parentLabel = pathRefs[i - 1].getLabel();
+                label = stripParentPrefix(parentLabel, label);
+                label = stripParentOverlap(parentLabel, label);
             }
             // Show only the leading segment (before the first list/title separator)
             // so each path level renders as one concise crumb — e.g.
@@ -179,6 +187,55 @@ public class TitleBar extends Panel {
         String remainder = child.substring(lcp).replaceAll("^\\s+", "");
         if (remainder.isEmpty()) return child;
         return remainder;
+    }
+
+    /**
+     * If the child label's leading word(s) restate the parent label's trailing
+     * word(s), strips that overlap and returns the remainder. E.g. parent
+     * "Abc Def Ghi", child "Ghi Jkl" → "Jkl", or parent "Knowledge Pixels
+     * Incubator Office Hours", child "Office Hour 24 June 2026" → "24 June 2026".
+     * The overlap is matched on whole words, case-insensitively and tolerating
+     * singular/plural variation ("Hours" ≈ "Hour"); the longest parent-suffix that
+     * matches a child-prefix wins. Returns the child unchanged when there is no
+     * overlap, or when the overlap would consume the whole child label (at least
+     * one word is always kept).
+     */
+    static String stripParentOverlap(String parent, String child) {
+        if (parent == null || parent.isEmpty() || child == null || child.isEmpty()) return child;
+        String[] parentWords = parent.trim().split("\\s+");
+        String[] childWords = child.trim().split("\\s+");
+        // Keep at least one child word, so the overlap can cover at most all but
+        // the last child word.
+        int maxK = Math.min(parentWords.length, childWords.length - 1);
+        for (int k = maxK; k >= 1; k--) {
+            boolean match = true;
+            for (int j = 0; j < k; j++) {
+                if (!wordsEquivalent(parentWords[parentWords.length - k + j], childWords[j])) {
+                    match = false;
+                    break;
+                }
+            }
+            if (match) {
+                return String.join(" ", java.util.Arrays.asList(childWords).subList(k, childWords.length));
+            }
+        }
+        return child;
+    }
+
+    /**
+     * Whether two breadcrumb words count as the same topic word: equal ignoring
+     * case, or equal once a single trailing plural "s" is dropped from each (so
+     * "Hours" matches "Hour", "Sessions" matches "Session").
+     */
+    private static boolean wordsEquivalent(String a, String b) {
+        if (a.equalsIgnoreCase(b)) return true;
+        return depluralize(a).equalsIgnoreCase(depluralize(b));
+    }
+
+    private static String depluralize(String word) {
+        return word.length() > 1 && (word.endsWith("s") || word.endsWith("S"))
+                ? word.substring(0, word.length() - 1)
+                : word;
     }
 
     /**

--- a/src/test/java/com/knowledgepixels/nanodash/component/TitleBarTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/component/TitleBarTest.java
@@ -1,0 +1,101 @@
+package com.knowledgepixels.nanodash.component;
+
+import com.knowledgepixels.nanodash.NanodashPageRef;
+import com.knowledgepixels.nanodash.component.TitleBar.CrumbPart;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TitleBarTest {
+
+    private static NanodashPageRef[] refs(String... labels) {
+        NanodashPageRef[] r = new NanodashPageRef[labels.length];
+        for (int i = 0; i < labels.length; i++) r[i] = new NanodashPageRef(labels[i]);
+        return r;
+    }
+
+    private static List<String> crumbLabels(String... labels) {
+        return TitleBar.buildCrumbParts(refs(labels)).stream().map(CrumbPart::label).toList();
+    }
+
+    @Test
+    void stripsParentSuffixChildPrefixOverlap() {
+        assertEquals("Jkl", TitleBar.stripParentOverlap("Abc Def Ghi", "Ghi Jkl"));
+    }
+
+    @Test
+    void breadcrumbStripsOverlap() {
+        assertEquals(List.of("Abc Def Ghi", "Jkl"), crumbLabels("Abc Def Ghi", "Ghi Jkl"));
+    }
+
+    @Test
+    void stripsLongestMultiWordOverlap() {
+        assertEquals("Qux", TitleBar.stripParentOverlap("Foo Bar Baz", "Bar Baz Qux"));
+    }
+
+    @Test
+    void overlapMatchIsCaseInsensitive() {
+        assertEquals("Jkl", TitleBar.stripParentOverlap("Abc Def Ghi", "ghi Jkl"));
+    }
+
+    @Test
+    void noOverlapLeavesChildUnchanged() {
+        assertEquals("Mno Pqr", TitleBar.stripParentOverlap("Abc Def Ghi", "Mno Pqr"));
+    }
+
+    @Test
+    void neverStripsWholeChildAway() {
+        // The child's only word equals the parent's last word — keep it rather than
+        // produce an empty crumb.
+        assertEquals("Ghi", TitleBar.stripParentOverlap("Abc Def Ghi", "Ghi"));
+    }
+
+    @Test
+    void handlesNullAndEmpty() {
+        assertEquals("Ghi Jkl", TitleBar.stripParentOverlap(null, "Ghi Jkl"));
+        assertEquals("Ghi Jkl", TitleBar.stripParentOverlap("", "Ghi Jkl"));
+        assertNull(TitleBar.stripParentOverlap("Abc", null));
+    }
+
+    @Test
+    void stripsSuffixOverlapWithPluralVariation() {
+        // Parent's trailing "Office Hours" overlaps the child's leading "Office
+        // Hour" (singular/plural), and the matching words are a suffix of the
+        // parent rather than its whole label.
+        assertEquals("24 June 2026",
+                TitleBar.stripParentOverlap("Knowledge Pixels Incubator Office Hours", "Office Hour 24 June 2026"));
+    }
+
+    @Test
+    void breadcrumbStripsSuffixOverlapWithPlural() {
+        assertEquals(
+                List.of("Knowledge Pixels", "Incubator", "Office Hours", "24 June 2026"),
+                crumbLabels(
+                        "Knowledge Pixels",
+                        "Knowledge Pixels Incubator",
+                        "Knowledge Pixels Incubator Office Hours",
+                        "Office Hour 24 June 2026"));
+    }
+
+    @Test
+    void breadcrumbStripsAncestorPrefixedLeafToo() {
+        // The same leaf may instead carry the fully ancestor-prefixed label; it
+        // must reduce to the same crumb via the character-prefix transform.
+        assertEquals(
+                List.of("Knowledge Pixels", "Incubator", "Office Hours", "24 June 2026"),
+                crumbLabels(
+                        "Knowledge Pixels",
+                        "Knowledge Pixels Incubator",
+                        "Knowledge Pixels Incubator Office Hours",
+                        "Knowledge Pixels Incubator Office Hour 24 June 2026"));
+    }
+
+    @Test
+    void existingParentPrefixStrippingStillApplies() {
+        // child extends parent — handled by the character-prefix transform.
+        assertEquals(List.of("Knowledge Pixels", "Incubator"),
+                crumbLabels("Knowledge Pixels", "Knowledge Pixels Incubator"));
+    }
+}


### PR DESCRIPTION
## Summary
Adds a breadcrumb label transform for the case where a child space's **leading** word(s) restate its parent's **trailing** word(s), without a shared leading character prefix — which the existing `stripParentPrefix` doesn't catch.

Examples:
- `"Abc Def Ghi"` › `"Ghi Jkl"` → **"Jkl"**
- `"Knowledge Pixels Incubator Office Hours"` › `"Office Hour 24 June 2026"` → **"24 June 2026"**

So a breadcrumb like *Knowledge Pixels › Incubator › Office Hours › Office Hour 24 June 2026* now reads *… › Office Hours › 24 June 2026*.

## Details
- New `stripParentOverlap` matches whole words, case-insensitively, tolerating singular/plural variation (`Hours` ≈ `Hour`, via `wordsEquivalent`/`depluralize`) — mirroring the character-level tolerance `stripParentPrefix` already had.
- Longest parent-suffix matching a child-prefix wins; at least one child word is always kept (never strips the whole label away).
- Wired into `TitleBar.buildCrumbParts` after `stripParentPrefix`, so all three breadcrumb call sites (`SpacePage`, `MaintainedResourcePage`, `ResourcePartPage`) benefit. The two transforms are complementary (disjoint scenarios).
- Handles the case where the same leaf instead carries a fully ancestor-prefixed label — it reduces to the same crumb via the existing prefix transform.

## Testing
- New `TitleBarTest` (11 cases): suffix overlap, plural variation, the real-world Office Hours breadcrumb (both label variants), longest multi-word overlap, case-insensitivity, no-overlap, whole-child guard, null/empty, and a regression check that the existing prefix-strip still works.
- `mvn test -Dtest=TitleBarTest` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)