### PR TITLE
feat: truncate over-long entity labels in links, buttons, and breadcrumbs

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/Utils.java
+++ b/src/main/java/com/knowledgepixels/nanodash/Utils.java
@@ -161,6 +161,21 @@ public class Utils {
     }
 
     /**
+     * Truncates an over-long entity label for display in a link or breadcrumb:
+     * labels longer than 60 characters are cut to 47 characters with an ellipsis
+     * ("...") appended, so a single long label (e.g. a full IRI tail) never blows
+     * up the surrounding UI. Shorter labels are returned unchanged. The full label
+     * stays available on the entity's own page, which shows it as the title.
+     *
+     * @param label the label to truncate, or null
+     * @return the truncated label, or the original if 60 characters or shorter
+     */
+    public static String truncateLinkLabel(String label) {
+        if (label == null || label.length() <= 60) return label;
+        return label.substring(0, 47).stripTrailing() + "...";
+    }
+
+    /**
      * Builds the HTML body for a menu entry whose label may begin with a leading
      * symbol/emoji used as the entry's icon. If {@code label} starts with a token
      * of symbol/emoji characters (no letters or digits) followed by whitespace,

--- a/src/main/java/com/knowledgepixels/nanodash/component/IriItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/IriItem.java
@@ -125,7 +125,9 @@ public class IriItem extends AbstractContextComponent {
         } else {
             href = NanodashLink.getPageUrl(iriString);
         }
-        final String linkLabelBase = labelString.replaceFirst(" - .*$", "");
+        // Truncate over-long labels for display; the full label stays available on
+        // the entity's own page (shown as its title).
+        final String linkLabelBase = Utils.truncateLinkLabel(labelString.replaceFirst(" - .*$", ""));
         IModel<String> linkLabelModel;
         if (autoNumber) {
             // Append the 1-based repetition index, but only once there is more than one

--- a/src/main/java/com/knowledgepixels/nanodash/component/JustPublishedMessagePanel.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/JustPublishedMessagePanel.java
@@ -59,7 +59,7 @@ public class JustPublishedMessagePanel extends Panel {
             Nanopub np = Utils.getAsNanopub(justPublishedId);
             String label = (np != null ? NanopubUtils.getLabel(np) : null);
             if (label == null || label.isEmpty()) label = Utils.getShortNameFromURI(justPublishedId);
-            confirmBox.add(new BookmarkablePageLink<Void>("link", ExplorePage.class, new PageParameters().set("id", justPublishedId)).setBody(Model.of(label)));
+            confirmBox.add(new BookmarkablePageLink<Void>("link", ExplorePage.class, new PageParameters().set("id", justPublishedId)).setBody(Model.of(Utils.truncateLinkLabel(label))));
             // Remember a freshly-published introduction so the warning below clears.
             if (np != null && Utils.usesPredicateInAssertion(np, NPX.DECLARED_BY)) session.setIntroPublishedNow();
         } else {

--- a/src/main/java/com/knowledgepixels/nanodash/component/NanodashLink.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/NanodashLink.java
@@ -173,25 +173,25 @@ public class NanodashLink extends Panel {
         if (contextId != null) params.set("context", contextId);
         // TODO Improve this
         if (isNp && uri.startsWith(DsConfig.get().getTargetNamespace())) {
-            return new BookmarkablePageLink<Void>(markupId, DsNanopubPage.class, params.set("mode", "final")).setBody(Model.of(label));
+            return new BookmarkablePageLink<Void>(markupId, DsNanopubPage.class, params.set("mode", "final")).setBody(Model.of(Utils.truncateLinkLabel(label)));
         } else if (isNp && uri.startsWith(BdjConfig.get().getTargetNamespace())) {
-            return new BookmarkablePageLink<Void>(markupId, BdjNanopubPage.class, params.set("mode", "final")).setBody(Model.of(label));
+            return new BookmarkablePageLink<Void>(markupId, BdjNanopubPage.class, params.set("mode", "final")).setBody(Model.of(Utils.truncateLinkLabel(label)));
         } else if (isNp && uri.startsWith(RioConfig.get().getTargetNamespace())) {
-            return new BookmarkablePageLink<Void>(markupId, RioNanopubPage.class, params.set("mode", "final")).setBody(Model.of(label));
+            return new BookmarkablePageLink<Void>(markupId, RioNanopubPage.class, params.set("mode", "final")).setBody(Model.of(Utils.truncateLinkLabel(label)));
         } else if (IndividualAgent.isUser(uri)) {
             label = User.getShortDisplayName(vf.createIRI(uri));
-            return new BookmarkablePageLink<Void>(markupId, UserPage.class, params).setBody(Model.of(label));
+            return new BookmarkablePageLink<Void>(markupId, UserPage.class, params).setBody(Model.of(Utils.truncateLinkLabel(label)));
         } else if (SpaceRepository.get().findById(uri) != null) {
             label = SpaceRepository.get().findById(uri).getLabel();
-            return new BookmarkablePageLink<Void>(markupId, SpacePage.class, params).setBody(Model.of(label));
+            return new BookmarkablePageLink<Void>(markupId, SpacePage.class, params).setBody(Model.of(Utils.truncateLinkLabel(label)));
         } else if (SpaceRepository.get().findByAltId(uri) != null) {
             Space space = SpaceRepository.get().findByAltId(uri);
             label = space.getLabel();
             params.set("id", space.getId());
-            return new BookmarkablePageLink<Void>(markupId, SpacePage.class, params).setBody(Model.of(label));
+            return new BookmarkablePageLink<Void>(markupId, SpacePage.class, params).setBody(Model.of(Utils.truncateLinkLabel(label)));
         } else if (MaintainedResourceRepository.get().findById(uri) != null) {
             label = MaintainedResourceRepository.get().findById(uri).getLabel();
-            return new BookmarkablePageLink<Void>(markupId, MaintainedResourcePage.class, params).setBody(Model.of(label));
+            return new BookmarkablePageLink<Void>(markupId, MaintainedResourcePage.class, params).setBody(Model.of(Utils.truncateLinkLabel(label)));
         } else {
             boolean isCaret = "^".equals(label);
             if (!isCaret) params.set("label", label);
@@ -201,7 +201,9 @@ public class NanodashLink extends Panel {
             } else {
                 link = new BookmarkablePageLink<Void>(markupId, ExplorePage.class, params.set("forward-to-part", "true"));
             }
-            link.setBody(Model.of(label));
+            // Truncate only the displayed label; the full label stays in the page
+            // params above so the destination page can still show it as its title.
+            link.setBody(Model.of(Utils.truncateLinkLabel(label)));
             // The "^" source-nanopub caret is styled like the admin lists (subtle, with
             // hover-darken), reusing SourceNanopub's `a.source` styling.
             if (isCaret) link.add(new AttributeAppender("class", "source"));

--- a/src/main/java/com/knowledgepixels/nanodash/component/ReadonlyItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/ReadonlyItem.java
@@ -189,12 +189,12 @@ public class ReadonlyItem extends AbstractContextComponent {
                         return foafNameMap.get(obj);
                     }
                     Space space = SpaceRepository.get().findById(obj);
-                    if (space != null) return space.getLabel();
+                    if (space != null) return Utils.truncateLinkLabel(space.getLabel());
                     space = SpaceRepository.get().findByAltId(obj);
-                    if (space != null) return space.getLabel();
+                    if (space != null) return Utils.truncateLinkLabel(space.getLabel());
                     MaintainedResource mr = MaintainedResourceRepository.get().findById(obj);
-                    if (mr != null) return mr.getLabel();
-                    return getLabelString(objIri);
+                    if (mr != null) return Utils.truncateLinkLabel(mr.getLabel());
+                    return Utils.truncateLinkLabel(getLabelString(objIri));
                 }
                 return obj;
             }

--- a/src/main/java/com/knowledgepixels/nanodash/component/TitleBar.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/TitleBar.java
@@ -16,6 +16,7 @@ import org.apache.wicket.markup.repeater.data.ListDataProvider;
 
 import com.knowledgepixels.nanodash.NanodashPageRef;
 import com.knowledgepixels.nanodash.NanodashPreferences;
+import com.knowledgepixels.nanodash.Utils;
 import com.knowledgepixels.nanodash.page.NanodashPage;
 import com.knowledgepixels.nanodash.page.PublishPage;
 import com.knowledgepixels.nanodash.page.QueryListPage;
@@ -148,13 +149,12 @@ public class TitleBar extends Panel {
     }
 
     /**
-     * Truncates an over-long crumb label: labels longer than 60 characters are
-     * cut to 47 characters with an ellipsis ("...") appended, so a single crumb
-     * never blows up the breadcrumb strip. Shorter labels are returned unchanged.
+     * Truncates an over-long crumb label so a single crumb never blows up the
+     * breadcrumb strip. Delegates to {@link Utils#truncateLinkLabel(String)} so
+     * breadcrumbs and entity links share one truncation rule.
      */
     static String truncateLabel(String label) {
-        if (label == null || label.length() <= 60) return label;
-        return label.substring(0, 47).stripTrailing() + "...";
+        return Utils.truncateLinkLabel(label);
     }
 
     /**

--- a/src/main/java/com/knowledgepixels/nanodash/page/ExplorePage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/ExplorePage.java
@@ -155,15 +155,15 @@ public class ExplorePage extends NanodashPage {
         if (SpaceRepository.get().findById(contextId) != null) {
             add(new BookmarkablePageLink<Void>("back-to-context-link", SpacePage.class, new PageParameters().set("id", contextId)).setBody(LoadableDetachableModel.of(() -> {
                 var space = SpaceRepository.get().findById(contextId);
-                return "back to " + (space == null ? contextId : space.getLabel());
+                return "back to " + Utils.truncateLinkLabel(space == null ? contextId : space.getLabel());
             })));
         } else if (MaintainedResourceRepository.get().findById(contextId) != null) {
             add(new BookmarkablePageLink<Void>("back-to-context-link", MaintainedResourcePage.class, new PageParameters().set("id", contextId)).setBody(LoadableDetachableModel.of(() -> {
                 var resource = MaintainedResourceRepository.get().findById(contextId);
-                return "back to " + (resource == null ? contextId : resource.getLabel());
+                return "back to " + Utils.truncateLinkLabel(resource == null ? contextId : resource.getLabel());
             })));
         } else if (IndividualAgent.isUser(contextId)) {
-            add(new BookmarkablePageLink<Void>("back-to-context-link", UserPage.class, new PageParameters().set("id", contextId)).setBody(LoadableDetachableModel.of(() -> "back to " + User.getShortDisplayName(Utils.vf.createIRI(contextId)))));
+            add(new BookmarkablePageLink<Void>("back-to-context-link", UserPage.class, new PageParameters().set("id", contextId)).setBody(LoadableDetachableModel.of(() -> "back to " + Utils.truncateLinkLabel(User.getShortDisplayName(Utils.vf.createIRI(contextId))))));
         } else {
             add(new Label("back-to-context-link").setVisible(false));
         }
@@ -315,8 +315,14 @@ public class ExplorePage extends NanodashPage {
 
         final String ref = tempRef;
         final String shortName;
-        if (publishedNanopub != null) {
-            shortName = NanopubUtils.getLabel(np);
+        // Prefer the resolved nanopub's own (full) label whenever we are exploring the
+        // nanopub itself — this avoids showing the truncated/ellipsised value carried in
+        // the incoming "label" param as the page title. The param is only used as a
+        // fallback for things we cannot resolve here (e.g. plain terms).
+        String npLabel = (np != null && (publishedNanopub != null || ref.equals(np.getUri().stringValue())))
+                ? NanopubUtils.getLabel(np) : null;
+        if (npLabel != null && !npLabel.isBlank()) {
+            shortName = npLabel;
         } else if (parameters.get("label").isEmpty()) {
             shortName = Utils.getShortNameFromURI(ref);
         } else {


### PR DESCRIPTION
## Summary

Extends the breadcrumb label truncation (PR #521) to **all** entity labels shown as links/buttons: anything longer than 60 characters is truncated to 47 + `…`. The full label stays available on the destination page (as its title) and via the existing hover tooltip.

A new shared `Utils.truncateLinkLabel` is the single truncation rule; `TitleBar` now delegates to it so breadcrumbs and links stay consistent.

## Render paths covered

- **`NanodashLink.createLink`** — nanopub / user / space / maintained-resource / term link bodies
- **`IriItem`** — template-rendered statement links
- **`ReadonlyItem`** — introduced/embedded resource links in assertions (the path that still showed full labels when a nanopub displays a resource it introduces)
- **`ExplorePage`** — "back to &lt;context&gt;" buttons
- **`JustPublishedMessagePanel`** — the publish-confirmation link

Only the *displayed* text is truncated — page parameters and the destination page's title are untouched.

## Explore page title fix

ExplorePage was using the incoming (already-truncated) `label` URL param verbatim as the page title, producing an ugly double-ellipsis (`……`). It now derives the title from the resolved nanopub's own **full** label (`NanopubUtils.getLabel`) when exploring the nanopub itself, falling back to the param only for things that can't be resolved here. The `label` param is otherwise left in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)