### PR TITLE
fix: forward known resources to Content tab, not Explore

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/page/ExplorePage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/ExplorePage.java
@@ -133,15 +133,15 @@ public class ExplorePage extends NanodashPage {
 
         String contextId = parameters.get("context").toString("");
 
-        // Known resources are explored via their own page's Explore tab; forward
-        // there instead of rendering the generic explore page.
+        // Known resources are shown on their own page; forward there (to the default
+        // Content tab) instead of rendering the generic explore page.
         if (publishedNanopub == null) {
             if (SpaceRepository.get().findById(tempRef) != null) {
-                throw new RestartResponseException(SpacePage.class, new PageParameters().set("id", tempRef).set("tab", "explore"));
+                throw new RestartResponseException(SpacePage.class, new PageParameters().set("id", tempRef));
             } else if (MaintainedResourceRepository.get().findById(tempRef) != null) {
-                throw new RestartResponseException(MaintainedResourcePage.class, new PageParameters().set("id", tempRef).set("tab", "explore"));
+                throw new RestartResponseException(MaintainedResourcePage.class, new PageParameters().set("id", tempRef));
             } else if (User.getUserData().isUser(tempRef)) {
-                throw new RestartResponseException(UserPage.class, new PageParameters().set("id", tempRef).set("tab", "explore"));
+                throw new RestartResponseException(UserPage.class, new PageParameters().set("id", tempRef));
             }
             // Note: forwarding to the part page when the context is a maintained
             // resource is handled further down (after np resolution), gated on


### PR DESCRIPTION
## Problem

Clicking a table entry that resolves to a registered Space, maintained resource, or user (e.g. clicking `https://w3id.org/fair/3pff/FA.10.T.4` on the 3pff space page) lands the user on the **Explore** tab instead of the expected **Content** tab.

## Cause

These links are rendered with the *space* as their context, so `NanodashLink` cannot match them to a resource directly and routes them through the generic `ExplorePage`. The first forwarding rule in `ExplorePage.initPage` (`ExplorePage.java:138-145`) recognizes that the target is itself a known Space / maintained resource / user and forwards to that resource's own page — but with `tab=explore` hard-coded.

## Fix

Drop the `tab` parameter from these three forwards. `ResourceTabs.activeFromParam` defaults to `content`, so the resource now opens on its default Content tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)