### PR TITLE
feat: recognize part membership of plain term IRIs via defining nanopub

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/page/ExplorePage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/ExplorePage.java
@@ -206,18 +206,44 @@ public class ExplorePage extends NanodashPage {
         // Forward to the part page when the explored resource actually qualifies as a
         // part of the context: either explicitly requested via forward-to-part, or
         // whenever the context is a maintained resource. In both cases the membership
-        // is verified below (dct:isPartOf / skos:inScheme or view-display applicability)
-        // rather than assumed from the context type.
+        // is verified below (dct:isPartOf / dct:isVersionOf / skos:inScheme or
+        // view-display applicability) rather than assumed from the context type.
         boolean contextIsMaintainedResource = !contextId.isEmpty() && MaintainedResourceRepository.get().findById(contextId) != null;
         if ((parameters.get("forward-to-part").toString("").equals("true") || contextIsMaintainedResource) && !contextId.isEmpty() && publishedNanopub == null) {
             parameters.remove("forward-to-part");
+            AbstractResourceWithProfile contextResource = AbstractResourceWithProfile.get(contextId);
+            if (contextResource instanceof IndividualAgent && !IndividualAgent.isUser(contextId)) {
+                contextResource = null;
+            }
+            // A plain (non-trusty) term IRI doesn't resolve to a nanopub by itself; look
+            // up its defining nanopub among those signed by the context's space members,
+            // the same way ResourcePartPage does.
+            Nanopub termNp = np;
+            if (termNp == null && contextResource != null) {
+                QueryRef getDefQuery = new QueryRef(QueryApiAccess.GET_TERM_DEFINITIONS, "term", tempRef);
+                if (contextResource.getSpace() != null) {
+                    for (IRI userIri : contextResource.getSpace().getUsers()) {
+                        for (String pubkey : User.getUserData().getPubkeyHashes(userIri, true)) {
+                            getDefQuery.getParams().put("pubkey", pubkey);
+                        }
+                    }
+                } else {
+                    for (String pubkey : User.getUserData().getPubkeyHashes(Utils.vf.createIRI(contextId), true)) {
+                        getDefQuery.getParams().put("pubkey", pubkey);
+                    }
+                }
+                ApiResponse getDefResp = ApiCache.retrieveResponseSync(getDefQuery, false);
+                if (getDefResp != null && !getDefResp.getData().isEmpty()) {
+                    termNp = Utils.getAsNanopub(getDefResp.getData().iterator().next().get("np"));
+                }
+            }
             Set<IRI> classes = new HashSet<>();
-            if (np != null) {
-                Set<String> introducedIds = NanopubUtils.getIntroducedIriIds(np);
+            if (termNp != null) {
+                Set<String> introducedIds = NanopubUtils.getIntroducedIriIds(termNp);
                 if (introducedIds.size() == 1 && introducedIds.iterator().next().equals(tempRef)) {
-                    for (Statement st : np.getAssertion()) {
+                    for (Statement st : termNp.getAssertion()) {
                         if (!st.getSubject().stringValue().equals(tempRef)) continue;
-                        if (st.getPredicate().equals(DCTERMS.IS_PART_OF) || st.getPredicate().equals(SKOS.IN_SCHEME)) {
+                        if (st.getPredicate().equals(DCTERMS.IS_PART_OF) || st.getPredicate().equals(DCTERMS.IS_VERSION_OF) || st.getPredicate().equals(SKOS.IN_SCHEME)) {
                             String resourceId = st.getObject().stringValue();
                             if (MaintainedResourceRepository.get().findById(resourceId) == null) continue;
                             throw new RestartResponseException(ResourcePartPage.class, parameters);
@@ -226,10 +252,6 @@ public class ExplorePage extends NanodashPage {
                         }
                     }
                 }
-            }
-            AbstractResourceWithProfile contextResource = AbstractResourceWithProfile.get(contextId);
-            if (contextResource instanceof IndividualAgent && !IndividualAgent.isUser(contextId)) {
-                contextResource = null;
             }
             if (contextResource != null && contextResource.appliesTo(tempRef, classes)) {
                 throw new RestartResponseException(ResourcePartPage.class, parameters);


### PR DESCRIPTION
## Problem

Exploring a plain term IRI (e.g. `https://w3id.org/spaces/biochementity/r/vocabulary/version/0.0.1`) with its owning maintained resource as context did not forward to the part page, even when the term's defining nanopub asserts `dct:isPartOf` pointing at that resource.

The explicit part-membership check in `ExplorePage` had a hidden precondition: it only ran when the explored ref itself resolved to a nanopub (trusty URI, or an `RA…` artifact code embedded in the ref). Clean term IRIs yield `np == null` there, so their assertions were never read and the check silently fell through to the namespace fallback — which doesn't cover nested IRIs or resources whose declared namespace differs from their own IRI.

## Change

- When the ref doesn't resolve to a nanopub and a context resource is given, look up the term's defining nanopub via `get-term-definitions`, scoped to the context space's member pubkeys (the same pattern `ResourcePartPage` already uses), and run the existing membership check on that nanopub's assertion.
- Add `dct:isVersionOf` to the recognized containment predicates alongside `dct:isPartOf` and `skos:inScheme`, so version nanopubs are recognized without an extra `isPartOf` triple.

## Verified

On a local jetty instance: `/explore?id=<version-IRI>&context=<vocabulary-IRI>` now 302s to `/part`, which renders with the label from the defining nanopub (`RApNpf1B…`). Context-less visits to the bare IRI still land on the generic explore page — term→resource discovery without a context remains deferred (needs a trust-gated global lookup or server-side materialization, as discussed in #519).

🤖 Generated with [Claude Code](https://claude.com/claude-code)