### PR TITLE
feat: route ORCID URIs to the user page, keeping query-supplied labels

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/component/NanodashLink.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/NanodashLink.java
@@ -178,8 +178,13 @@ public class NanodashLink extends Panel {
             return new BookmarkablePageLink<Void>(markupId, BdjNanopubPage.class, params.set("mode", "final")).setBody(Model.of(Utils.truncateLinkLabel(label)));
         } else if (isNp && uri.startsWith(RioConfig.get().getTargetNamespace())) {
             return new BookmarkablePageLink<Void>(markupId, RioNanopubPage.class, params.set("mode", "final")).setBody(Model.of(Utils.truncateLinkLabel(label)));
-        } else if (IndividualAgent.isUser(uri)) {
-            label = User.getShortDisplayName(vf.createIRI(uri));
+        } else if (IndividualAgent.isUser(uri) || IndividualAgent.isOrcidIri(uri)) {
+            IRI userIri = vf.createIRI(uri);
+            // Prefer our own known display name; otherwise keep a label supplied by the
+            // caller (e.g. a name resolved by a query) before falling back to the bare id.
+            if (User.getName(userIri) != null || label == null || label.isBlank()) {
+                label = User.getShortDisplayName(userIri);
+            }
             return new BookmarkablePageLink<Void>(markupId, UserPage.class, params).setBody(Model.of(Utils.truncateLinkLabel(label)));
         } else if (SpaceRepository.get().findById(uri) != null) {
             label = SpaceRepository.get().findById(uri).getLabel();
@@ -216,7 +221,7 @@ public class NanodashLink extends Panel {
      * falling back to the Explore page otherwise.
      */
     public static String getPageUrl(String uri) {
-        if (IndividualAgent.isUser(uri)) {
+        if (IndividualAgent.isUser(uri) || IndividualAgent.isOrcidIri(uri)) {
             return UserPage.MOUNT_PATH + "?id=" + URLEncoder.encode(uri, java.nio.charset.StandardCharsets.UTF_8);
         } else if (SpaceRepository.get().findById(uri) != null) {
             return SpacePage.MOUNT_PATH + "?id=" + URLEncoder.encode(uri, java.nio.charset.StandardCharsets.UTF_8);

--- a/src/main/java/com/knowledgepixels/nanodash/domain/IndividualAgent.java
+++ b/src/main/java/com/knowledgepixels/nanodash/domain/IndividualAgent.java
@@ -45,6 +45,20 @@ public class IndividualAgent extends AbstractResourceWithProfile {
     }
 
     /**
+     * Checks whether the given URI is a well-formed ORCID IRI (e.g.
+     * {@code https://orcid.org/0000-0002-1825-0097}). Such IRIs identify
+     * individual agents even when they are not (yet) known users, so links to
+     * them can be routed to the user page (shown as a not-yet-configured profile)
+     * rather than the generic explore page.
+     *
+     * @param uri The URI to check.
+     * @return True if the URI is a well-formed ORCID IRI, false otherwise.
+     */
+    public static boolean isOrcidIri(String uri) {
+        return uri != null && uri.matches("https://orcid\\.org/[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]");
+    }
+
+    /**
      * Checks if a given IRI represents a software agent.
      *
      * @param userIri The IRI to check.


### PR DESCRIPTION
## Summary

Clicking a well-formed ORCID IRI now opens the **user page** — shown as a not-yet-configured profile — even when the ORCID is not a known user, instead of falling through to the generic explore page. `UserPage` already renders such IRIs gracefully (strips the `orcid.org/` prefix for the name, default user icon, and the existing *"This user hasn't configured their profile yet, but below you can find their latest nanopublications."* notice + latest-nanopubs view), so no `UserPage` changes were needed.

## Label precedence fix

The user link branch previously replaced the caller-supplied label with `getShortDisplayName`, which for an unknown ORCID is just the bare id — discarding a name resolved by a query. The precedence is now:

1. **Known user** → our own canonical display name (authoritative).
2. **Unknown ORCID with a query-supplied label** → show that label.
3. **Unknown ORCID, no label** → bare ORCID id.

This also benefits the assertion/`TripleItem` path: an unknown ORCID carrying an `rdfs:label`/API label in the nanopub's pubinfo now surfaces that name.

## Changes

- `IndividualAgent.isOrcidIri(uri)` — new predicate, gated on the full ORCID pattern so non-profile `orcid.org` URLs (e.g. OAuth endpoints) are excluded.
- `NanodashLink.createLink` and `NanodashLink.getPageUrl` — widen the user-page routing gate to `isUser(uri) || isOrcidIri(uri)`; the former also keeps a caller/query label when we have no known name.

Note: this covers link routing. Direct navigation to `/explore?id=<orcid>` still shows the explore page (could add a redirect later if wanted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)