### PR TITLE
feat: truncate over-long breadcrumb labels

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/component/TitleBar.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/TitleBar.java
@@ -141,10 +141,20 @@ public class TitleBar extends Panel {
             // "3PFF: the Three Point FAIRification Framework" → "3PFF".
             List<String> segments = splitLabel(label);
             if (!segments.isEmpty()) {
-                parts.add(new CrumbPart(pathRefs[i], segments.get(0)));
+                parts.add(new CrumbPart(pathRefs[i], truncateLabel(segments.get(0))));
             }
         }
         return parts;
+    }
+
+    /**
+     * Truncates an over-long crumb label: labels longer than 60 characters are
+     * cut to 47 characters with an ellipsis ("...") appended, so a single crumb
+     * never blows up the breadcrumb strip. Shorter labels are returned unchanged.
+     */
+    static String truncateLabel(String label) {
+        if (label == null || label.length() <= 60) return label;
+        return label.substring(0, 47).stripTrailing() + "...";
     }
 
     /**


### PR DESCRIPTION
## Summary

Breadcrumb labels longer than 60 characters are now truncated to 47 characters with `...` appended, so a single long crumb (e.g. a full space IRI tail like `.../zonmw/antibiotica-resistentie-abr/541003003`) no longer overflows the breadcrumb strip.

## Details

- Added `TitleBar.truncateLabel(String)` and applied it to the final crumb label in `buildCrumbParts`, after the existing parent-prefix/overlap stripping and leading-segment split — so it only kicks in when a concise crumb is still genuinely long.
- Uses `stripTrailing()` on the cut so the ellipsis never follows a dangling space.

🤖 Generated with [Claude Code](https://claude.com/claude-code)