### PR TITLE
fix: unify artifact-code placeholder on derive (#529)

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/component/IriItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/IriItem.java
@@ -173,11 +173,33 @@ public class IriItem extends AbstractContextComponent {
         if (!(v instanceof IRI)) return false;
         // TODO: Check that template URIs don't have regex characters:
         String iriS = iri.stringValue().replaceFirst("^" + context.getTemplateId() + "[#/]?", LocalUri.PREFIX);
+        String vs = v.stringValue();
         if (context.isReadOnly()) {
-            return iriS.equals(v.stringValue().replaceFirst("^" + context.getExistingNanopub().getUri() + "[#/]?", LocalUri.PREFIX));
-        } else {
-            return iriS.equals(v.stringValue());
+            vs = vs.replaceFirst("^" + context.getExistingNanopub().getUri() + "[#/]?", LocalUri.PREFIX);
         }
+        if (iriS.contains(ARTIFACT_CODE_MARKER)) {
+            // A fresh artifact code is minted for this resource at publish time, so the
+            // "~~~ARTIFACTCODE~~~" marker acts as a wildcard: a source resource that already
+            // carries a concrete artifact code (supersede/derive/override) must still unify.
+            return vs.matches(artifactCodeUnifyRegex(iriS));
+        }
+        return iriS.equals(vs);
+    }
+
+    // Marker left in the IRI once StatementItem.transform has expanded a template's
+    // "~~ARTIFACTCODE~~" placeholder (see StatementItem#transform).
+    private static final String ARTIFACT_CODE_MARKER = "~~~ARTIFACTCODE~~~";
+
+    // Turns an IRI holding the artifact-code marker into a regex that matches the same IRI
+    // with any (trusty) artifact code in that position; all other characters stay literal.
+    private static String artifactCodeUnifyRegex(String iriWithMarker) {
+        String[] parts = iriWithMarker.split(java.util.regex.Pattern.quote(ARTIFACT_CODE_MARKER), -1);
+        StringBuilder regex = new StringBuilder();
+        for (int i = 0; i < parts.length; i++) {
+            if (i > 0) regex.append("[A-Za-z0-9_-]+");
+            regex.append(java.util.regex.Pattern.quote(parts[i]));
+        }
+        return regex.toString();
     }
 
     /**

--- a/src/test/java/com/knowledgepixels/nanodash/template/DeriveIntroducedResourceFillTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/template/DeriveIntroducedResourceFillTest.java
@@ -1,0 +1,59 @@
+package com.knowledgepixels.nanodash.template;
+
+import com.knowledgepixels.nanodash.Utils;
+import com.knowledgepixels.nanodash.WicketApplication;
+import com.knowledgepixels.nanodash.component.PublishForm.FillMode;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.util.tester.WicketTester;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.nanopub.Nanopub;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Reproduction for issue #529: when deriving from a nanopub whose introduced
+ * resource IRI embeds a concrete artifact code (e.g.
+ * {@code .../biochementities/RAZdhuW9...}), the template's introduced-resource
+ * IRI still carries the {@code ~~~ARTIFACTCODE~~~} marker. The introduced
+ * resource is the subject of every assertion statement, so if the marker fails
+ * to unify with the source's concrete code, none of the statements match and
+ * every placeholder (name, group label, external ids, …) is left empty.
+ */
+class DeriveIntroducedResourceFillTest {
+
+    // "Defining a biochementity" template — introduced resource IRI is
+    // https://w3id.org/peh/biochementities/~~ARTIFACTCODE~~ .
+    private static final String TEMPLATE = "https://w3id.org/np/RAD4mKOVqsJc7nAVVR0dXXcVFU2IOjrFywv2GspkpalfQ";
+    // A published biochementity, used as the derive source.
+    private static final String DERIVE_FROM = "https://w3id.org/np/RAZdhuW9ExtLpk8aVBcYyaaGO0mXbYGGER7kZDfqlH_qc";
+    // A distinctive literal only reachable if the introduced-resource statements unify.
+    private static final String GROUP_LABEL = "flame retardants";
+
+    @BeforeEach
+    void setUp() {
+        new WicketTester(new WicketApplication());
+    }
+
+    @Test
+    void deriveFillsIntroducedResourceStatements() throws Exception {
+        String targetNamespace = "https://example.org/np/~~~ARTIFACTCODE~~~/";
+        TemplateContext context = new TemplateContext(ContextType.ASSERTION, TEMPLATE, "statement", targetNamespace);
+        context.setFillMode(FillMode.DERIVE);
+        context.initStatements();
+
+        Nanopub deriveFrom = Utils.getNanopub(DERIVE_FROM);
+        assertNotNull(deriveFrom, "derive-source nanopub should be fetchable");
+        ValueFiller filler = new ValueFiller(deriveFrom, ContextType.ASSERTION, true, FillMode.DERIVE);
+        filler.fill(context);
+
+        context.finalizeStatements();
+
+        boolean groupLabelPresent = context.getComponentModels().values().stream()
+                .map(IModel::getObject)
+                .filter(o -> o != null)
+                .anyMatch(o -> GROUP_LABEL.equals(o.toString()));
+        assertTrue(groupLabelPresent,
+                "deriving should fill the introduced resource's statements into the form");
+    }
+}


### PR DESCRIPTION
## Problem

Fixes #529. Deriving from a nanopub whose introduced-resource IRI embeds a concrete artifact code (e.g. `.../biochementities/RAZdhuW9…`) produced an empty form — none of the source's statements were filled in.

## Root cause

The template's introduced-resource IRI carries the `~~ARTIFACTCODE~~` marker (replaced with a fresh trusty code at publish time). This IRI is a **constant**, so in `DERIVE` mode `ValueItem` renders it as an `IriItem` (the `ReadonlyItem` branch only fires for supersede/override). `IriItem.isUnifiableWith` compared the marker form (`…/~~~ARTIFACTCODE~~~`) against the source's concrete `…/RAZdhuW9…` by exact string equality, which never matched.

Because the introduced resource is the **subject of every assertion statement**, and a statement only fills when subject *and* predicate *and* object unify, all source statements were dropped as "unused" and every field (name, group label, external IDs, `isMetaboliteOf`, …) came up empty.

Supersede/override are unaffected — they render a `ReadonlyItem` whose empty model unifies with anything.

## Fix

In `IriItem.isUnifiableWith`, when the template IRI carries the `~~~ARTIFACTCODE~~~` marker, treat that segment as a wildcard (`[A-Za-z0-9_-]+`) and match by regex. `unifyWith` needs no change: the constant emits nothing, and on publish the marker is re-minted to the new nanopub's code — the correct derive semantics (new entity, new identifier, source statements carried over).

## Test

`DeriveIntroducedResourceFillTest` derives from the real biochementity nanopub and asserts a distinctive source literal reaches the form. Fails on `master`, passes with the fix. The existing derive/fill suite still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)