### PR TITLE
feat: show namespace-declaring resource's part view for plain terms

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/page/ExplorePage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/ExplorePage.java
@@ -236,6 +236,15 @@ public class ExplorePage extends NanodashPage {
             }
         }
 
+        // Lowest-priority rule: a plain term whose namespace is declared by a maintained
+        // resource is shown as a part of that resource. Applies only once the earlier
+        // rules (known resource, explicit part membership of the given context) have not
+        // matched; the incoming context here is typically just the space the user came
+        // from, not the resource that owns the term. Never for nanopub identifiers.
+        if (publishedNanopub == null && !isNanopubId) {
+            ResourcePartPage.forwardToContainingResource(new PageParameters(parameters).set("id", tempRef));
+        }
+
         WebMarkupContainer nanopubSection = new WebMarkupContainer("nanopub-section");
 
         if (np == null) {

--- a/src/main/java/com/knowledgepixels/nanodash/page/ResourcePartPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/ResourcePartPage.java
@@ -12,6 +12,7 @@ import com.knowledgepixels.nanodash.domain.User;
 import com.knowledgepixels.nanodash.repository.MaintainedResourceRepository;
 import com.knowledgepixels.nanodash.repository.SpaceRepository;
 import org.apache.wicket.Component;
+import org.apache.wicket.RestartResponseException;
 import org.apache.wicket.extensions.ajax.markup.html.AjaxLazyLoadPanel;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
@@ -54,6 +55,24 @@ public class ResourcePartPage extends NanodashPage {
      * Resource with profile (Space or MaintainedResource) object with the data shown on this page.
      */
     private AbstractResourceWithProfile resourceWithProfile;
+
+    /**
+     * If the {@code id} in the given parameters falls under a namespace declared by a
+     * maintained resource, forward to this page with that resource set as the
+     * {@code context}. Does nothing if no maintained resource declares the namespace.
+     *
+     * @param parameters page parameters containing the {@code id} to resolve
+     * @throws RestartResponseException if a containing maintained resource is found
+     */
+    public static void forwardToContainingResource(PageParameters parameters) {
+        String id = parameters.get("id").toString();
+        MaintainedResource containingResource = MaintainedResourceRepository.get().findByNamespace(MaintainedResource.getNamespace(id));
+        if (containingResource != null) {
+            PageParameters partParameters = new PageParameters(parameters);
+            partParameters.set("context", containingResource.getId());
+            throw new RestartResponseException(ResourcePartPage.class, partParameters);
+        }
+    }
 
     public ResourcePartPage(final PageParameters parameters) {
         super(parameters);

--- a/src/main/java/com/knowledgepixels/nanodash/page/SpacePage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/SpacePage.java
@@ -274,12 +274,7 @@ public class SpacePage extends NanodashPage {
             if (MaintainedResourceRepository.get().findById(id) != null) {
                 throw new RestartResponseException(MaintainedResourcePage.class, parameters);
             }
-            MaintainedResource containingResource = MaintainedResourceRepository.get().findByNamespace(MaintainedResource.getNamespace(id));
-            if (containingResource != null) {
-                PageParameters partParameters = new PageParameters(parameters);
-                partParameters.set("context", containingResource.getId());
-                throw new RestartResponseException(ResourcePartPage.class, partParameters);
-            }
+            ResourcePartPage.forwardToContainingResource(parameters);
             throw new IllegalArgumentException("No space or resource found for id: " + id);
         }
 


### PR DESCRIPTION
## Summary

When a plain term (e.g. `https://w3id.org/kpxl/gen/terms/Event`) whose namespace is declared by a maintained resource is explored and no higher-priority rule applies, we now forward to the **part-level view of the maintained resource that declares its namespace**.

Previously such a term fell through to the generic explore page even though a maintained resource owns its namespace.

## Changes

- **`ResourcePartPage`** — new static helper `forwardToContainingResource(parameters)` that, given an `id`, looks up the maintained resource declaring its namespace (`findByNamespace(getNamespace(id))`) and forwards to the part page with that resource as `context`. No-op when no resource declares the namespace.
- **`SpacePage`** — `resolveSpace()` now delegates to the shared helper instead of an inline copy of the same logic (behaviour unchanged).
- **`ExplorePage`** — applies the helper as the **lowest-priority** rule in `initPage()`, after the known-resource checks and the explicit part-membership (`dct:isPartOf` / `skos:inScheme` / `appliesTo`) check. The incoming `context` is typically just the space the user came from, so the fallback runs regardless of it; skipped for nanopub identifiers and just-published nanopubs.

## Notes

- Precedence is preserved: explicit part membership of the given context still wins over the namespace fallback.
- Inherits the existing last-write-wins behaviour for namespace conflicts (see `// TODO Handle conflicts` in `MaintainedResourceRepository`).

## Testing

Compiles cleanly. Manually verified: clicking a term like **Event** now lands on `/part` with the declaring maintained resource as context instead of the generic explore page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)