### PR TITLE
feat: emit role-direction pins in pubinfo from templates

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/component/PublishForm.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/PublishForm.java
@@ -2,6 +2,7 @@ package com.knowledgepixels.nanodash.component;
 
 import com.knowledgepixels.nanodash.*;
 import com.knowledgepixels.nanodash.domain.AbstractResourceWithProfile;
+import com.knowledgepixels.nanodash.vocabulary.KPXL_TERMS;
 import com.knowledgepixels.nanodash.domain.IndividualAgent;
 import com.knowledgepixels.nanodash.domain.User;
 import com.knowledgepixels.nanodash.page.*;
@@ -39,6 +40,7 @@ import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.FOAF;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.nanopub.MalformedNanopubException;
 import org.nanopub.Nanopub;
@@ -896,6 +898,7 @@ public class PublishForm extends Panel {
 
     private synchronized Nanopub createNanopub() throws MalformedNanopubException, NanopubAlreadyFinalizedException {
         assertionContext.getIntroducedIris().clear();
+        assertionContext.getRolePropertyPins().clear();
         NanopubCreator npCreator = new NanopubCreator(targetNamespace);
         npCreator.setAssertionUri(vf.createIRI(targetNamespace + "assertion"));
         assertionContext.propagateStatements(npCreator);
@@ -908,6 +911,15 @@ public class PublishForm extends Panel {
         }
         for (IRI embeddedIri : assertionContext.getEmbeddedIris()) {
             npCreator.addPubinfoStatement(NPX.EMBEDS, embeddedIri);
+        }
+        Map<IRI, IRI> rolePropertyPins = assertionContext.getRolePropertyPins();
+        if (!rolePropertyPins.isEmpty()) {
+            // A role predicate carrying a direction pin makes this a role-instantiation
+            // nanopub; nanopub-query's pin-resolution branch is gated on this type (#525).
+            npCreator.addPubinfoStatement(NPX.HAS_NANOPUB_TYPE, KPXL_TERMS.ROLE_INSTANTIATION);
+            for (Map.Entry<IRI, IRI> pin : rolePropertyPins.entrySet()) {
+                npCreator.addPubinfoStatement(pin.getKey(), RDF.TYPE, pin.getValue());
+            }
         }
         npCreator.addNamespace("this", targetNamespace);
         npCreator.addNamespace("sub", targetNamespace + "/");

--- a/src/main/java/com/knowledgepixels/nanodash/template/Template.java
+++ b/src/main/java/com/knowledgepixels/nanodash/template/Template.java
@@ -14,6 +14,7 @@ import org.eclipse.rdf4j.model.vocabulary.SHACL;
 import org.nanopub.Nanopub;
 import org.nanopub.NanopubUtils;
 import org.nanopub.vocabulary.NTEMPLATE;
+import com.knowledgepixels.nanodash.vocabulary.KPXL_TERMS;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -319,6 +320,26 @@ public class Template implements Serializable {
     public boolean isIntroducedResource(IRI iri) {
         iri = transform(iri);
         return typeMap.containsKey(iri) && typeMap.get(iri).contains(NTEMPLATE.INTRODUCED_RESOURCE);
+    }
+
+    /**
+     * Returns the role-instantiation direction pin declared on a (predicate) IRI, if
+     * any: {@link KPXL_TERMS#INVERSE_ROLE_PROPERTY} or
+     * {@link KPXL_TERMS#REGULAR_ROLE_PROPERTY}. Templates declare the pin as an
+     * {@code rdf:type} on the predicate (constant or placeholder); nanodash lifts it into
+     * pubinfo at publish time so nanopub-query can resolve a custom role predicate's
+     * direction (see #525).
+     *
+     * @param iri the IRI to check (a predicate constant or placeholder).
+     * @return the pin class, or null if the IRI carries no role-direction pin.
+     */
+    public IRI getRoleDirectionPin(IRI iri) {
+        iri = transform(iri);
+        if (!typeMap.containsKey(iri)) return null;
+        List<IRI> types = typeMap.get(iri);
+        if (types.contains(KPXL_TERMS.INVERSE_ROLE_PROPERTY)) return KPXL_TERMS.INVERSE_ROLE_PROPERTY;
+        if (types.contains(KPXL_TERMS.REGULAR_ROLE_PROPERTY)) return KPXL_TERMS.REGULAR_ROLE_PROPERTY;
+        return null;
     }
 
     /**

--- a/src/main/java/com/knowledgepixels/nanodash/template/TemplateContext.java
+++ b/src/main/java/com/knowledgepixels/nanodash/template/TemplateContext.java
@@ -39,6 +39,7 @@ public class TemplateContext implements Serializable {
     private final Map<IRI, IModel<?>> componentModels = new HashMap<>();
     private Set<IRI> introducedIris = new HashSet<>();
     private Set<IRI> embeddedIris = new HashSet<>();
+    private Map<IRI, IRI> rolePropertyPins = new LinkedHashMap<>();
     private List<StatementItem> statementItems;
     private Set<IRI> iriSet = new HashSet<>();
     private Map<IRI, StatementItem> narrowScopeMap = new HashMap<>();
@@ -264,6 +265,18 @@ public class TemplateContext implements Serializable {
     }
 
     /**
+     * Returns the role-instantiation direction pins collected in this context, mapping
+     * each filled/constant role predicate to its pin class
+     * ({@link com.knowledgepixels.nanodash.vocabulary.KPXL_TERMS#INVERSE_ROLE_PROPERTY}
+     * or {@code REGULAR_ROLE_PROPERTY}). Emitted into pubinfo at publish time; see #525.
+     *
+     * @return a map of predicate IRI to direction-pin class
+     */
+    public Map<IRI, IRI> getRolePropertyPins() {
+        return rolePropertyPins;
+    }
+
+    /**
      * Processes an IRI by applying the template's processing rules.
      *
      * @param iri the IRI to process
@@ -410,6 +423,10 @@ public class TemplateContext implements Serializable {
         }
         if (processedValue instanceof IRI pvIri && template.isEmbeddedResource(iri)) {
             embeddedIris.add(pvIri);
+        }
+        if (processedValue instanceof IRI pvIri) {
+            IRI directionPin = template.getRoleDirectionPin(iri);
+            if (directionPin != null) rolePropertyPins.put(pvIri, directionPin);
         }
         return processedValue;
     }

--- a/src/main/java/com/knowledgepixels/nanodash/template/ValueFiller.java
+++ b/src/main/java/com/knowledgepixels/nanodash/template/ValueFiller.java
@@ -4,9 +4,11 @@ import com.knowledgepixels.nanodash.LocalUri;
 import com.knowledgepixels.nanodash.Utils;
 import com.knowledgepixels.nanodash.component.GuidedChoiceItem;
 import com.knowledgepixels.nanodash.component.PublishForm.FillMode;
+import com.knowledgepixels.nanodash.vocabulary.KPXL_TERMS;
 import org.eclipse.rdf4j.model.*;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.DCTERMS;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.nanopub.Nanopub;
 import org.nanopub.NanopubUtils;
@@ -164,7 +166,13 @@ public class ValueFiller {
                 if (pred.equals(NTEMPLATE.WAS_CREATED_FROM_TEMPLATE)) return null;
                 if (pred.equals(NTEMPLATE.WAS_CREATED_FROM_PROVENANCE_TEMPLATE)) return null;
                 if (pred.equals(NTEMPLATE.WAS_CREATED_FROM_PUBINFO_TEMPLATE)) return null;
+                // Role-instantiation type auto-added by PublishForm alongside the direction pins (#525).
+                if (pred.equals(NPX.HAS_NANOPUB_TYPE) && st.getObject().equals(KPXL_TERMS.ROLE_INSTANTIATION)) return null;
             }
+            // Role-direction pins auto-added by PublishForm; the subject is the (arbitrary)
+            // role predicate, not the nanopub, so this is checked outside the block above (#525).
+            if (pred.equals(RDF.TYPE) && (st.getObject().equals(KPXL_TERMS.INVERSE_ROLE_PROPERTY)
+                    || st.getObject().equals(KPXL_TERMS.REGULAR_ROLE_PROPERTY))) return null;
             if (pred.equals(NPX.HAS_ALGORITHM)) return null;
             if (pred.equals(NPX.HAS_PUBLIC_KEY)) return null;
             if (pred.equals(NPX.HAS_SIGNATURE)) return null;

--- a/src/main/java/com/knowledgepixels/nanodash/vocabulary/KPXL_TERMS.java
+++ b/src/main/java/com/knowledgepixels/nanodash/vocabulary/KPXL_TERMS.java
@@ -106,6 +106,17 @@ public class KPXL_TERMS {
 
     public static final IRI HAS_DEFAULT_LICENSE = VocabUtils.createIRI(NAMESPACE, "hasDefaultLicense");
 
+    // Role-instantiation direction pinning (nanodash #525 / nanopub-query #136 Part B).
+    // A role-assigning nanopub can carry a pubinfo pin `<predicate> a
+    // gen:InverseRoleProperty` (or gen:RegularRoleProperty) so nanopub-query's
+    // SpacesExtractor can resolve a custom role predicate's direction from the nanopub
+    // alone. Templates declare the pin as a type on the (constant or placeholder)
+    // predicate; nanodash lifts it into pubinfo and also attaches ROLE_INSTANTIATION,
+    // which the extractor's pin-resolution branch is gated on.
+    public static final IRI ROLE_INSTANTIATION = VocabUtils.createIRI(NAMESPACE, "RoleInstantiation");
+    public static final IRI INVERSE_ROLE_PROPERTY = VocabUtils.createIRI(NAMESPACE, "InverseRoleProperty");
+    public static final IRI REGULAR_ROLE_PROPERTY = VocabUtils.createIRI(NAMESPACE, "RegularRoleProperty");
+
     // Role tiers (subclasses of gen:SpaceMemberRole; materialized server-side by
     // nanopub-query as the npa:hasRoleType value). Ordered admin > maintainer >
     // member > observer; observer is the default when a role declares no tier.


### PR DESCRIPTION
Closes #525.

## What

Lets an assertion template pin a role predicate's direction so nanopub-query can resolve it from the nanopub alone (nanopub-query#136 Part B, merged in nanopub-query#137).

A template marks a role predicate — a **constant IRI** (e.g. `gen:hasHelper`) or a **predicate placeholder** — with `gen:InverseRoleProperty` / `gen:RegularRoleProperty`. On publish, nanodash lifts that into pubinfo:

```turtle
# pubinfo
this: npx:hasNanopubType gen:RoleInstantiation .
gen:hasHelper a gen:InverseRoleProperty .
```

The `RoleInstantiation` type is required because nanopub-query's `SpacesExtractor` pin-resolution branch is gated on it — a pin without the type is silently inert.

## Changes

- **`KPXL_TERMS`** — add `ROLE_INSTANTIATION`, `INVERSE_ROLE_PROPERTY`, `REGULAR_ROLE_PROPERTY` (namespace already the `gen:` namespace, matching nanopub-query's `GEN`).
- **`Template.getRoleDirectionPin(iri)`** — read the pin type declared on a predicate IRI (mirrors `isIntroducedResource`).
- **`TemplateContext`** — collect resolved-predicate → pin-class during fill (beside `introducedIris`/`embeddedIris`).
- **`PublishForm.createNanopub()`** — when pins are present, emit `npx:hasNanopubType gen:RoleInstantiation` once + `<pred> a gen:…RoleProperty` per pin. Idempotent; only when a pin is present, so non-role templates are unaffected.
- **`ValueFiller`** — ignore these auto-added pubinfo statements when superseding/deriving, like `npx:introduces`/`embeds`. The pin triples' subject is the predicate (not the nanopub), so they're filtered outside the nanopub-subject block.

## Reuse decision

Reuses the `gen:` classes directly as the template markers rather than minting parallel `nt:` terms — the template marker and the emitted pin are the same statement about the same predicate, so an `nt:→gen:` indirection would only drift.

## Notes

- The pin only tells the extractor how to read the assertion triple; the author must still arrange subject/object to match (inverse ⇒ `<space> <pred> <agent>`, regular ⇒ `<agent> <pred> <space>`).
- Server precedence: `BackcompatRolePredicates` wins over pins, so a pin on an already-known predicate is inert/redundant — pins matter for custom predicates + the `hasHelper` pilot.

## Authoring support (published separately)

A test "template template" exposing these as a role-predicate-direction statement group is live at `https://w3id.org/np/RAlA89umMNpYpI_MRD8ODmkpTkUiHds5-EXbWChS1RC4g`.

## Testing

`mvn compile` passes. Not yet exercised end-to-end via the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)