### PR TITLE
feat: resolve space-governed view versions via gen:governedBy

### DIFF
--- a/docs/queries/get-latest-governed-version.trig
+++ b/docs/queries/get-latest-governed-version.trig
@@ -1,0 +1,54 @@
+@prefix this: <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
+@prefix sub: <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
+@prefix np: <http://www.nanopub.org/nschema#> .
+@prefix grlc: <https://w3id.org/kpxl/grlc/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix npx: <http://purl.org/nanopub/x/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix orcid: <https://orcid.org/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+sub:Head { this: a np:Nanopublication; np:hasAssertion sub:assertion; np:hasProvenance sub:provenance; np:hasPublicationInfo sub:pubinfo . }
+sub:assertion {
+  sub:get-latest-governed-version a grlc:grlc-query;
+    dct:description "Resolves the canonical (latest authorized) version of a space-governed view definition, per docs/views-and-presets-as-maintained-resources.md in the nanodash repo. Takes the definition's kind IRI (its dct:isVersionOf target; kind) and the governing space IRI (space) and returns at most one row: the newest version nanopub that (a) declares dct:isVersionOf <kind> plus gen:governedBy <space>, and (b) is signed by a pubkey of a CURRENT member+ (admin/maintainer/member, not observer) of that space's governing ref -- with the kind validated as a maintained resource of the space (npa:isMaintainedBy + npa:hasGoverningSpaceRef in the materialized state graph; the two anchors that make gen:governedBy a label, not a grant). The RoleInstantiation's npa:forSpace/npa:forSpaceRef pair ties the governing ref to the given space IRI, so a multi-maintainer kind never floats across pairs. An empty result means no valid floating candidate: the caller keeps its pinned version (the pin is the floor and is not re-validated here). Versions retracted by their own signing key are skipped. Hosted on the spaces repo; the version/pubkey lookup federates to the gen:ResourceView type repo with kind and space as text-substituted constants, so the federated scan stays narrow.";
+    dct:license <http://www.apache.org/licenses/LICENSE-2.0>;
+    rdfs:label "Get latest governed version";
+    grlc:endpoint <https://w3id.org/np/l/nanopub-query-1.1/repo/spaces>;
+    grlc:sparql """prefix np: <http://www.nanopub.org/nschema#>
+prefix npa: <http://purl.org/nanopub/admin/>
+prefix npx: <http://purl.org/nanopub/x/>
+prefix dct: <http://purl.org/dc/terms/>
+prefix gen: <https://w3id.org/kpxl/gen/terms/>
+
+select distinct ?version ?date ?np ("^" as ?np_label) where {
+  graph npa:graph { npa:thisRepo npa:hasCurrentSpaceState ?stateG . }
+  graph ?stateG {
+    ?_kind_iri npa:isMaintainedBy ?_space_iri ; npa:hasGoverningSpaceRef ?ref .
+    ?ri a gen:RoleInstantiation ; npa:forSpace ?_space_iri ; npa:forSpaceRef ?ref ;
+        npa:hasRoleType ?tier ; npa:forAgent ?agent .
+    filter(?tier = gen:AdminRole || ?tier = gen:MaintainerRole || ?tier = gen:MemberRole)
+    ?acct a npa:AccountState ; npa:agent ?agent ; npa:pubkey ?pubkey .
+  }
+  service <https://w3id.org/np/l/nanopub-query-1.1/repo/type/ec6722efa3b44e0a18aa63afe5964158a1fdb7f0413ea5f23bfddf5c03ca0221> {
+    graph npa:graph {
+      ?np npa:hasValidSignatureForPublicKeyHash ?pubkey ;
+          dct:created ?date ;
+          npx:embeds ?version ;
+          np:hasAssertion ?a .
+      filter not exists { ?npx npx:invalidates ?np ; npa:hasValidSignatureForPublicKeyHash ?pubkey . }
+    }
+    graph ?a {
+      ?version dct:isVersionOf ?_kind_iri ;
+               gen:governedBy ?_space_iri .
+    }
+  }
+}
+order by desc(?date) desc(?np) limit 1""" .
+}
+sub:provenance { sub:assertion prov:wasAttributedTo orcid:0000-0002-1267-0234 . }
+sub:pubinfo {
+  orcid:0000-0002-1267-0234 foaf:name "Tobias Kuhn" .
+  this: dct:created "2026-07-03T09:59:49Z"^^xsd:dateTime; dct:creator orcid:0000-0002-1267-0234; dct:license <https://creativecommons.org/licenses/by/4.0/>; npx:embeds sub:get-latest-governed-version .
+}

--- a/docs/queries/get-view-displays-ref.trig
+++ b/docs/queries/get-view-displays-ref.trig
@@ -9,10 +9,17 @@
 @prefix orcid: <https://orcid.org/> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
-sub:Head { this: a np:Nanopublication; np:hasAssertion sub:assertion; np:hasProvenance sub:provenance; np:hasPublicationInfo sub:pubinfo . }
+
+sub:Head {
+  this: a np:Nanopublication;
+    np:hasAssertion sub:assertion;
+    np:hasProvenance sub:provenance;
+    np:hasPublicationInfo sub:pubinfo .
+}
+
 sub:assertion {
   sub:get-view-displays a grlc:grlc-query;
-    dct:description "Ref-scoped variant of get-view-displays (the Content-tab renderer query) for a single space ref. Takes TWO inputs: the space IRI (resource) and the ref's root nanopub (root_np); the authority gate is scoped to admins/maintainers of THAT ref (npa:forSpaceRef resolved from root_np) instead of the space IRI merged across all its refs. Both inputs are concrete (VALUES) so federation bindings propagate. Space-only companion to get-view-displays; same columns. Regenerate from the latest get-view-displays by adding the root_np VALUES, the ?passedRef npa:rootNanopub resolution, and npa:forSpaceRef ?passedRef on the gate's RoleInstantiation.";
+    dct:description "Ref-scoped variant of get-view-displays (the Content-tab renderer query) for a single space ref. Takes TWO inputs: the space IRI (resource) and the ref's root nanopub (root_np); the authority gate is scoped to admins/maintainers of THAT ref (npa:forSpaceRef resolved from root_np) instead of the space IRI merged across all its refs. Both inputs are concrete (VALUES) so federation bindings propagate. Space-only companion to get-view-displays; same columns. Regenerate from the latest get-view-displays by adding the root_np VALUES, the ?passedRef npa:rootNanopub resolution, and npa:forSpaceRef ?passedRef on the gate's RoleInstantiation. Space-governed versions (gen:governedBy, nanodash docs/views-and-presets-as-maintained-resources.md): a referenced version declaring gen:governedBy resolves to the newest version of its (kind, space) pair signed by a current member+ (admin/maintainer/member) of that space -- with the kind validated as a maintained resource of the space -- taking precedence over the supersedes-based head; without a valid governed candidate the pinned version stands.";
     dct:license <http://www.apache.org/licenses/LICENSE-2.0>;
     rdfs:label "Get view displays (ref-scoped)";
     grlc:endpoint <https://w3id.org/np/l/nanopub-query-1.1/repo/type/11daee46fdfff957dc17b46f5dc1a618045afd4f5634d5334ce9db19c3689a3c>;
@@ -103,9 +110,10 @@ select distinct ?display ?view (coalesce(?viewKindOptional, ?view) as ?viewKind)
   # round-trips were the dominant cost of earlier versions.
   optional {
     service <https://w3id.org/np/l/nanopub-query-1.1/repo/type/ec6722efa3b44e0a18aa63afe5964158a1fdb7f0413ea5f23bfddf5c03ca0221> {
-      select distinct ?refView ?latestView ?viewKindOptional where {
+      select distinct ?refView ?latestView ?viewKindOptional ?pinKind ?pinSpace where {
         graph npa:graph { ?rnp npx:embeds ?refView ; np:hasAssertion ?ra . }
         graph ?ra { ?refView a gen:ResourceView . }
+        optional { graph ?ra { ?refView dct:isVersionOf ?pinKind ; gen:governedBy ?pinSpace . } }
         optional {
           ?vnp npx:embeds ?refView .
           ?latestNp (npx:supersedes|^npx:supersedes)* ?vnp ; dct:created ?ldate ; npx:embeds ?latestView ; np:hasAssertion ?va ; npa:hasValidSignatureForPublicKeyHash ?invPk .
@@ -122,12 +130,46 @@ select distinct ?display ?view (coalesce(?viewKindOptional, ?view) as ?viewKind)
       }
     }
   }
-  bind(coalesce(?latestView, ?refView) as ?view)
+    # Space-governed resolution (gen:governedBy; nanodash docs/views-and-presets-as-
+  # maintained-resources.md): a pinned version declaring a governing space resolves to
+  # the newest member+-signed version of its (kind, space) pair instead of the
+  # supersedes head; no valid candidate -> the pin stands.
+  optional {
+        { select ?pinKind ?pinSpace (iri(strafter(max(concat(str(?cDate), \">\", str(?cver))), \">\")) as ?governedLatest) where {
+            service <https://w3id.org/np/l/nanopub-query-1.1/repo/type/ec6722efa3b44e0a18aa63afe5964158a1fdb7f0413ea5f23bfddf5c03ca0221> {
+              graph npa:graph {
+                ?cnp dct:created ?cDate ; npa:hasValidSignatureForPublicKeyHash ?cpk ; npx:embeds ?cver ; np:hasAssertion ?ca .
+                filter not exists { ?ci npx:invalidates ?cnp ; npa:hasValidSignatureForPublicKeyHash ?cpk . }
+              }
+              graph ?ca { ?cver dct:isVersionOf ?pinKind ; gen:governedBy ?pinSpace . }
+            }
+            service <https://w3id.org/np/l/nanopub-query-1.1/repo/spaces> {
+              graph npa:graph { <http://purl.org/nanopub/admin/thisRepo> npa:hasCurrentSpaceState ?gsg . }
+              graph ?gsg {
+                ?pinKind npa:isMaintainedBy ?pinSpace ; npa:hasGoverningSpaceRef ?gref .
+                ?gri a gen:RoleInstantiation ; npa:forSpace ?pinSpace ; npa:forSpaceRef ?gref ; npa:hasRoleType ?gtier ; npa:forAgent ?gag .
+                filter(?gtier = gen:AdminRole || ?gtier = gen:MaintainerRole || ?gtier = gen:MemberRole)
+                ?gacct a npa:AccountState ; npa:agent ?gag ; npa:pubkey ?cpk .
+              }
+            }
+          } group by ?pinKind ?pinSpace }
+  }
+  bind(if(bound(?pinSpace), coalesce(?governedLatest, ?refView), coalesce(?latestView, ?refView)) as ?view)
 }
 order by desc(?date)""" .
 }
-sub:provenance { sub:assertion prov:wasAttributedTo orcid:0000-0002-1267-0234 . }
+
+sub:provenance {
+  sub:assertion prov:wasAttributedTo orcid:0000-0002-1267-0234 .
+}
+
 sub:pubinfo {
   orcid:0000-0002-1267-0234 foaf:name "Tobias Kuhn" .
-  this: dct:created "2026-06-25T16:05:53Z"^^xsd:dateTime; dct:creator orcid:0000-0002-1267-0234; dct:license <https://creativecommons.org/licenses/by/4.0/>; npx:embeds sub:get-view-displays; npx:supersedes <https://w3id.org/np/RAIpgHc6ckHcb2yBWM3QJ68xjghrgBdEOQRGFKCGseAcA> .
+  
+  this: dct:created "2026-07-03T13:00:55Z"^^xsd:dateTime;
+    dct:creator orcid:0000-0002-1267-0234;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    npx:embeds sub:get-view-displays;
+    npx:supersedes <https://w3id.org/np/RAtZbUry42si1BZpBoRBkgbzGweNzfPmOludNIoJYT2VM> .
 }
+

--- a/docs/queries/get-view-displays.trig
+++ b/docs/queries/get-view-displays.trig
@@ -19,7 +19,7 @@ sub:Head {
 
 sub:assertion {
   sub:get-view-displays a <https://w3id.org/kpxl/grlc/grlc-query>;
-    dct:description "Returns the views to display for a given resource: both standalone view displays and the views contributed by assigned presets (issue #302), unioned and ordered by date so latest-wins override resolution holds across both. Filtered server-side to declarations signed by an admin or maintainer of the owning space, or by the affected user themselves (for an agent's own page). Each referenced view is resolved to its latest version by following the npx:supersedes chain: among the version tree's current heads (nanopubs that are themselves neither superseded nor validly retracted via npx:invalidates), the most recent is chosen, so ?view is the latest non-retracted view definition (no separate latest-version lookup needed by the client). Choosing a current head rather than the max-timestamp node makes resolution robust to backdated supersedes and to retracted versions. Preset-derived rows have an unbound ?display and carry the resolved ?view plus the assignment's activation mode. The view-version resolution is wrapped in a run-once sub-SELECT so the cross-repo lookup is evaluated once for the whole view set rather than once per referenced view.";
+    dct:description "Returns the views to display for a given resource: both standalone view displays and the views contributed by assigned presets (issue #302), unioned and ordered by date so latest-wins override resolution holds across both. Filtered server-side to declarations signed by an admin or maintainer of the owning space, or by the affected user themselves (for an agent's own page). Each referenced view is resolved to its latest version by following the npx:supersedes chain: among the version tree's current heads (nanopubs that are themselves neither superseded nor validly retracted via npx:invalidates), the most recent is chosen, so ?view is the latest non-retracted view definition (no separate latest-version lookup needed by the client). Choosing a current head rather than the max-timestamp node makes resolution robust to backdated supersedes and to retracted versions. Preset-derived rows have an unbound ?display and carry the resolved ?view plus the assignment's activation mode. The view-version resolution is wrapped in a run-once sub-SELECT so the cross-repo lookup is evaluated once for the whole view set rather than once per referenced view. Space-governed versions (gen:governedBy, nanodash docs/views-and-presets-as-maintained-resources.md): a referenced version declaring gen:governedBy resolves to the newest version of its (kind, space) pair signed by a current member+ (admin/maintainer/member) of that space -- with the kind validated as a maintained resource of the space -- taking precedence over the supersedes-based head; without a valid governed candidate the pinned version stands.";
     dct:license <http://www.apache.org/licenses/LICENSE-2.0>;
     rdfs:label "Get view displays";
     <https://w3id.org/kpxl/grlc/endpoint> <https://w3id.org/np/l/nanopub-query-1.1/repo/type/11daee46fdfff957dc17b46f5dc1a618045afd4f5634d5334ce9db19c3689a3c>;
@@ -107,9 +107,10 @@ select distinct ?display ?view (coalesce(?viewKindOptional, ?view) as ?viewKind)
   # round-trips were the dominant cost of earlier versions.
   optional {
     service <https://w3id.org/np/l/nanopub-query-1.1/repo/type/ec6722efa3b44e0a18aa63afe5964158a1fdb7f0413ea5f23bfddf5c03ca0221> {
-      select distinct ?refView ?latestView ?viewKindOptional where {
+      select distinct ?refView ?latestView ?viewKindOptional ?pinKind ?pinSpace where {
         graph npa:graph { ?rnp npx:embeds ?refView ; np:hasAssertion ?ra . }
         graph ?ra { ?refView a gen:ResourceView . }
+        optional { graph ?ra { ?refView dct:isVersionOf ?pinKind ; gen:governedBy ?pinSpace . } }
         optional {
           ?vnp npx:embeds ?refView .
           ?latestNp (npx:supersedes|^npx:supersedes)* ?vnp ; dct:created ?ldate ; npx:embeds ?latestView ; np:hasAssertion ?va ; npa:hasValidSignatureForPublicKeyHash ?invPk .
@@ -126,7 +127,31 @@ select distinct ?display ?view (coalesce(?viewKindOptional, ?view) as ?viewKind)
       }
     }
   }
-  bind(coalesce(?latestView, ?refView) as ?view)
+    # Space-governed resolution (gen:governedBy; nanodash docs/views-and-presets-as-
+  # maintained-resources.md): a pinned version declaring a governing space resolves to
+  # the newest member+-signed version of its (kind, space) pair instead of the
+  # supersedes head; no valid candidate -> the pin stands.
+  optional {
+        { select ?pinKind ?pinSpace (iri(strafter(max(concat(str(?cDate), \">\", str(?cver))), \">\")) as ?governedLatest) where {
+            service <https://w3id.org/np/l/nanopub-query-1.1/repo/type/ec6722efa3b44e0a18aa63afe5964158a1fdb7f0413ea5f23bfddf5c03ca0221> {
+              graph npa:graph {
+                ?cnp dct:created ?cDate ; npa:hasValidSignatureForPublicKeyHash ?cpk ; npx:embeds ?cver ; np:hasAssertion ?ca .
+                filter not exists { ?ci npx:invalidates ?cnp ; npa:hasValidSignatureForPublicKeyHash ?cpk . }
+              }
+              graph ?ca { ?cver dct:isVersionOf ?pinKind ; gen:governedBy ?pinSpace . }
+            }
+            service <https://w3id.org/np/l/nanopub-query-1.1/repo/spaces> {
+              graph npa:graph { <http://purl.org/nanopub/admin/thisRepo> npa:hasCurrentSpaceState ?gsg . }
+              graph ?gsg {
+                ?pinKind npa:isMaintainedBy ?pinSpace ; npa:hasGoverningSpaceRef ?gref .
+                ?gri a gen:RoleInstantiation ; npa:forSpace ?pinSpace ; npa:forSpaceRef ?gref ; npa:hasRoleType ?gtier ; npa:forAgent ?gag .
+                filter(?gtier = gen:AdminRole || ?gtier = gen:MaintainerRole || ?gtier = gen:MemberRole)
+                ?gacct a npa:AccountState ; npa:agent ?gag ; npa:pubkey ?cpk .
+              }
+            }
+          } group by ?pinKind ?pinSpace }
+  }
+  bind(if(bound(?pinSpace), coalesce(?governedLatest, ?refView), coalesce(?latestView, ?refView)) as ?view)
 }
 order by desc(?date)""" .
 }
@@ -138,11 +163,11 @@ sub:provenance {
 sub:pubinfo {
   orcid:0000-0002-1267-0234 foaf:name "Tobias Kuhn" .
   
-  this: dct:created "2026-06-25T16:05:53Z"^^xsd:dateTime;
+  this: dct:created "2026-07-03T13:00:55Z"^^xsd:dateTime;
     dct:creator orcid:0000-0002-1267-0234;
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
     npx:embeds sub:get-view-displays;
-    npx:supersedes <https://w3id.org/np/RAd105Rjy3ZCTGxOqBuXlztyeRG50r7j_CF4dMzERyI00>;
+    npx:supersedes <https://w3id.org/np/RA4TGV_zGtvVPjvffGF6OTbNV-ZmjwIdcZ3-JNYdEhpoE>;
     rdfs:label "Get view displays";
     nt:wasCreatedFromProvenanceTemplate <https://w3id.org/np/RA7lSq6MuK_TIC6JMSHvLtee3lpLoZDOqLJCLXevnrPoU>;
     nt:wasCreatedFromPubinfoTemplate <https://w3id.org/np/RA0J4vUn_dekg-U1kK3AOEt02p9mT2WO03uGxLDec1jLw>,

--- a/docs/queries/list-view-displays-ref.trig
+++ b/docs/queries/list-view-displays-ref.trig
@@ -9,10 +9,17 @@
 @prefix orcid: <https://orcid.org/> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
-sub:Head { this: a np:Nanopublication; np:hasAssertion sub:assertion; np:hasProvenance sub:provenance; np:hasPublicationInfo sub:pubinfo . }
+
+sub:Head {
+  this: a np:Nanopublication;
+    np:hasAssertion sub:assertion;
+    np:hasProvenance sub:provenance;
+    np:hasPublicationInfo sub:pubinfo .
+}
+
 sub:assertion {
   sub:list-view-displays a grlc:grlc-query;
-    dct:description "Ref-scoped view displays for a single space ref. Like list-view-displays but takes TWO inputs: the space IRI (resource) and the ref's root nanopub (root_np). The authority gate is scoped to admins/maintainers of THAT ref (npa:forSpaceRef resolved from root_np) rather than the space IRI merged across all its refs. Both inputs are concrete (VALUES) so federation bindings propagate (a single auto-detecting param can't: a service-derived resource IRI does not push into the federated SERVICE blocks). Space-only companion to list-view-displays; same columns. Regenerate from the latest list-view-displays by adding the root_np VALUES, the ?passedRef npa:rootNanopub resolution, and npa:forSpaceRef ?passedRef on the gate's RoleInstantiation.";
+    dct:description "Ref-scoped view displays for a single space ref. Like list-view-displays but takes TWO inputs: the space IRI (resource) and the ref's root nanopub (root_np). The authority gate is scoped to admins/maintainers of THAT ref (npa:forSpaceRef resolved from root_np) rather than the space IRI merged across all its refs. Both inputs are concrete (VALUES) so federation bindings propagate (a single auto-detecting param can't: a service-derived resource IRI does not push into the federated SERVICE blocks). Space-only companion to list-view-displays; same columns. Regenerate from the latest list-view-displays by adding the root_np VALUES, the ?passedRef npa:rootNanopub resolution, and npa:forSpaceRef ?passedRef on the gate's RoleInstantiation. Space-governed versions (gen:governedBy, nanodash docs/views-and-presets-as-maintained-resources.md): a referenced version declaring gen:governedBy resolves to the newest version of its (kind, space) pair signed by a current member+ (admin/maintainer/member) of that space -- with the kind validated as a maintained resource of the space -- taking precedence over the supersedes-based head; without a valid governed candidate the pinned version stands.";
     dct:license <http://www.apache.org/licenses/LICENSE-2.0>;
     rdfs:label "List view displays (ref-scoped)";
     grlc:endpoint <https://w3id.org/np/l/nanopub-query-1.1/repo/type/11daee46fdfff957dc17b46f5dc1a618045afd4f5634d5334ce9db19c3689a3c>;
@@ -60,7 +67,7 @@ where {
   where {
   {
     select ?_resource_multi_iri ?viewRef ?viewLatest ?view_label ?position ?preset ?preset_label ?presetScope ?user ?date ?np
-           ?ownClass ?dApply ?dTarget ?vTarget where {
+           ?ownClass ?dApply ?dTarget ?effVTarget ?pinSpace ?governedLatest where {
       values ?_resource_multi_iri {}
       values ?_root_np_multi_iri {}
       service <https://w3id.org/np/l/nanopub-query-1.1/repo/spaces> {
@@ -194,24 +201,63 @@ where {
                     npx:embeds ?viewLatest ; np:hasAssertion ?hva .
             filter not exists { ?i2 npx:invalidates ?headNp ; npa:hasValidSignatureForPublicKey ?vKey . }
           }
-          graph ?hva { ?viewLatest dct:title ?view_label . }
+          graph ?hva { ?viewLatest dct:title ?supLabel . }
           optional { graph ?hva { ?viewLatest gen:hasStructuralPosition ?viewPos . } }
           optional { graph ?hva { ?viewLatest (gen:appliesToInstancesOf|gen:appliesToNamespace) ?vTarget . } }
         }
       }
-      bind(coalesce(?dispPos, ?viewPos, \"\") as ?position)
+            # Space-governed resolution (gen:governedBy; nanodash docs/views-and-presets-as-
+      # maintained-resources.md): if the pinned version declares a governing space, the
+      # newest version of its (kind, space) pair signed by a current member+ of that
+      # space wins, with the kind validated as maintained by the space. Run-once
+      # sub-select over all governed versions network-wide (gen:governedBy is highly
+      # selective), joined back per pin. No valid candidate -> the pin stands.
+      optional {
+        service <https://w3id.org/np/l/nanopub-query-1.1/repo/type/ec6722efa3b44e0a18aa63afe5964158a1fdb7f0413ea5f23bfddf5c03ca0221> {
+          graph npa:graph { ?pinNp npx:embeds ?viewRef ; np:hasAssertion ?pinA . }
+          graph ?pinA { ?viewRef dct:isVersionOf ?pinKind ; gen:governedBy ?pinSpace . }
+        }
+        { select ?pinKind ?pinSpace (iri(strafter(max(concat(str(?cDate), \">\", str(?cver))), \">\")) as ?governedLatest) where {
+            service <https://w3id.org/np/l/nanopub-query-1.1/repo/type/ec6722efa3b44e0a18aa63afe5964158a1fdb7f0413ea5f23bfddf5c03ca0221> {
+              graph npa:graph {
+                ?cnp dct:created ?cDate ; npa:hasValidSignatureForPublicKeyHash ?cpk ; npx:embeds ?cver ; np:hasAssertion ?ca .
+                filter not exists { ?ci npx:invalidates ?cnp ; npa:hasValidSignatureForPublicKeyHash ?cpk . }
+              }
+              graph ?ca { ?cver dct:isVersionOf ?pinKind ; gen:governedBy ?pinSpace . }
+            }
+            service <https://w3id.org/np/l/nanopub-query-1.1/repo/spaces> {
+              graph npa:graph { <http://purl.org/nanopub/admin/thisRepo> npa:hasCurrentSpaceState ?gsg . }
+              graph ?gsg {
+                ?pinKind npa:isMaintainedBy ?pinSpace ; npa:hasGoverningSpaceRef ?gref .
+                ?gri a gen:RoleInstantiation ; npa:forSpace ?pinSpace ; npa:forSpaceRef ?gref ; npa:hasRoleType ?gtier ; npa:forAgent ?gag .
+                filter(?gtier = gen:AdminRole || ?gtier = gen:MaintainerRole || ?gtier = gen:MemberRole)
+                ?gacct a npa:AccountState ; npa:agent ?gag ; npa:pubkey ?cpk .
+              }
+            }
+          } group by ?pinKind ?pinSpace }
+        service <https://w3id.org/np/l/nanopub-query-1.1/repo/type/ec6722efa3b44e0a18aa63afe5964158a1fdb7f0413ea5f23bfddf5c03ca0221> {
+          graph npa:graph { ?gnp npx:embeds ?governedLatest ; np:hasAssertion ?gva . }
+          graph ?gva { ?governedLatest dct:title ?gTitle . }
+          optional { graph ?gva { ?governedLatest gen:hasStructuralPosition ?gPos . } }
+          optional { graph ?gva { ?governedLatest (gen:appliesToInstancesOf|gen:appliesToNamespace) ?gTarget . } }
+        }
+      }
+      bind(if(bound(?governedLatest), ?gTitle, ?supLabel) as ?view_label)
+      bind(if(bound(?governedLatest), ?gPos, ?viewPos) as ?effViewPos)
+      bind(if(bound(?governedLatest), ?gTarget, ?vTarget) as ?effVTarget)
+      bind(coalesce(?dispPos, ?effViewPos, \"\") as ?position)
     }
   }
   bind(if(coalesce(str(?dApply) = str(?_resource_multi_iri), false), 1, 0) as ?fDApplyHere)
   bind(if(bound(?dApply), 1, 0) as ?fDHasApply)
   bind(if(bound(?dTarget), 1, 0) as ?fDHasTarget)
   bind(if(coalesce(str(?dTarget) = str(?ownClass), false) || coalesce(strstarts(str(?_resource_multi_iri), str(?dTarget)), false), 1, 0) as ?fDMatch)
-  bind(if(bound(?vTarget), 1, 0) as ?fVHasTarget)
-  bind(if(coalesce(str(?vTarget) = str(?ownClass), false) || coalesce(strstarts(str(?_resource_multi_iri), str(?vTarget)), false), 1, 0) as ?fVMatch)
-  bind(coalesce(?dTarget, ?vTarget) as ?targetIri)
+  bind(if(bound(?effVTarget), 1, 0) as ?fVHasTarget)
+  bind(if(coalesce(str(?effVTarget) = str(?ownClass), false) || coalesce(strstarts(str(?_resource_multi_iri), str(?effVTarget)), false), 1, 0) as ?fVMatch)
+  bind(coalesce(?dTarget, ?effVTarget) as ?targetIri)
   bind(replace(str(?targetIri), \"^.*[/#]\", \"\") as ?targetLocalName)
   bind(if(coalesce(strlen(?targetLocalName) > 0, false), ?targetLocalName, str(?targetIri)) as ?targetLabel)
-  bind(coalesce(?viewLatest, ?viewRef) as ?view)
+  bind(if(bound(?pinSpace), coalesce(?governedLatest, ?viewRef), coalesce(?viewLatest, ?viewRef)) as ?view)
   bind(str(?viewRef) as ?deactivateView)
   }
   group by ?view ?view_label ?position ?preset ?preset_label ?presetScope ?user ?date ?deactivateView ?np
@@ -221,8 +267,18 @@ where {
 group by ?view
 order by desc(?displayed_here) ?position""" .
 }
-sub:provenance { sub:assertion prov:wasAttributedTo orcid:0000-0002-1267-0234 . }
+
+sub:provenance {
+  sub:assertion prov:wasAttributedTo orcid:0000-0002-1267-0234 .
+}
+
 sub:pubinfo {
   orcid:0000-0002-1267-0234 foaf:name "Tobias Kuhn" .
-  this: dct:created "2026-06-25T16:05:53Z"^^xsd:dateTime; dct:creator orcid:0000-0002-1267-0234; dct:license <https://creativecommons.org/licenses/by/4.0/>; npx:embeds sub:list-view-displays; npx:supersedes <https://w3id.org/np/RAE8SOXg7x9nreFldSIdcCku_fHMeIP1RnXizITBj2ggo> .
+  
+  this: dct:created "2026-07-03T13:00:55Z"^^xsd:dateTime;
+    dct:creator orcid:0000-0002-1267-0234;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    npx:embeds sub:list-view-displays;
+    npx:supersedes <https://w3id.org/np/RAfGpyfUX8qjSMN5-aRWOPeVqHajs3f6zUzcnMuRibk1g> .
 }
+

--- a/docs/queries/list-view-displays-space.trig
+++ b/docs/queries/list-view-displays-space.trig
@@ -1,6 +1,7 @@
 @prefix this: <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
 @prefix sub: <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
 @prefix np: <http://www.nanopub.org/nschema#> .
+@prefix grlc: <https://w3id.org/kpxl/grlc/> .
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix npx: <http://purl.org/nanopub/x/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
@@ -17,64 +18,95 @@ sub:Head {
 }
 
 sub:assertion {
-  sub:list-part-view-displays a <https://w3id.org/kpxl/grlc/grlc-query>;
-    dct:description "Lists, for a PART page (a resource viewed as a part of a maintained resource/space/user), the view displays configured on the part's owning resource, flagged for this specific part (read-only). Same display set and admin/maintainer authorization as list-view-displays, keyed on the owning resource (the 'resource' parameter): standalone view displays plus preset-contributed views, deactivations applied, each view resolved to its latest version. The displayed_here column is a flag (check mark, else blank) indicating whether the view is shown on THIS part -- i.e. its appliesToInstancesOf matches one of the part's own classes (the 'partclass' multi-valued parameter), or it is pinned to the part via gen:appliesTo, or its namespace targeting covers the part's IRI (the 'partid' parameter). A hasTopLevelView preset is pinned to the owning resource's own page and is therefore never shown on a part (blank); a hasView preset falls back to the view's own targeting. For blank (not-shown) rows the target_multi_iri column lists the class(es)/namespace(s) the view targets. Rows are ordered shown-here first, then by structural position. Space-governed versions (gen:governedBy, nanodash docs/views-and-presets-as-maintained-resources.md): a referenced version declaring gen:governedBy resolves to the newest version of its (kind, space) pair signed by a current member+ (admin/maintainer/member) of that space -- with the kind validated as a maintained resource of the space -- taking precedence over the supersedes-based head; without a valid governed candidate the pinned version stands.";
+  sub:list-view-displays-space a grlc:grlc-query;
+    dct:description "Space-scoped view displays for a single space ref. Derived from list-view-displays (RAfGpyfUX8qjSMN5-aRWOPeVqHajs3f6zUzcnMuRibk1g) but specialised for gen:Space resources: the authority gate keeps only the governing-space-ref hop -- issue #130's reflexive self-edge already exposes the space's own admins/maintainers there -- and drops the agent-self UNION branch, leaving a single non-UNION join under the variable state graph. This avoids the RDF4J planner timeout documented in nanopub-query doc/sparql-quirks.md (variable hasCurrentSpaceState pointer + multi-join + UNION => intermittent 504) that made the space View-displays view fail intermittently. ?ownClass is folded to the constant gen:Space. Takes the same two concrete inputs (resource = space IRI, root_np = ref root) and returns the same columns as list-view-displays. The outer SELECT collapses multiple attach rows per view deterministically: ?displayed_here via max() (shown if any live path displays it), every other column pinned to the single newest (date_added, np) row via argmax -- replacing the old non-deterministic sample() aggregates. Space-governed versions (gen:governedBy, nanodash docs/views-and-presets-as-maintained-resources.md): a referenced version declaring gen:governedBy resolves to the newest version of its (kind, space) pair signed by a current member+ (admin/maintainer/member) of that space -- with the kind validated as a maintained resource of the space -- taking precedence over the supersedes-based head; without a valid governed candidate the pinned version stands.";
     dct:license <http://www.apache.org/licenses/LICENSE-2.0>;
-    rdfs:label "List part view displays";
-    <https://w3id.org/kpxl/grlc/endpoint> <https://w3id.org/np/l/nanopub-query-1.1/repo/type/11daee46fdfff957dc17b46f5dc1a618045afd4f5634d5334ce9db19c3689a3c>;
-    <https://w3id.org/kpxl/grlc/sparql> """prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+    rdfs:label "List view displays (space)";
+    grlc:endpoint <https://w3id.org/np/l/nanopub-query-1.1/repo/type/11daee46fdfff957dc17b46f5dc1a618045afd4f5634d5334ce9db19c3689a3c>;
+    grlc:sparql """prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 prefix dct: <http://purl.org/dc/terms/>
 prefix np: <http://www.nanopub.org/nschema#>
 prefix npa: <http://purl.org/nanopub/admin/>
 prefix npx: <http://purl.org/nanopub/x/>
 prefix gen: <https://w3id.org/kpxl/gen/terms/>
 
+select ?view
+       (?view_label_g as ?view_label)
+       (?displayed_here_g as ?displayed_here)
+       (?position_g as ?position)
+       (substr(?position_g, 1, 3) as ?position_label)
+       (if(strlen(?via_preset_g) > 0, iri(?via_preset_g), ?undef_vp) as ?via_preset)
+       (?via_preset_label_g as ?via_preset_label)
+       (if(strlen(?added_by_g) > 0, iri(?added_by_g), ?undef_ab) as ?added_by)
+       (?deactivateView_g as ?deactivateView)
+       (?date_added_g as ?date_added)
+       (?np_g as ?np)
+       (?np_label_g as ?np_label) where {
+# Collapse to one deterministic row per ?view. The page can reach a view through several
+# rows (a direct ViewDisplay AND a preset, multiple display nanopubs, class+namespace targets);
+# group by ?view picks ONE. ?displayed_here uses max() = \"shown if displayed via any live path\"
+# (\"\" < the check mark, so max yields the check when any path shows it) and is order-stable.
+# Every other column is pinned to the single newest row via an argmax over (date_added, np) --
+# the same trick already used for ?np -- so the detail columns stay mutually consistent
+# (no value mixed in from a different source row) instead of independently SAMPLE()d at random.
+select ?view
+       (min(?view_label) as ?view_label_g)
+       (max(?displayed_here) as ?displayed_here_g)
+       (strafter(strafter(max(concat(str(?date_added), \"\\\\t\", str(?np), \"\\\\t\", str(?position))), \"\\\\t\"), \"\\\\t\") as ?position_g)
+       (strafter(strafter(max(concat(str(?date_added), \"\\\\t\", str(?np), \"\\\\t\", coalesce(str(?via_preset), \"\"))), \"\\\\t\"), \"\\\\t\") as ?via_preset_g)
+       (strafter(strafter(max(concat(str(?date_added), \"\\\\t\", str(?np), \"\\\\t\", coalesce(str(?via_preset_label), \"\"))), \"\\\\t\"), \"\\\\t\") as ?via_preset_label_g)
+       (strafter(strafter(max(concat(str(?date_added), \"\\\\t\", str(?np), \"\\\\t\", coalesce(str(?added_by), \"\"))), \"\\\\t\"), \"\\\\t\") as ?added_by_g)
+       (strafter(strafter(max(concat(str(?date_added), \"\\\\t\", str(?np), \"\\\\t\", str(?deactivateView))), \"\\\\t\"), \"\\\\t\") as ?deactivateView_g)
+       (max(?date_added) as ?date_added_g)
+       (iri(strafter(max(concat(str(?date_added), \"\\\\t\", str(?np))), \"\\\\t\")) as ?np_g)
+       (\"^\" as ?np_label_g) where {
 select ?view ?view_label ?displayed_here ?position
-       (substr(?position, 1, 3) as ?position_label)
        (if(?displayed_here = \"\", ?target_multi_iri_raw, \"\") as ?target_multi_iri)
        (if(?displayed_here = \"\", ?target_label_multi_raw, \"\") as ?target_label_multi)
-       ?via_preset ?via_preset_label ?added_by ?date_added ?np ?np_label
+       ?via_preset ?via_preset_label ?added_by ?date_added ?deactivateView ?np ?np_label
 where {
  select ?view ?view_label ?position
        (if(bound(?presetScope), ?presetScope,
          if(bound(?preset),
-            if(?aVHasTarget > 0, if(?aVMatch > 0, \"✓\", \"\"), \"\"),
+            if(?aVHasTarget > 0, if(?aVMatch > 0, \"✓\", \"\"), \"✓\"),
           if(?aDApplyHere > 0, \"✓\",
            if(?aDHasTarget > 0, if(?aDMatch > 0, \"✓\", \"\"),
             if(?aDHasApply > 0, \"\",
-             if(?aVHasTarget > 0, if(?aVMatch > 0, \"✓\", \"\"), \"\")))))) as ?displayed_here)
+             if(?aVHasTarget > 0, if(?aVMatch > 0, \"✓\", \"\"), \"✓\")))))) as ?displayed_here)
        ?target_multi_iri_raw ?target_label_multi_raw
        (?preset as ?via_preset) (?preset_label as ?via_preset_label)
        (?user as ?added_by) (?date as ?date_added)
-       ?np (\"^\" as ?np_label) where {
-  select ?view ?view_label ?position ?preset ?preset_label ?presetScope ?user ?date ?np
+       ?deactivateView ?np (\"^\" as ?np_label) where {
+  select ?view ?view_label ?position ?preset ?preset_label ?presetScope ?user ?date ?deactivateView ?np
          (max(?fDApplyHere) as ?aDApplyHere) (max(?fDHasApply) as ?aDHasApply) (max(?fDHasTarget) as ?aDHasTarget)
          (max(?fDMatch) as ?aDMatch) (max(?fVHasTarget) as ?aVHasTarget) (max(?fVMatch) as ?aVMatch)
          (group_concat(distinct ?targetIri; separator=\" \") as ?target_multi_iri_raw)
-         (group_concat(distinct ?targetLabel; separator=\"\\n\") as ?target_label_multi_raw)
+         (group_concat(distinct ?targetLabel; separator=\"\\\\n\") as ?target_label_multi_raw)
   where {
   {
     select ?_resource_multi_iri ?viewRef ?viewLatest ?view_label ?position ?preset ?preset_label ?presetScope ?user ?date ?np
-           ?dApply ?dTarget ?effVTarget ?pinSpace ?governedLatest where {
+           ?ownClass ?dApply ?dTarget ?effVTarget ?pinSpace ?governedLatest where {
       values ?_resource_multi_iri {}
+      values ?_root_np_multi_iri {}
       service <https://w3id.org/np/l/nanopub-query-1.1/repo/spaces> {
         graph npa:graph { npa:thisRepo npa:hasCurrentSpaceState ?stateG . }
-        {
-          # Authority gate (issue #130 / nanodash#510): a single mandatory hop through the
-          # governing space ref, which covers both a maintained resource and a space itself
-          # (the reflexive self-edge), keyed on the role tier materialized on the
-          # RoleInstantiation since #125. Replaces the old bare-IRI isMaintainedBy? hop and
-          # the dead RoleDeclaration maintainer join. Non-ref variant: any ref claiming the
-          # IRI, so authority merges across refs (the ref variant pins a single ?passedRef).
-          graph ?stateG {
-            ?_resource_multi_iri npa:hasGoverningSpaceRef ?spaceRef .
-            ?ri a gen:RoleInstantiation ; npa:forSpaceRef ?spaceRef ; npa:hasRoleType ?roleType ; npa:forAgent ?authAgent .
-            filter(?roleType = gen:AdminRole || ?roleType = gen:MaintainerRole)
-            ?authAcct a npa:AccountState ; npa:agent ?authAgent ; npa:pubkey ?pubkey .
-          }
-        } union {
-          graph ?stateG { ?selfAcct a npa:AccountState ; npa:agent ?_resource_multi_iri ; npa:pubkey ?pubkey . }
+        graph npa:spacesGraph { ?passedRef npa:rootNanopub ?_root_np_multi_iri . }
+        # Authority gate (space-scoped, no-UNION variant of list-view-displays): a single
+        # mandatory hop through the governing space ref. For a gen:Space resource, issue #130's
+        # reflexive self-edge (?space npa:hasGoverningSpaceRef ?ownRef) already exposes the
+        # space's own admins/maintainers through this same hop, so the agent-self UNION branch
+        # carried by the general list-view-displays is redundant here and is dropped. That leaves
+        # a single non-UNION join under the variable ?stateG, avoiding the RDF4J planner timeout
+        # documented in nanopub-query doc/sparql-quirks.md (variable hasCurrentSpaceState pointer
+        # + multi-join + UNION => intermittent 504). ?ownClass is the constant gen:Space (this
+        # query only backs gen:Space views), so the two ownClass exists-probes are folded away too.
+        graph ?stateG {
+          ?_resource_multi_iri npa:hasGoverningSpaceRef ?passedRef .
+          ?ri a gen:RoleInstantiation ; npa:forSpaceRef ?passedRef ; npa:hasRoleType ?roleType ; npa:forAgent ?authAgent .
+          filter(?roleType = gen:AdminRole || ?roleType = gen:MaintainerRole)
+          ?authAcct a npa:AccountState ; npa:agent ?authAgent ; npa:pubkey ?pubkey .
         }
+        bind(gen:Space as ?ownClass)
       }
       {
         graph npa:graph {
@@ -138,7 +170,7 @@ where {
             graph ?pa {
               ?preset a gen:Preset .
               optional { ?preset rdfs:label ?preset_label . }
-              { ?preset gen:hasTopLevelView ?viewRef . bind(\"\" as ?presetScope) }
+              { ?preset gen:hasTopLevelView ?viewRef . bind(\"✓\" as ?presetScope) }
               union { ?preset gen:hasView ?viewRef }
             }
           }
@@ -230,26 +262,30 @@ where {
       bind(coalesce(?dispPos, ?effViewPos, \"\") as ?position)
     }
   }
-  values ?__partclass_multi_iri {}
-  bind(if(coalesce(str(?dApply) = str(?_partid_iri), false), 1, 0) as ?fDApplyHere)
+  bind(if(coalesce(str(?dApply) = str(?_resource_multi_iri), false), 1, 0) as ?fDApplyHere)
   bind(if(bound(?dApply), 1, 0) as ?fDHasApply)
   bind(if(bound(?dTarget), 1, 0) as ?fDHasTarget)
-  bind(if(coalesce(?dTarget = ?__partclass_multi_iri, false) || coalesce(strstarts(str(?_partid_iri), str(?dTarget)), false), 1, 0) as ?fDMatch)
+  bind(if(coalesce(str(?dTarget) = str(?ownClass), false) || coalesce(strstarts(str(?_resource_multi_iri), str(?dTarget)), false), 1, 0) as ?fDMatch)
   bind(if(bound(?effVTarget), 1, 0) as ?fVHasTarget)
-  bind(if(coalesce(?effVTarget = ?__partclass_multi_iri, false) || coalesce(strstarts(str(?_partid_iri), str(?effVTarget)), false), 1, 0) as ?fVMatch)
+  bind(if(coalesce(str(?effVTarget) = str(?ownClass), false) || coalesce(strstarts(str(?_resource_multi_iri), str(?effVTarget)), false), 1, 0) as ?fVMatch)
   bind(coalesce(?dTarget, ?effVTarget) as ?targetIri)
   bind(replace(str(?targetIri), \"^.*[/#]\", \"\") as ?targetLocalName)
   bind(if(coalesce(strlen(?targetLocalName) > 0, false), ?targetLocalName, str(?targetIri)) as ?targetLabel)
   bind(if(bound(?pinSpace), coalesce(?governedLatest, ?viewRef), coalesce(?viewLatest, ?viewRef)) as ?view)
+  bind(str(?viewRef) as ?deactivateView)
   }
-  group by ?view ?view_label ?position ?preset ?preset_label ?presetScope ?user ?date ?np
+  group by ?view ?view_label ?position ?preset ?preset_label ?presetScope ?user ?date ?deactivateView ?np
  }
 }
-order by desc(?displayed_here) ?position desc(?date_added)""" .
+}
+group by ?view
+}
+order by desc(?displayed_here) ?position""" .
 }
 
 sub:provenance {
-  sub:assertion prov:wasAttributedTo orcid:0000-0002-1267-0234 .
+  sub:assertion prov:wasAttributedTo orcid:0000-0002-1267-0234;
+    prov:wasDerivedFrom <https://w3id.org/np/RAfGpyfUX8qjSMN5-aRWOPeVqHajs3f6zUzcnMuRibk1g> .
 }
 
 sub:pubinfo {
@@ -258,8 +294,7 @@ sub:pubinfo {
   this: dct:created "2026-07-03T13:00:55Z"^^xsd:dateTime;
     dct:creator orcid:0000-0002-1267-0234;
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    npx:embeds sub:list-part-view-displays;
-    npx:supersedes <https://w3id.org/np/RAs9S7c9wdasz2c745f-mBg53JSQ1q20vLLHkmnXCmX2w>;
-    rdfs:label "List part view displays" .
+    npx:embeds sub:list-view-displays-space;
+    npx:supersedes <https://w3id.org/np/RADjwb3jEpw_WkU7VCDygvkabnHmmKwmLylRtbXamFItM> .
 }
 

--- a/docs/queries/list-view-displays.trig
+++ b/docs/queries/list-view-displays.trig
@@ -18,7 +18,7 @@ sub:Head {
 
 sub:assertion {
   sub:list-view-displays a <https://w3id.org/kpxl/grlc/grlc-query>;
-    dct:description "Lists the currently active view displays of a resource for the About page (standalone + preset-contributed, deactivations applied, latest version, one row per resolved view keeping the latest). displayed_here flags whether the view is shown on this resource's own page. Ordered shown-here first, then by structural position.";
+    dct:description "Lists the currently active view displays of a resource for the About page (standalone + preset-contributed, deactivations applied, latest version, one row per resolved view keeping the latest). displayed_here flags whether the view is shown on this resource's own page. Ordered shown-here first, then by structural position. Space-governed versions (gen:governedBy, nanodash docs/views-and-presets-as-maintained-resources.md): a referenced version declaring gen:governedBy resolves to the newest version of its (kind, space) pair signed by a current member+ (admin/maintainer/member) of that space -- with the kind validated as a maintained resource of the space -- taking precedence over the supersedes-based head; without a valid governed candidate the pinned version stands.";
     dct:license <http://www.apache.org/licenses/LICENSE-2.0>;
     rdfs:label "List view displays";
     <https://w3id.org/kpxl/grlc/endpoint> <https://w3id.org/np/l/nanopub-query-1.1/repo/type/11daee46fdfff957dc17b46f5dc1a618045afd4f5634d5334ce9db19c3689a3c>;
@@ -66,7 +66,7 @@ where {
   where {
   {
     select ?_resource_multi_iri ?viewRef ?viewLatest ?view_label ?position ?preset ?preset_label ?presetScope ?user ?date ?np
-           ?ownClass ?dApply ?dTarget ?vTarget where {
+           ?ownClass ?dApply ?dTarget ?effVTarget ?pinSpace ?governedLatest where {
       values ?_resource_multi_iri {}
       service <https://w3id.org/np/l/nanopub-query-1.1/repo/spaces> {
         graph npa:graph { npa:thisRepo npa:hasCurrentSpaceState ?stateG . }
@@ -197,24 +197,63 @@ where {
                     npx:embeds ?viewLatest ; np:hasAssertion ?hva .
             filter not exists { ?i2 npx:invalidates ?headNp ; npa:hasValidSignatureForPublicKey ?vKey . }
           }
-          graph ?hva { ?viewLatest dct:title ?view_label . }
+          graph ?hva { ?viewLatest dct:title ?supLabel . }
           optional { graph ?hva { ?viewLatest gen:hasStructuralPosition ?viewPos . } }
           optional { graph ?hva { ?viewLatest (gen:appliesToInstancesOf|gen:appliesToNamespace) ?vTarget . } }
         }
       }
-      bind(coalesce(?dispPos, ?viewPos, \"\") as ?position)
+            # Space-governed resolution (gen:governedBy; nanodash docs/views-and-presets-as-
+      # maintained-resources.md): if the pinned version declares a governing space, the
+      # newest version of its (kind, space) pair signed by a current member+ of that
+      # space wins, with the kind validated as maintained by the space. Run-once
+      # sub-select over all governed versions network-wide (gen:governedBy is highly
+      # selective), joined back per pin. No valid candidate -> the pin stands.
+      optional {
+        service <https://w3id.org/np/l/nanopub-query-1.1/repo/type/ec6722efa3b44e0a18aa63afe5964158a1fdb7f0413ea5f23bfddf5c03ca0221> {
+          graph npa:graph { ?pinNp npx:embeds ?viewRef ; np:hasAssertion ?pinA . }
+          graph ?pinA { ?viewRef dct:isVersionOf ?pinKind ; gen:governedBy ?pinSpace . }
+        }
+        { select ?pinKind ?pinSpace (iri(strafter(max(concat(str(?cDate), \">\", str(?cver))), \">\")) as ?governedLatest) where {
+            service <https://w3id.org/np/l/nanopub-query-1.1/repo/type/ec6722efa3b44e0a18aa63afe5964158a1fdb7f0413ea5f23bfddf5c03ca0221> {
+              graph npa:graph {
+                ?cnp dct:created ?cDate ; npa:hasValidSignatureForPublicKeyHash ?cpk ; npx:embeds ?cver ; np:hasAssertion ?ca .
+                filter not exists { ?ci npx:invalidates ?cnp ; npa:hasValidSignatureForPublicKeyHash ?cpk . }
+              }
+              graph ?ca { ?cver dct:isVersionOf ?pinKind ; gen:governedBy ?pinSpace . }
+            }
+            service <https://w3id.org/np/l/nanopub-query-1.1/repo/spaces> {
+              graph npa:graph { <http://purl.org/nanopub/admin/thisRepo> npa:hasCurrentSpaceState ?gsg . }
+              graph ?gsg {
+                ?pinKind npa:isMaintainedBy ?pinSpace ; npa:hasGoverningSpaceRef ?gref .
+                ?gri a gen:RoleInstantiation ; npa:forSpace ?pinSpace ; npa:forSpaceRef ?gref ; npa:hasRoleType ?gtier ; npa:forAgent ?gag .
+                filter(?gtier = gen:AdminRole || ?gtier = gen:MaintainerRole || ?gtier = gen:MemberRole)
+                ?gacct a npa:AccountState ; npa:agent ?gag ; npa:pubkey ?cpk .
+              }
+            }
+          } group by ?pinKind ?pinSpace }
+        service <https://w3id.org/np/l/nanopub-query-1.1/repo/type/ec6722efa3b44e0a18aa63afe5964158a1fdb7f0413ea5f23bfddf5c03ca0221> {
+          graph npa:graph { ?gnp npx:embeds ?governedLatest ; np:hasAssertion ?gva . }
+          graph ?gva { ?governedLatest dct:title ?gTitle . }
+          optional { graph ?gva { ?governedLatest gen:hasStructuralPosition ?gPos . } }
+          optional { graph ?gva { ?governedLatest (gen:appliesToInstancesOf|gen:appliesToNamespace) ?gTarget . } }
+        }
+      }
+      bind(if(bound(?governedLatest), ?gTitle, ?supLabel) as ?view_label)
+      bind(if(bound(?governedLatest), ?gPos, ?viewPos) as ?effViewPos)
+      bind(if(bound(?governedLatest), ?gTarget, ?vTarget) as ?effVTarget)
+      bind(coalesce(?dispPos, ?effViewPos, \"\") as ?position)
     }
   }
   bind(if(coalesce(str(?dApply) = str(?_resource_multi_iri), false), 1, 0) as ?fDApplyHere)
   bind(if(bound(?dApply), 1, 0) as ?fDHasApply)
   bind(if(bound(?dTarget), 1, 0) as ?fDHasTarget)
   bind(if(coalesce(str(?dTarget) = str(?ownClass), false) || coalesce(strstarts(str(?_resource_multi_iri), str(?dTarget)), false), 1, 0) as ?fDMatch)
-  bind(if(bound(?vTarget), 1, 0) as ?fVHasTarget)
-  bind(if(coalesce(str(?vTarget) = str(?ownClass), false) || coalesce(strstarts(str(?_resource_multi_iri), str(?vTarget)), false), 1, 0) as ?fVMatch)
-  bind(coalesce(?dTarget, ?vTarget) as ?targetIri)
+  bind(if(bound(?effVTarget), 1, 0) as ?fVHasTarget)
+  bind(if(coalesce(str(?effVTarget) = str(?ownClass), false) || coalesce(strstarts(str(?_resource_multi_iri), str(?effVTarget)), false), 1, 0) as ?fVMatch)
+  bind(coalesce(?dTarget, ?effVTarget) as ?targetIri)
   bind(replace(str(?targetIri), \"^.*[/#]\", \"\") as ?targetLocalName)
   bind(if(coalesce(strlen(?targetLocalName) > 0, false), ?targetLocalName, str(?targetIri)) as ?targetLabel)
-  bind(coalesce(?viewLatest, ?viewRef) as ?view)
+  bind(if(bound(?pinSpace), coalesce(?governedLatest, ?viewRef), coalesce(?viewLatest, ?viewRef)) as ?view)
   bind(str(?viewRef) as ?deactivateView)
   }
   group by ?view ?view_label ?position ?preset ?preset_label ?presetScope ?user ?date ?deactivateView ?np
@@ -232,11 +271,11 @@ sub:provenance {
 sub:pubinfo {
   orcid:0000-0002-1267-0234 foaf:name "Tobias Kuhn" .
   
-  this: dct:created "2026-06-25T16:05:53Z"^^xsd:dateTime;
+  this: dct:created "2026-07-03T13:00:55Z"^^xsd:dateTime;
     dct:creator orcid:0000-0002-1267-0234;
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
     npx:embeds sub:list-view-displays;
-    npx:supersedes <https://w3id.org/np/RAUiNhjuycdEOsElNOK13ot7rOqr5Jt4NRkXWveoCvIVg>;
+    npx:supersedes <https://w3id.org/np/RAF4bDQmpjbUZK_fA2UBzpUAiwm-7WK3BCpOqOfgr0zd4>;
     rdfs:label "List view displays" .
 }
 

--- a/docs/queries/maintained-resource-view-displays-view.trig
+++ b/docs/queries/maintained-resource-view-displays-view.trig
@@ -1,6 +1,5 @@
 @prefix this: <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
 @prefix sub: <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
-@prefix gen: <https://w3id.org/kpxl/gen/terms/> .
 @prefix np: <http://www.nanopub.org/nschema#> .
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix nt: <https://w3id.org/np/o/ntemplate/> .
@@ -19,31 +18,31 @@ sub:Head {
 }
 
 sub:assertion {
-  sub:add-view-display-action a gen:ViewResultAction;
+  sub:add-view-display-action a <https://w3id.org/kpxl/gen/terms/ViewResultAction>;
     rdfs:label "➕ add view display";
-    gen:hasActionTemplate <https://w3id.org/np/RAe0zantvnJlVWIC2LueG1IAMktXGFIqCdWliok1rOrmU>;
-    gen:hasActionTemplatePartField "void";
-    gen:hasActionTemplateQueryMapping "void";
-    gen:hasActionTemplateTargetField "resource";
-    gen:isVisibleTo gen:MaintainerRole .
+    <https://w3id.org/kpxl/gen/terms/hasActionTemplate> <https://w3id.org/np/RAe0zantvnJlVWIC2LueG1IAMktXGFIqCdWliok1rOrmU>;
+    <https://w3id.org/kpxl/gen/terms/hasActionTemplatePartField> "void";
+    <https://w3id.org/kpxl/gen/terms/hasActionTemplateQueryMapping> "void";
+    <https://w3id.org/kpxl/gen/terms/hasActionTemplateTargetField> "resource";
+    <https://w3id.org/kpxl/gen/terms/isVisibleTo> <https://w3id.org/kpxl/gen/terms/MaintainerRole> .
   
-  sub:deactivate-action a gen:ViewEntryAction;
-    rdfs:label "deactivate";
-    gen:hasActionTemplate <https://w3id.org/np/RAZ47_4JquvEXk30HYnVeSgFRcQqHtpdibcfBOeqHI2j4>;
-    gen:hasActionTemplatePartField "void";
-    gen:hasActionTemplateQueryMapping "deactivateView:view";
-    gen:hasActionTemplateTargetField "resource";
-    gen:isVisibleTo gen:MaintainerRole .
+  sub:deactivate-action a <https://w3id.org/kpxl/gen/terms/ViewEntryAction>;
+    rdfs:label "🚫 deactivate";
+    <https://w3id.org/kpxl/gen/terms/hasActionTemplate> <https://w3id.org/np/RAZ47_4JquvEXk30HYnVeSgFRcQqHtpdibcfBOeqHI2j4>;
+    <https://w3id.org/kpxl/gen/terms/hasActionTemplatePartField> "void";
+    <https://w3id.org/kpxl/gen/terms/hasActionTemplateQueryMapping> "deactivateView:view";
+    <https://w3id.org/kpxl/gen/terms/hasActionTemplateTargetField> "resource";
+    <https://w3id.org/kpxl/gen/terms/isVisibleTo> <https://w3id.org/kpxl/gen/terms/MaintainerRole> .
   
-  sub:view-displays-view a gen:ResourceView, gen:TabularView;
+  sub:view-displays-view a <https://w3id.org/kpxl/gen/terms/ResourceView>, <https://w3id.org/kpxl/gen/terms/TabularView>;
     dct:isVersionOf <https://w3id.org/np/RAZOxROZRaxSeoeO05iI0tKpDIy2mEN3jlUuVIo0uZN1I/maintained-resource-view-displays-view-kind>;
-    dct:title "🖵 View displays";
+    dct:title "⬜ View displays";
     rdfs:label "View displays view (Maintained resource)";
-    gen:appliesToInstancesOf gen:MaintainedResource;
-    gen:hasStructuralPosition "5.5.viewDisplays";
-    gen:hasViewAction sub:add-view-display-action, sub:deactivate-action;
-    gen:hasViewQuery <https://w3id.org/np/RAfGpyfUX8qjSMN5-aRWOPeVqHajs3f6zUzcnMuRibk1g/list-view-displays>;
-    gen:hasViewQueryTargetField "resource" .
+    <https://w3id.org/kpxl/gen/terms/appliesToInstancesOf> <https://w3id.org/kpxl/gen/terms/MaintainedResource>;
+    <https://w3id.org/kpxl/gen/terms/hasStructuralPosition> "5.5.viewDisplays";
+    <https://w3id.org/kpxl/gen/terms/hasViewAction> sub:add-view-display-action, sub:deactivate-action;
+    <https://w3id.org/kpxl/gen/terms/hasViewQuery> <https://w3id.org/np/RADxYPBjhY_43rli1aFlKYJBgDquEiSmH6ggzjaSOS0Cc/list-view-displays>;
+    <https://w3id.org/kpxl/gen/terms/hasViewQueryTargetField> "resource" .
 }
 
 sub:provenance {
@@ -53,15 +52,16 @@ sub:provenance {
 sub:pubinfo {
   orcid:0000-0002-1267-0234 foaf:name "Tobias Kuhn" .
   
-  this: dct:created "2026-06-25T16:12:02Z"^^xsd:dateTime;
+  this: dct:created "2026-07-03T13:17:04Z"^^xsd:dateTime;
     dct:creator orcid:0000-0002-1267-0234;
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
     npx:embeds sub:view-displays-view;
     npx:introduces <https://w3id.org/np/RAZOxROZRaxSeoeO05iI0tKpDIy2mEN3jlUuVIo0uZN1I/maintained-resource-view-displays-view-kind>;
-    npx:supersedes <https://w3id.org/np/RAYgOvKdvtMDs5NIvP0KvJu0jyCtAG6HslBoQwstjmDOI>;
-    rdfs:label "View displays view (Maintained resource)";
+    npx:supersedes <https://w3id.org/np/RAv1OhKmQMAsJejBxT0tuMCwBkhmpX_gu0e17Gz6vz7mE>;
+    npx:wasCreatedAt <http://localhost:37373/>;
     nt:wasCreatedFromProvenanceTemplate <https://w3id.org/np/RA7lSq6MuK_TIC6JMSHvLtee3lpLoZDOqLJCLXevnrPoU>;
     nt:wasCreatedFromPubinfoTemplate <https://w3id.org/np/RACJ58Gvyn91LqCKIO9zu1eijDQIeEff28iyDrJgjSJF8>,
       <https://w3id.org/np/RAoTD7udB2KtUuOuAe74tJi1t3VzK0DyWS7rYVAq1GRvw>, <https://w3id.org/np/RAukAcWHRDlkqxk7H2XNSegc1WnHI569INvNr-xdptDGI>;
     nt:wasCreatedFromTemplate <https://w3id.org/np/RA8_hijwsfGCryMYtjtEpec21ZSNY68-qmL0bHRWR0sWM> .
 }
+

--- a/docs/queries/space-view-displays-view.trig
+++ b/docs/queries/space-view-displays-view.trig
@@ -1,6 +1,5 @@
 @prefix this: <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
 @prefix sub: <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
-@prefix gen: <https://w3id.org/kpxl/gen/terms/> .
 @prefix np: <http://www.nanopub.org/nschema#> .
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix nt: <https://w3id.org/np/o/ntemplate/> .
@@ -19,31 +18,31 @@ sub:Head {
 }
 
 sub:assertion {
-  sub:add-view-display-action a gen:ViewResultAction;
+  sub:add-view-display-action a <https://w3id.org/kpxl/gen/terms/ViewResultAction>;
     rdfs:label "➕ add view display";
-    gen:hasActionTemplate <https://w3id.org/np/RAwPPxDxkXwgWwYhmvzi6SUs8djPZS4IgWJdp2G0blqoQ>;
-    gen:hasActionTemplatePartField "void";
-    gen:hasActionTemplateQueryMapping "void";
-    gen:hasActionTemplateTargetField "resource";
-    gen:isVisibleTo gen:MaintainerRole .
+    <https://w3id.org/kpxl/gen/terms/hasActionTemplate> <https://w3id.org/np/RAwPPxDxkXwgWwYhmvzi6SUs8djPZS4IgWJdp2G0blqoQ>;
+    <https://w3id.org/kpxl/gen/terms/hasActionTemplatePartField> "void";
+    <https://w3id.org/kpxl/gen/terms/hasActionTemplateQueryMapping> "void";
+    <https://w3id.org/kpxl/gen/terms/hasActionTemplateTargetField> "resource";
+    <https://w3id.org/kpxl/gen/terms/isVisibleTo> <https://w3id.org/kpxl/gen/terms/MaintainerRole> .
   
-  sub:deactivate-action a gen:ViewEntryAction;
-    rdfs:label "deactivate";
-    gen:hasActionTemplate <https://w3id.org/np/RAZ47_4JquvEXk30HYnVeSgFRcQqHtpdibcfBOeqHI2j4>;
-    gen:hasActionTemplatePartField "void";
-    gen:hasActionTemplateQueryMapping "deactivateView:view";
-    gen:hasActionTemplateTargetField "resource";
-    gen:isVisibleTo gen:MaintainerRole .
+  sub:deactivate-action a <https://w3id.org/kpxl/gen/terms/ViewEntryAction>;
+    rdfs:label "🚫 deactivate";
+    <https://w3id.org/kpxl/gen/terms/hasActionTemplate> <https://w3id.org/np/RAZ47_4JquvEXk30HYnVeSgFRcQqHtpdibcfBOeqHI2j4>;
+    <https://w3id.org/kpxl/gen/terms/hasActionTemplatePartField> "void";
+    <https://w3id.org/kpxl/gen/terms/hasActionTemplateQueryMapping> "deactivateView:view";
+    <https://w3id.org/kpxl/gen/terms/hasActionTemplateTargetField> "resource";
+    <https://w3id.org/kpxl/gen/terms/isVisibleTo> <https://w3id.org/kpxl/gen/terms/MaintainerRole> .
   
-  sub:view-displays-view a gen:ResourceView, gen:TabularView;
+  sub:view-displays-view a <https://w3id.org/kpxl/gen/terms/ResourceView>, <https://w3id.org/kpxl/gen/terms/TabularView>;
     dct:isVersionOf <https://w3id.org/np/RAiNrals9m7glgRFdu1i4pygixr5VGfA1ERoA_DpwdT0A/space-view-displays-view-kind>;
-    dct:title "🖵 View displays";
+    dct:title "⬜ View displays";
     rdfs:label "View displays view (space)";
-    gen:appliesToInstancesOf gen:Space;
-    gen:hasStructuralPosition "5.5.viewDisplays";
-    gen:hasViewAction sub:add-view-display-action, sub:deactivate-action;
-    gen:hasViewQuery <https://w3id.org/np/RAfGpyfUX8qjSMN5-aRWOPeVqHajs3f6zUzcnMuRibk1g/list-view-displays>;
-    gen:hasViewQueryTargetField "resource" .
+    <https://w3id.org/kpxl/gen/terms/appliesToInstancesOf> <https://w3id.org/kpxl/gen/terms/Space>;
+    <https://w3id.org/kpxl/gen/terms/hasStructuralPosition> "5.5.viewDisplays";
+    <https://w3id.org/kpxl/gen/terms/hasViewAction> sub:add-view-display-action, sub:deactivate-action;
+    <https://w3id.org/kpxl/gen/terms/hasViewQuery> <https://w3id.org/np/RAq18TQpYyfgTQg6NfmZA34rWqI74N2Sbh6PEuuBDO7uU/list-view-displays-space>;
+    <https://w3id.org/kpxl/gen/terms/hasViewQueryTargetField> "resource" .
 }
 
 sub:provenance {
@@ -53,14 +52,15 @@ sub:provenance {
 sub:pubinfo {
   orcid:0000-0002-1267-0234 foaf:name "Tobias Kuhn" .
   
-  this: dct:created "2026-06-25T16:12:02Z"^^xsd:dateTime;
+  this: dct:created "2026-07-03T13:17:04Z"^^xsd:dateTime;
     dct:creator orcid:0000-0002-1267-0234;
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
     npx:embeds sub:view-displays-view;
     npx:introduces <https://w3id.org/np/RAiNrals9m7glgRFdu1i4pygixr5VGfA1ERoA_DpwdT0A/space-view-displays-view-kind>;
-    npx:supersedes <https://w3id.org/np/RAiNrals9m7glgRFdu1i4pygixr5VGfA1ERoA_DpwdT0A>;
-    rdfs:label "View displays view (space)";
+    npx:supersedes <https://w3id.org/np/RA9DnE-Vept1wWP3VPuvhqaLtveH1JZVX-LmRepxIRkG0>;
     nt:wasCreatedFromProvenanceTemplate <https://w3id.org/np/RA7lSq6MuK_TIC6JMSHvLtee3lpLoZDOqLJCLXevnrPoU>;
-    nt:wasCreatedFromPubinfoTemplate <https://w3id.org/np/RACJ58Gvyn91LqCKIO9zu1eijDQIeEff28iyDrJgjSJF8>;
+    nt:wasCreatedFromPubinfoTemplate <https://w3id.org/np/RACJ58Gvyn91LqCKIO9zu1eijDQIeEff28iyDrJgjSJF8>,
+      <https://w3id.org/np/RAoTD7udB2KtUuOuAe74tJi1t3VzK0DyWS7rYVAq1GRvw>, <https://w3id.org/np/RAukAcWHRDlkqxk7H2XNSegc1WnHI569INvNr-xdptDGI>;
     nt:wasCreatedFromTemplate <https://w3id.org/np/RA8_hijwsfGCryMYtjtEpec21ZSNY68-qmL0bHRWR0sWM> .
 }
+

--- a/docs/queries/user-view-displays-view.trig
+++ b/docs/queries/user-view-displays-view.trig
@@ -1,6 +1,5 @@
 @prefix this: <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
 @prefix sub: <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
-@prefix gen: <https://w3id.org/kpxl/gen/terms/> .
 @prefix np: <http://www.nanopub.org/nschema#> .
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix nt: <https://w3id.org/np/o/ntemplate/> .
@@ -19,30 +18,32 @@ sub:Head {
 }
 
 sub:assertion {
-  sub:add-view-display-action a gen:ViewResultAction;
+  sub:add-view-display-action a <https://w3id.org/kpxl/gen/terms/ViewResultAction>;
     rdfs:label "➕ add view display";
-    gen:hasActionTemplate <https://w3id.org/np/RAQhTCHtfzGCj1YiE1LualWcZjg3thlRiquFWUE14UF-g>;
-    gen:hasActionTemplatePartField "void";
-    gen:hasActionTemplateQueryMapping "void";
-    gen:hasActionTemplateTargetField "resource";
-    gen:isVisibleTo gen:MaintainerRole .
+    <https://w3id.org/kpxl/gen/terms/hasActionTemplate> <https://w3id.org/np/RAQhTCHtfzGCj1YiE1LualWcZjg3thlRiquFWUE14UF-g>;
+    <https://w3id.org/kpxl/gen/terms/hasActionTemplatePartField> "void";
+    <https://w3id.org/kpxl/gen/terms/hasActionTemplateQueryMapping> "void";
+    <https://w3id.org/kpxl/gen/terms/hasActionTemplateTargetField> "resource";
+    <https://w3id.org/kpxl/gen/terms/isVisibleTo> <https://w3id.org/kpxl/gen/terms/MaintainerRole> .
   
-  sub:deactivate-action a gen:ViewEntryAction;
-    rdfs:label "deactivate";
-    gen:hasActionTemplate <https://w3id.org/np/RAZ47_4JquvEXk30HYnVeSgFRcQqHtpdibcfBOeqHI2j4>;
-    gen:hasActionTemplatePartField "void";
-    gen:hasActionTemplateQueryMapping "deactivateView:view";
-    gen:hasActionTemplateTargetField "resource";
-    gen:isVisibleTo gen:MaintainerRole .
+  sub:deactivate-action a <https://w3id.org/kpxl/gen/terms/ViewEntryAction>;
+    rdfs:label "🚫 deactivate";
+    <https://w3id.org/kpxl/gen/terms/hasActionTemplate> <https://w3id.org/np/RAZ47_4JquvEXk30HYnVeSgFRcQqHtpdibcfBOeqHI2j4>;
+    <https://w3id.org/kpxl/gen/terms/hasActionTemplatePartField> "void";
+    <https://w3id.org/kpxl/gen/terms/hasActionTemplateQueryMapping> "deactivateView:view";
+    <https://w3id.org/kpxl/gen/terms/hasActionTemplateTargetField> "resource";
+    <https://w3id.org/kpxl/gen/terms/isVisibleTo> <https://w3id.org/kpxl/gen/terms/MaintainerRole> .
   
-  sub:view-displays-view a gen:ResourceView, gen:TabularView;
+  sub:view-displays-view a <https://w3id.org/kpxl/gen/terms/ResourceView>, <https://w3id.org/kpxl/gen/terms/TabularView>;
     dct:isVersionOf <https://w3id.org/np/RA1d1qBF8Fk-ZWKtNB-wZd56HrV0wdtJkw0wp58sHxM0E/user-view-displays-view-kind>;
-    dct:title "🖵 View displays";
+    dct:title "⬜ View displays";
     rdfs:label "View displays view (User)";
-    gen:hasStructuralPosition "5.5.viewDisplays";
-    gen:hasViewAction sub:add-view-display-action, sub:deactivate-action;
-    gen:hasViewQuery <https://w3id.org/np/RAF4bDQmpjbUZK_fA2UBzpUAiwm-7WK3BCpOqOfgr0zd4/list-view-displays>;
-    gen:hasViewQueryTargetField "resource" .
+    <https://w3id.org/kpxl/gen/terms/appliesToInstancesOf> <https://w3id.org/kpxl/gen/terms/IndividualAgent>;
+    <https://w3id.org/kpxl/gen/terms/governedBy> <https://w3id.org/spaces/knowledgepixels>;
+    <https://w3id.org/kpxl/gen/terms/hasStructuralPosition> "5.5.viewDisplays";
+    <https://w3id.org/kpxl/gen/terms/hasViewAction> sub:add-view-display-action, sub:deactivate-action;
+    <https://w3id.org/kpxl/gen/terms/hasViewQuery> <https://w3id.org/np/RAIz68nc9V2_cduYc8ptnCmyAKCdmB0mHvDy2eqdWgKYE/list-view-displays>;
+    <https://w3id.org/kpxl/gen/terms/hasViewQueryTargetField> "resource" .
 }
 
 sub:provenance {
@@ -52,15 +53,15 @@ sub:provenance {
 sub:pubinfo {
   orcid:0000-0002-1267-0234 foaf:name "Tobias Kuhn" .
   
-  this: dct:created "2026-06-25T16:12:02Z"^^xsd:dateTime;
+  this: dct:created "2026-07-03T13:17:04Z"^^xsd:dateTime;
     dct:creator orcid:0000-0002-1267-0234;
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
     npx:embeds sub:view-displays-view;
     npx:introduces <https://w3id.org/np/RA1d1qBF8Fk-ZWKtNB-wZd56HrV0wdtJkw0wp58sHxM0E/user-view-displays-view-kind>;
-    npx:supersedes <https://w3id.org/np/RA-4lD6SrcEplUkOuCs2G-pCe3gSyuMg2qmH5uuTIDzls>;
-    rdfs:label "View displays view (User)";
+    npx:supersedes <https://w3id.org/np/RAg5UFwfYk7jsE6hxv3f6wF_qaT9B6do6bXDEkdSgRZwc>;
     nt:wasCreatedFromProvenanceTemplate <https://w3id.org/np/RA7lSq6MuK_TIC6JMSHvLtee3lpLoZDOqLJCLXevnrPoU>;
     nt:wasCreatedFromPubinfoTemplate <https://w3id.org/np/RACJ58Gvyn91LqCKIO9zu1eijDQIeEff28iyDrJgjSJF8>,
       <https://w3id.org/np/RAoTD7udB2KtUuOuAe74tJi1t3VzK0DyWS7rYVAq1GRvw>, <https://w3id.org/np/RAukAcWHRDlkqxk7H2XNSegc1WnHI569INvNr-xdptDGI>;
-    nt:wasCreatedFromTemplate <https://w3id.org/np/RA8_hijwsfGCryMYtjtEpec21ZSNY68-qmL0bHRWR0sWM> .
+    nt:wasCreatedFromTemplate <https://w3id.org/np/RAr1Krh98VGXbIc7JVSJpH24bWi2JEVRYfvJ_KJq0wJtc> .
 }
+

--- a/src/main/java/com/knowledgepixels/nanodash/QueryApiAccess.java
+++ b/src/main/java/com/knowledgepixels/nanodash/QueryApiAccess.java
@@ -83,7 +83,11 @@ public class QueryApiAccess {
     // dead RoleDeclaration maintainer arm with a single npa:hasGoverningSpaceRef gate keyed on the
     // materialized npa:hasRoleType (nanopub-query#130 / issue #510); fixes maintainer visibility and
     // cross-ref bleed. No-regression verified against RAd105Rj across resources.
-    public static final String GET_VIEW_DISPLAYS = "RA4TGV_zGtvVPjvffGF6OTbNV-ZmjwIdcZ3-JNYdEhpoE/get-view-displays";
+        // RArKslem (supersedes RA4TGV_z) adds space-governed version resolution (gen:governedBy;
+    // docs/views-and-presets-as-maintained-resources.md): a referenced version declaring a
+    // governing space resolves to the newest member+-signed version of its (kind, space)
+    // pair via a run-once governed sub-select, falling back to the pinned version.
+    public static final String GET_VIEW_DISPLAYS = "RArKslem_skNR9Q9qEpHhIQbJdP47PxDojp40Z5r11Ubs/get-view-displays";
     // Ref-scoped get-view-displays (the Content-tab renderer query): takes the space IRI (resource)
     // AND the ref's root nanopub (root_np) as two concrete params, gating the authorised signers on
     // that ref's admins/maintainers (npa:forSpaceRef) instead of the IRI merged across refs, so the
@@ -95,7 +99,11 @@ public class QueryApiAccess {
     // gated). No-regression verified against RA8iqtd across spaces.
     // RAtZbUry (supersedes RAIpgHc6): same hasGoverningSpaceRef gate as get-view-displays, with the
     // governing ref pinned to ?passedRef so authority cannot bleed across rival refs (issue #510).
-    public static final String GET_VIEW_DISPLAYS_REF = "RAtZbUry42si1BZpBoRBkgbzGweNzfPmOludNIoJYT2VM/get-view-displays";
+        // RActfK6C (supersedes RAtZbUry) adds space-governed version resolution (gen:governedBy;
+    // docs/views-and-presets-as-maintained-resources.md): a referenced version declaring a
+    // governing space resolves to the newest member+-signed version of its (kind, space)
+    // pair via a run-once governed sub-select, falling back to the pinned version.
+    public static final String GET_VIEW_DISPLAYS_REF = "RActfK6Cb1qEPe6in0Ug7IThR_ckkgdNl0mKqF_HOGkqM/get-view-displays";
 
     // Spaces-repo queries (endpoint: nanopub-query .../repo/spaces)
     // v2: IRI-keyed get-spaces. Prior client head, retained for reference; deployments up
@@ -243,7 +251,11 @@ public class QueryApiAccess {
     // literal on hover.
     // RAs9S7c9 (supersedes RA2LG9c5) swaps the authority gate to the npa:hasGoverningSpaceRef gate
     // keyed on materialized npa:hasRoleType (issue #510), preserving the ?position_label column.
-    public static final String LIST_PART_VIEW_DISPLAYS = "RAs9S7c9wdasz2c745f-mBg53JSQ1q20vLLHkmnXCmX2w/list-part-view-displays";
+        // RAKHyaoB (supersedes RAs9S7c9) adds space-governed version resolution (gen:governedBy;
+    // docs/views-and-presets-as-maintained-resources.md): a referenced version declaring a
+    // governing space resolves to the newest member+-signed version of its (kind, space)
+    // pair via a run-once governed sub-select, falling back to the pinned version.
+    public static final String LIST_PART_VIEW_DISPLAYS = "RAKHyaoBCpNdbGsdPLdc8lbxLb4KuLhnmU0V2-NcxHei0/list-part-view-displays";
 
     // Ref-scoped preset-assignment listing (root_np): reads the server-materialised
     // npa:PresetAssignment rows scoped by npa:forSpaceRef from the validated current space-state

--- a/src/main/java/com/knowledgepixels/nanodash/QueryApiAccess.java
+++ b/src/main/java/com/knowledgepixels/nanodash/QueryApiAccess.java
@@ -114,6 +114,14 @@ public class QueryApiAccess {
     // get-space-admins fan-out with a single fetch. Which ref is the representative (default) is
     // decided client-side. Source at docs/queries/list-space-claimants.trig.
     public static final String LIST_SPACE_CLAIMANTS = "RApsQhJnK7MV5fHzFQe4GsnsUdf_HvPT186E02JE-4CTY/list-space-claimants";
+    // Space-governed view-version resolution: given a definition kind (dct:isVersionOf
+    // target) and its governing space, returns at most one row -- the newest version
+    // declaring gen:governedBy that space, signed by a current member+ of the space's
+    // governing ref, with the kind validated as maintained by the space. Empty result =
+    // the caller keeps its pinned version (the pin is the floor). Source at
+    // docs/queries/get-latest-governed-version.trig; see
+    // docs/views-and-presets-as-maintained-resources.md.
+    public static final String GET_LATEST_GOVERNED_VERSION = "RABmOzHjDWhpqoRJsD4XinfDoxDOxKJ8NgJA826O_I-OI/get-latest-governed-version";
     public static final String GET_SUB_SPACE_LINKS = "RAWgoQbP9_B9h3Bnwd1FGYX1gLYPyZFOxaeqIeA3TTPSU/get-sub-space-links";
     public static final String GET_MAINTAINED_RESOURCES = "RAOOq81R84exTUKUBQT3BbgCaSJyC2lqPDXIP2XaDTosM/get-maintained-resources";
     public static final String GET_SPACE_ADMINS = "RAaHOXMQ7Kq37T9syR9at0RqushclHenlPOFRwFDn0Cfs/get-space-admins";

--- a/src/main/java/com/knowledgepixels/nanodash/View.java
+++ b/src/main/java/com/knowledgepixels/nanodash/View.java
@@ -12,11 +12,15 @@ import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.nanopub.Nanopub;
 import org.nanopub.NanopubUtils;
+import org.nanopub.extra.services.ApiResponse;
+import org.nanopub.extra.services.QueryRef;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
 
 import java.io.Serializable;
 import java.util.*;
@@ -121,12 +125,21 @@ public class View implements Serializable {
      *                      the caller already holds a latest-resolved IRI (e.g. from
      *                      the get-view-displays query, which now resolves it
      *                      server-side) to avoid a redundant network round-trip.
+     *                      A version declaring {@code gen:governedBy} still gets the
+     *                      space-based resolution here even with false: its float is
+     *                      not supersedes-based, so the caller's server-side
+     *                      resolution doesn't cover it.
      * @return the View object
      */
     public static View get(String id, boolean resolveLatest) {
         String npId = id.replaceFirst("^(.*[^A-Za-z0-9-_]RA[A-Za-z0-9-_]{43})[^A-Za-z0-9-_].*$", "$1");
         if (!resolveLatest) {
-            return getExactVersion(id, npId);
+            View exact = getExactVersion(id, npId);
+            if (exact == null || exact.getGoverningSpace() == null || exact.getViewKindIri() == null) {
+                return exact;
+            }
+            // fall through to the memoized latest path, which resolves a governed
+            // version space-based (never supersedes-based) for this pin
         }
         Pair<Long, View> memo = latestResolvedViews.getIfPresent(id);
         if (memo != null) {
@@ -143,12 +156,19 @@ public class View implements Serializable {
     }
 
     /**
-     * Resolves a view id to the latest version of its view definition by
-     * following the supersedes chain, falling back to the exact given version
-     * if the lookup fails or doesn't yield a single embedded view IRI. This is
-     * the network-touching part of {@link #get(String)}.
+     * Resolves a view id to the latest version of its view definition, falling
+     * back to the exact given version if the lookup fails or doesn't yield a
+     * single embedded view IRI. This is the network-touching part of
+     * {@link #get(String)}. A version that declares {@code gen:governedBy}
+     * resolves space-based (authority-scoped latest-wins within its
+     * {@code (kind, space)} pair); one that doesn't follows the supersedes
+     * chain as before. See docs/views-and-presets-as-maintained-resources.md.
      */
     private static View resolveLatestVersion(String id, String npId) {
+        View pinned = getExactVersion(id, npId);
+        if (pinned != null && pinned.getGoverningSpace() != null && pinned.getViewKindIri() != null) {
+            return resolveGovernedVersion(pinned);
+        }
         // Automatically selecting latest version of view definition:
         // TODO This should be made configurable at some point, so one can make it a fixed version.
         try {
@@ -171,7 +191,36 @@ public class View implements Serializable {
         } catch (Exception ex) {
             logger.error("Error resolving latest version for view: {}", id, ex);
         }
-        return getExactVersion(id, npId);
+        return pinned;
+    }
+
+    /**
+     * Resolves the latest space-governed version of the pinned view's
+     * {@code (kind, space)} pair: the newest version declaring the same kind and
+     * governing space, signed by a current member+ of that space, with the kind
+     * validated as maintained by the space — all checked server-side by the
+     * {@link QueryApiAccess#GET_LATEST_GOVERNED_VERSION} query. The pin is the
+     * floor: on an empty result (or any failure) the pinned version stands,
+     * un-revalidated.
+     */
+    private static View resolveGovernedVersion(View pinned) {
+        try {
+            Multimap<String, String> params = ArrayListMultimap.create();
+            params.put("kind", pinned.getViewKindIri().stringValue());
+            params.put("space", pinned.getGoverningSpace().stringValue());
+            ApiResponse resp = ApiCache.retrieveResponseSync(new QueryRef(QueryApiAccess.GET_LATEST_GOVERNED_VERSION, params), false);
+            if (resp != null && !resp.getData().isEmpty()) {
+                String latestId = resp.getData().get(0).get("version");
+                if (latestId != null && !latestId.isEmpty() && !latestId.equals(pinned.getId())) {
+                    String latestNpId = latestId.replaceFirst("^(.*[^A-Za-z0-9-_]RA[A-Za-z0-9-_]{43})[^A-Za-z0-9-_].*$", "$1");
+                    View resolved = getExactVersion(latestId, latestNpId);
+                    if (resolved != null) return resolved;
+                }
+            }
+        } catch (Exception ex) {
+            logger.error("Error resolving governed version for view: {}", pinned.getId(), ex);
+        }
+        return pinned;
     }
 
     /**
@@ -218,6 +267,7 @@ public class View implements Serializable {
     private String id;
     private Nanopub nanopub;
     private IRI viewKind;
+    private IRI governingSpace;
     private String label;
     private String title = "View";
     private GrlcQuery query;
@@ -254,6 +304,8 @@ public class View implements Serializable {
                     }
                 } else if (st.getPredicate().equals(DCTERMS.IS_VERSION_OF) && st.getObject() instanceof IRI objIri) {
                     viewKind = objIri;
+                } else if (st.getPredicate().equals(KPXL_TERMS.GOVERNED_BY) && st.getObject() instanceof IRI objIri) {
+                    governingSpace = objIri;
                 } else if (st.getPredicate().equals(RDFS.LABEL)) {
                     label = st.getObject().stringValue();
                 } else if (st.getPredicate().equals(DCTERMS.TITLE)) {
@@ -354,6 +406,17 @@ public class View implements Serializable {
 
     public IRI getViewKindIri() {
         return viewKind;
+    }
+
+    /**
+     * Gets the space governing this view version's {@code (kind, space)} pair via
+     * {@code gen:governedBy}, or null if the version doesn't opt into space
+     * governance (in which case latest-version resolution stays supersedes-based).
+     *
+     * @return the governing space IRI, or null
+     */
+    public IRI getGoverningSpace() {
+        return governingSpace;
     }
 
     /**

--- a/src/main/java/com/knowledgepixels/nanodash/vocabulary/KPXL_TERMS.java
+++ b/src/main/java/com/knowledgepixels/nanodash/vocabulary/KPXL_TERMS.java
@@ -67,6 +67,15 @@ public class KPXL_TERMS {
     public static final IRI IS_DISPLAY_OF_VIEW = VocabUtils.createIRI(NAMESPACE, "isDisplayOfView");
     public static final IRI IS_DISPLAY_FOR = VocabUtils.createIRI(NAMESPACE, "isDisplayFor");
 
+    /**
+     * Links a view/preset version to the space that governs its {@code (kind, space)}
+     * pair for authority-scoped latest-version resolution. A label, not a grant:
+     * authority comes from the kind being maintained by that space plus the version
+     * being signed by a current member+ of it. See
+     * docs/views-and-presets-as-maintained-resources.md.
+     */
+    public static final IRI GOVERNED_BY = VocabUtils.createIRI(NAMESPACE, "governedBy");
+
     // Preset properties (issue #302):
     public static final IRI HAS_TOP_LEVEL_VIEW = VocabUtils.createIRI(NAMESPACE, "hasTopLevelView");
     public static final IRI HAS_VIEW = VocabUtils.createIRI(NAMESPACE, "hasView");


### PR DESCRIPTION
## Summary

Implements the client side of **space-governed view versions** (design: `docs/views-and-presets-as-maintained-resources.md`). A view version declaring `gen:governedBy <space>` (alongside its `dct:isVersionOf` kind) now resolves to the newest version of that `(kind, space)` pair published by a **current member+** of the space — no `npx:supersedes` link or shared signing key needed. Versions without `gen:governedBy` keep today's supersedes-chain resolution, so behavior is unchanged for every existing view.

- `KPXL_TERMS`: new `GOVERNED_BY` term
- `View`: parses `gen:governedBy` → `governingSpace`; `resolveLatestVersion` branches to `resolveGovernedVersion` (query-or-pin, **fails closed to the pinned version** on empty result or error); `get(id, false)` falls through to governed resolution, since the callers' server-side supersedes resolution doesn't cover governance
- `QueryApiAccess`: `GET_LATEST_GOVERNED_VERSION` constant; query source in `docs/queries/get-latest-governed-version.trig`

Both authority anchors are checked server-side by the query (hosted on the spaces repo): the kind is a validated maintained resource of the space (`npa:isMaintainedBy` + `npa:hasGoverningSpaceRef`), and the signer is a member+ (admin/maintainer/member) of the space's governing ref — so `gen:governedBy` is a label, not a grant.

## Published artifacts (live)

| Artifact | ID |
|---|---|
| Resolution query | `RABmOzHj…/get-latest-governed-version` |
| View template "Declaring a resource view (with governed-by)" | `RAr1Krh9…` (derived from `RA8_hijw…`) |
| First governed production view (user view-displays) | `RAg5UFwf…` (kind registration `RAsNvoWV…`) |

## Test plan

- `mvn compile` clean, `ViewTest` passes
- End-to-end on live data: pinned test version floated to a newer governed version (different signing key, no supersedes) once the kind's maintained-resource declaration materialized; empty/missing-anchor cases fall back to the pin
- Governed query and supersedes chain currently agree on the user view-displays view, so old and new code resolve identically during rollout

## Known gap

Server-resolved listing columns (`get-view-displays`/`list-view-displays` family) still show supersedes-heads only; rendering is correct via the client fall-through. Durable fix: knowledgepixels/nanopub-query#138 (type-agnostic canonical-version materialization).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
