### PR TITLE
feat: persistent navigation context with back-link and post-publish forwarding

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/NavigationContext.java
+++ b/src/main/java/com/knowledgepixels/nanodash/NavigationContext.java
@@ -1,0 +1,158 @@
+package com.knowledgepixels.nanodash;
+
+import com.knowledgepixels.nanodash.domain.AbstractResourceWithProfile;
+import com.knowledgepixels.nanodash.domain.IndividualAgent;
+import com.knowledgepixels.nanodash.domain.MaintainedResource;
+import com.knowledgepixels.nanodash.domain.Space;
+import com.knowledgepixels.nanodash.page.HomePage;
+import com.knowledgepixels.nanodash.page.MaintainedResourcePage;
+import com.knowledgepixels.nanodash.page.NanodashPage;
+import com.knowledgepixels.nanodash.page.ResourcePartPage;
+import com.knowledgepixels.nanodash.page.SpacePage;
+import com.knowledgepixels.nanodash.page.UserPage;
+import org.apache.wicket.Component;
+import org.apache.wicket.RestartResponseException;
+import org.apache.wicket.behavior.Behavior;
+import org.apache.wicket.markup.html.link.BookmarkablePageLink;
+import org.apache.wicket.request.mapper.parameter.PageParameters;
+import org.nanopub.Nanopub;
+
+/**
+ * The navigation context: the space, user, or maintained resource a page was reached
+ * under, carried across pages as the {@code context} URL parameter. It determines where
+ * the user is forwarded to after publishing a nanopub and where the title bar's
+ * back-link points on pages that are not themselves a context resource's page.
+ */
+public class NavigationContext {
+
+    private NavigationContext() {
+    }
+
+    /**
+     * Name of the page parameter holding the navigation context resource id.
+     */
+    public static final String CONTEXT_PARAM = "context";
+
+    /**
+     * Reads the navigation context id from the given page parameters.
+     *
+     * @param params the page parameters
+     * @return the context resource id, or null if not set
+     */
+    public static String getContextId(PageParameters params) {
+        if (params == null) return null;
+        String contextId = params.get(CONTEXT_PARAM).toString("");
+        return contextId.isEmpty() ? null : contextId;
+    }
+
+    /**
+     * Resolves a context id to its space, maintained resource, or user. Agents are
+     * created lazily, so a plain {@link AbstractResourceWithProfile#get(String)} lookup
+     * alone would miss users not touched yet this session; hence the explicit user check.
+     *
+     * @param contextId the context resource id
+     * @return the resolved resource, or null if the id is not a known space, maintained resource, or user
+     */
+    public static AbstractResourceWithProfile resolve(String contextId) {
+        if (contextId == null || contextId.isEmpty()) return null;
+        AbstractResourceWithProfile resource = AbstractResourceWithProfile.get(contextId);
+        if (resource == null && IndividualAgent.isUser(contextId)) {
+            resource = IndividualAgent.get(contextId);
+        }
+        if (resource instanceof IndividualAgent && !IndividualAgent.isUser(contextId)) return null;
+        return resource;
+    }
+
+    /**
+     * The page class showing the given resource.
+     *
+     * @param resource the context resource
+     * @return the page class, or null if the resource is null
+     */
+    public static Class<? extends NanodashPage> getPageClass(AbstractResourceWithProfile resource) {
+        if (resource instanceof Space) return SpacePage.class;
+        if (resource instanceof MaintainedResource) return MaintainedResourcePage.class;
+        if (resource instanceof IndividualAgent) return UserPage.class;
+        return null;
+    }
+
+    /**
+     * A page reference (link target + label) for the given context id.
+     *
+     * @param contextId the context resource id
+     * @return the page reference, or null if the id cannot be resolved
+     */
+    public static NanodashPageRef getPageRef(String contextId) {
+        AbstractResourceWithProfile resource = resolve(contextId);
+        if (resource == null) return null;
+        return new NanodashPageRef(getPageClass(resource), new PageParameters().set("id", contextId), resource.getLabel());
+    }
+
+    /**
+     * Sets the given context id on the parameters, unless it is null or a context is
+     * already set (call sites that know the context resource remain authoritative).
+     *
+     * @param params    the page parameters to extend
+     * @param contextId the context resource id, or null for a no-op
+     * @return the same page parameters, for chaining
+     */
+    public static PageParameters withContext(PageParameters params, String contextId) {
+        if (contextId != null && !contextId.isEmpty() && params.get(CONTEXT_PARAM).isEmpty()) {
+            params.set(CONTEXT_PARAM, contextId);
+        }
+        return params;
+    }
+
+    /**
+     * A behavior that fills in the page's navigation context on a
+     * {@link BookmarkablePageLink} that doesn't carry one yet. Useful where the context
+     * id isn't at hand when the link is built (e.g. nanopub cards); runs at configure
+     * time, when the component is attached to its page.
+     *
+     * @return the context-fallback behavior
+     */
+    public static Behavior pageContextFallback() {
+        return new Behavior() {
+            @Override
+            public void onConfigure(Component component) {
+                if (component instanceof BookmarkablePageLink<?> link && component.getPage() instanceof NanodashPage page
+                        && link.getPageParameters() != null) {
+                    withContext(link.getPageParameters(), page.getContextId());
+                }
+            }
+        };
+    }
+
+    /**
+     * Forwards to the page of the context resource (or its part) after a successful
+     * publication, with the just-published nanopub shown only in the title bar message;
+     * forwards to the home page if no (resolvable) context is set. Always throws.
+     *
+     * @param signedNp   the just-published nanopub
+     * @param pageParams the parameters of the publish form's page
+     */
+    public static void redirectAfterPublish(Nanopub signedNp, PageParameters pageParams) {
+        String npUri = signedNp.getUri().stringValue();
+        String contextId = getContextId(pageParams);
+        if (contextId != null) {
+            PageParameters redirectParams = new PageParameters().set("just-published", npUri);
+            String partId = pageParams.get("part").toString("");
+            if (!partId.isEmpty()) {
+                // User was on a part page (e.g. paper collection); redirect back to the part page
+                redirectParams.set("id", partId).set(CONTEXT_PARAM, contextId);
+                throw new RestartResponseException(ResourcePartPage.class, redirectParams);
+            }
+            redirectParams.set("id", contextId);
+            // Return to the tab the action asked for (e.g. "about" for a
+            // space's About-tab role actions); default is the Content tab.
+            String postpubTab = pageParams.get("postpub-tab").toString("");
+            if (!postpubTab.isEmpty()) redirectParams.set("tab", postpubTab);
+            AbstractResourceWithProfile resource = resolve(contextId);
+            if (resource != null) {
+                throw new RestartResponseException(getPageClass(resource), redirectParams);
+            }
+        }
+        throw new RestartResponseException(HomePage.class, new PageParameters().set("just-published", npUri));
+    }
+
+}

--- a/src/main/java/com/knowledgepixels/nanodash/QueryResult.java
+++ b/src/main/java/com/knowledgepixels/nanodash/QueryResult.java
@@ -12,6 +12,8 @@ import org.nanopub.extra.services.QueryRef;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Abstract base class for displaying query results in different formats.
@@ -156,6 +158,61 @@ public abstract class QueryResult extends Panel {
             parameters.set("context", contextId);
         }
         menuActions.add(new MenuAction(label, pageClass, parameters));
+    }
+
+    /**
+     * The navigation context to stamp on links in result cells: this view's context
+     * resource if bound to one, else the page's navigation context. Only usable at
+     * render time (needs the page).
+     *
+     * @return the context id, or null if neither is set
+     */
+    private String renderContextId() {
+        if (contextId != null) return contextId;
+        if (getPage() instanceof NanodashPage nanodashPage) return nanodashPage.getContextId();
+        return null;
+    }
+
+    /**
+     * The {@code &context=...} URL suffix for template/query links in result cells.
+     * Empty string when no context is set. Only usable at render time (needs the page).
+     *
+     * @return the context URL parameter suffix, possibly empty
+     */
+    protected String templateLinkContextParam() {
+        String ctx = renderContextId();
+        return ctx == null ? "" : "&context=" + Utils.urlEncode(ctx);
+    }
+
+    private static final Pattern INTERNAL_HREF_PATTERN = Pattern.compile("href=\"(/[^\"]*)\"");
+
+    /**
+     * Appends the navigation context to app-internal links ({@code href="/..."}) inside
+     * sanitized result-cell HTML, so ready-made links coming from the query data itself
+     * (e.g. template or query links emitted by the SPARQL) also lead back to the
+     * current context. Links already carrying a context are left alone.
+     *
+     * @param sanitizedHtml the sanitized cell HTML, or null
+     * @return the HTML with context-enriched internal links
+     */
+    protected String withContextInHtmlLinks(String sanitizedHtml) {
+        String ctx = renderContextId();
+        if (ctx == null || sanitizedHtml == null) return sanitizedHtml;
+        String encodedCtx = Utils.urlEncode(ctx);
+        Matcher m = INTERNAL_HREF_PATTERN.matcher(sanitizedHtml);
+        StringBuilder sb = new StringBuilder();
+        while (m.find()) {
+            String url = m.group(1);
+            String replacement = m.group();
+            // The sanitizer escapes "=" as "&#61;", so check both spellings.
+            if (!url.contains("context=") && !url.contains("context&#61;")) {
+                String separator = url.contains("?") ? "&amp;" : "?";
+                replacement = "href=\"" + url + separator + "context=" + encodedCtx + "\"";
+            }
+            m.appendReplacement(sb, Matcher.quoteReplacement(replacement));
+        }
+        m.appendTail(sb);
+        return sb.toString();
     }
 
     /**

--- a/src/main/java/com/knowledgepixels/nanodash/component/NanodashLink.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/NanodashLink.java
@@ -1,10 +1,11 @@
 package com.knowledgepixels.nanodash.component;
 
+import com.knowledgepixels.nanodash.NavigationContext;
+import com.knowledgepixels.nanodash.Utils;
 import com.knowledgepixels.nanodash.domain.IndividualAgent;
 import com.knowledgepixels.nanodash.domain.MaintainedResource;
 import com.knowledgepixels.nanodash.domain.Space;
 import com.knowledgepixels.nanodash.domain.User;
-import com.knowledgepixels.nanodash.Utils;
 import com.knowledgepixels.nanodash.connector.ios.DsConfig;
 import com.knowledgepixels.nanodash.connector.ios.DsNanopubPage;
 import com.knowledgepixels.nanodash.connector.pensoft.BdjConfig;
@@ -168,6 +169,16 @@ public class NanodashLink extends Panel {
      * @return a {@link org.apache.wicket.Component} object
      */
     public static Component createLink(String markupId, String uri, String label, String contextId) {
+        Component link = createLinkComponent(markupId, uri, label, contextId);
+        // Fall back to the page's navigation context when the caller didn't supply one
+        // (e.g. nanopub cards), so the target page's back-link still points back here.
+        if (link instanceof BookmarkablePageLink) {
+            link.add(NavigationContext.pageContextFallback());
+        }
+        return link;
+    }
+
+    private static Component createLinkComponent(String markupId, String uri, String label, String contextId) {
         boolean isNp = TrustyUriUtils.isPotentialTrustyUri(uri);
         PageParameters params = new PageParameters().set("id", uri);
         if (contextId != null) params.set("context", contextId);

--- a/src/main/java/com/knowledgepixels/nanodash/component/NanopubItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/NanopubItem.java
@@ -133,7 +133,8 @@ public class NanopubItem extends Panel {
                 protected void populateItem(Item<IRI> item) {
                     IRI typeIri = item.getModelObject();
                     String label = Utils.getTypeLabel(typeIri);
-                    item.add(new BookmarkablePageLink<Void>("type", ListPage.class, new PageParameters().add("type", typeIri)).setBody(Model.of(label)));
+                    item.add(new BookmarkablePageLink<Void>("type", ListPage.class, new PageParameters().add("type", typeIri)).setBody(Model.of(label))
+                            .add(NavigationContext.pageContextFallback()));
                 }
 
             });

--- a/src/main/java/com/knowledgepixels/nanodash/component/ProfileAccountPanel.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/ProfileAccountPanel.java
@@ -65,6 +65,7 @@ public class ProfileAccountPanel extends Panel {
                     + "&param_key-declaration=" + Utils.urlEncode(shortKey)
                     + "&param_key-declaration-ref=" + Utils.urlEncode(shortKey)
                     + "&param_key-location=" + Utils.urlEncode(prefs.getWebsiteUrl())
+                    + "&context=" + Utils.urlEncode(userIriString)
                     + "&postpub-redirect-url=" + Utils.urlEncode(aboutUrl)
                     + "&link-message=" + Utils.urlEncode("Check the checkbox at the end of this page and press 'Publish' to "
                             + "publish this introduction linking your ORCID identifier to the local key used on this site.");

--- a/src/main/java/com/knowledgepixels/nanodash/component/PublishForm.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/PublishForm.java
@@ -3,11 +3,8 @@ package com.knowledgepixels.nanodash.component;
 import com.knowledgepixels.nanodash.*;
 import com.knowledgepixels.nanodash.domain.AbstractResourceWithProfile;
 import com.knowledgepixels.nanodash.vocabulary.KPXL_TERMS;
-import com.knowledgepixels.nanodash.domain.IndividualAgent;
 import com.knowledgepixels.nanodash.domain.User;
 import com.knowledgepixels.nanodash.page.*;
-import com.knowledgepixels.nanodash.repository.MaintainedResourceRepository;
-import com.knowledgepixels.nanodash.repository.SpaceRepository;
 import com.knowledgepixels.nanodash.template.*;
 import org.apache.commons.lang3.Strings;
 import org.apache.wicket.Component;
@@ -490,35 +487,16 @@ public class PublishForm extends Panel {
                             && AbstractResourceWithProfile.isResourceWithProfile(contextId)) {
                         WicketApplication.get().notifyNanopubPublished(signedNp, contextId, 5 * 1000);
                     }
-                    String partId = pageParams.get("part").toString("");
-                    if (!contextId.isEmpty() && pageParams.get("postpub-redirect-url").isEmpty()) {
-                        PageParameters redirectParams = new PageParameters().set("just-published", signedNp.getUri().stringValue());
-                        if (!partId.isEmpty()) {
-                            // User was on a part page (e.g. paper collection); redirect back to the part page
-                            redirectParams.set("id", partId).set("context", contextId);
-                            throw new RestartResponseException(ResourcePartPage.class, redirectParams);
-                        }
-                        redirectParams.set("id", contextId);
-                        // Return to the tab the action asked for (e.g. "about" for a
-                        // space's About-tab role actions); default is the Content tab.
-                        String postpubTab = pageParams.get("postpub-tab").toString("");
-                        if (!postpubTab.isEmpty()) redirectParams.set("tab", postpubTab);
-                        if (SpaceRepository.get().findById(contextId) != null) {
-                            throw new RestartResponseException(SpacePage.class, redirectParams);
-                        }
-                        if (MaintainedResourceRepository.get().findById(contextId) != null) {
-                            throw new RestartResponseException(MaintainedResourcePage.class, redirectParams);
-                        }
-                        if (IndividualAgent.isUser(contextId)) {
-                            throw new RestartResponseException(UserPage.class, redirectParams);
-                        }
+                    if (pageParams.get("postpub-redirect-url").isEmpty() && confirmPageClass == null) {
+                        // Forward to the context resource's page, or home if no context; always throws.
+                        NavigationContext.redirectAfterPublish(signedNp, pageParams);
                     }
+                    // Connector flow: show the connector's own confirmation page.
                     NanodashPage confirmPage = getConfirmPage(signedNp, pageParams);
                     if (confirmPage != null) {
                         throw new RestartResponseException(confirmPage);
                     }
-                    throw new RestartResponseException(ExplorePage.class,
-                            new PageParameters(pageParams).set("id", signedNp.getUri().stringValue()));
+                    NavigationContext.redirectAfterPublish(signedNp, pageParams);
                 }
             }
 
@@ -1022,6 +1000,7 @@ public class PublishForm extends Panel {
     }
 
     private NanodashPage getConfirmPage(Nanopub signedNp, PageParameters pageParams) {
+        if (confirmPageClass == null) return null;
         try {
             return (NanodashPage) confirmPageClass.getConstructor(Nanopub.class, PageParameters.class).newInstance(signedNp, pageParams);
         } catch (InstantiationException | IllegalAccessException | IllegalArgumentException |

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultItemList.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultItemList.java
@@ -97,7 +97,7 @@ public class QueryResultItemList extends QueryResult {
                         return;
                     } else if (key.endsWith("template_iri")) {
                         String displayLabel = (entryLabel != null && !entryLabel.isBlank()) ? entryLabel : value;
-                        String templateUrl = PublishPage.MOUNT_PATH + "?template=" + Utils.urlEncode(value) + "&template-version=latest";
+                        String templateUrl = PublishPage.MOUNT_PATH + "?template=" + Utils.urlEncode(value) + "&template-version=latest" + templateLinkContextParam();
                         String html = "<span class=\"form-icon\"></span> <a href=\"" + Strings.escapeMarkup(templateUrl) + "\">" + Strings.escapeMarkup(displayLabel) + "</a>";
                         item.add(new Label("listItem", html).setEscapeModelStrings(false));
                         return;

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultList.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultList.java
@@ -136,7 +136,7 @@ public class QueryResultList extends QueryResult {
                         } else if (key.endsWith("template_iri")) {
                             String templateLabel = entry.get(key + "_label");
                             String displayLabel = templateLabel != null && !templateLabel.isBlank() ? templateLabel : entryValue;
-                            String templateUrl = PublishPage.MOUNT_PATH + "?template=" + Utils.urlEncode(entryValue) + "&template-version=latest";
+                            String templateUrl = PublishPage.MOUNT_PATH + "?template=" + Utils.urlEncode(entryValue) + "&template-version=latest" + templateLinkContextParam();
                             String linkHtml = "<a href=\"" + Strings.escapeMarkup(templateUrl) + "\">" + Strings.escapeMarkup(displayLabel) + "</a>";
                             components.add(new ComponentSequence("component", " ", List.of(
                                     new Label("component", "<span class=\"form-icon\"></span>").setEscapeModelStrings(false),
@@ -144,7 +144,7 @@ public class QueryResultList extends QueryResult {
                         } else if (key.endsWith("query_iri")) {
                             String queryLabel = entry.get(key + "_label");
                             String displayLabel = queryLabel != null && !queryLabel.isBlank() ? queryLabel : entryValue;
-                            String queryUrl = QueryPage.MOUNT_PATH + "?id=" + Utils.urlEncode(entryValue);
+                            String queryUrl = QueryPage.MOUNT_PATH + "?id=" + Utils.urlEncode(entryValue) + templateLinkContextParam();
                             String linkHtml = "<a href=\"" + Strings.escapeMarkup(queryUrl) + "\">" + Strings.escapeMarkup(displayLabel) + "</a>";
                             components.add(new Label("component", linkHtml).setEscapeModelStrings(false));
                         } else if (key.endsWith("_multi_iri")) {
@@ -184,7 +184,7 @@ public class QueryResultList extends QueryResult {
                                         String display = label != null ? label : unescaped;
                                         boolean isHtml = Utils.looksLikeHtml(display);
                                         if (isHtml) {
-                                            display = Utils.sanitizeHtml(display);
+                                            display = withContextInHtmlLinks(Utils.sanitizeHtml(display));
                                         }
                                         multiComponents.add(new Label("component", display).setEscapeModelStrings(!isHtml));
                                     }
@@ -225,7 +225,7 @@ public class QueryResultList extends QueryResult {
                             } else {
                                 String display = hasLabel ? entryLabel : entryValue;
                                 if (Utils.looksLikeHtml(display)) {
-                                    display = Utils.sanitizeHtml(display);
+                                    display = withContextInHtmlLinks(Utils.sanitizeHtml(display));
                                 } else if (hasLabel) {
                                     display = Strings.escapeMarkup(display).toString();
                                 }
@@ -288,6 +288,7 @@ public class QueryResultList extends QueryResult {
                 if (sourceUri != null) {
                     AbstractLink sourceLink = new BookmarkablePageLink<NanodashPage>("link", ExplorePage.class,
                             new PageParameters().set("id", sourceUri));
+                    sourceLink.add(NavigationContext.pageContextFallback());
                     sourceLink.setBody(Model.of("<span class=\"actionmenu-icon\">↗︎</span>source")).setEscapeModelStrings(false);
                     actionLinks.add(sourceLink);
                 }

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultPlainParagraph.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultPlainParagraph.java
@@ -1,6 +1,7 @@
 package com.knowledgepixels.nanodash.component;
 
 import com.knowledgepixels.nanodash.FilteredQueryResultDataProvider;
+import com.knowledgepixels.nanodash.NavigationContext;
 import com.knowledgepixels.nanodash.QueryResult;
 import com.knowledgepixels.nanodash.QueryResultDataProvider;
 import com.knowledgepixels.nanodash.Utils;
@@ -106,6 +107,7 @@ public class QueryResultPlainParagraph extends QueryResult {
                     List<AbstractLink> links = new ArrayList<>();
                     BookmarkablePageLink<Void> sourceLink = new BookmarkablePageLink<>("link", ExplorePage.class,
                             new PageParameters().set("id", npId));
+                    sourceLink.add(NavigationContext.pageContextFallback());
                     sourceLink.setBody(Model.of("<span class=\"actionmenu-icon\">↗︎</span>source")).setEscapeModelStrings(false);
                     links.add(sourceLink);
                     header.add(new EntryActionMenu("pnp", links));
@@ -114,7 +116,7 @@ public class QueryResultPlainParagraph extends QueryResult {
                 }
                 item.add(header);
                 String content = item.getModelObject().get("content");
-                item.add(new Label("content", content == null ? null : Utils.sanitizeHtml(content)).setEscapeModelStrings(false));
+                item.add(new Label("content", content == null ? null : withContextInHtmlLinks(Utils.sanitizeHtml(content))).setEscapeModelStrings(false));
             }
         };
     }

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultTable.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultTable.java
@@ -319,6 +319,7 @@ public class QueryResultTable extends QueryResult {
                         if (sourceUri != null && !sourceUri.isBlank()) {
                             AbstractLink sourceLink = new BookmarkablePageLink<NanodashPage>("link", ExplorePage.class,
                                     new PageParameters().set("id", sourceUri));
+                            sourceLink.add(NavigationContext.pageContextFallback());
                             sourceLink.setBody(Model.of("<span class=\"actionmenu-icon\">↗︎</span>source")).setEscapeModelStrings(false);
                             links.add(sourceLink);
                         }
@@ -370,7 +371,7 @@ public class QueryResultTable extends QueryResult {
                                 } else {
                                     String display = label != null ? label : unescaped;
                                     if (Utils.looksLikeHtml(display)) {
-                                        components.add(new Label("component", Utils.sanitizeHtml(display))
+                                        components.add(new Label("component", withContextInHtmlLinks(Utils.sanitizeHtml(display)))
                                                 .setEscapeModelStrings(false)
                                                 .add(new AttributeAppender("class", "cell-data-html")));
                                     } else {
@@ -394,7 +395,7 @@ public class QueryResultTable extends QueryResult {
                                 components.add(new Label("component", Utils.friendlyDateHtml(display, display))
                                         .setEscapeModelStrings(false));
                             } else if (Utils.looksLikeHtml(display)) {
-                                components.add(new Label("component", Utils.sanitizeHtml(display))
+                                components.add(new Label("component", withContextInHtmlLinks(Utils.sanitizeHtml(display)))
                                         .setEscapeModelStrings(false)
                                         .add(new AttributeAppender("class", "cell-data-html")));
                             } else {
@@ -405,7 +406,7 @@ public class QueryResultTable extends QueryResult {
                     } else if (key.endsWith("template_iri")) {
                         String label = truncateLabel(rowModel.getObject().get(key + "_label"));
                         if (label == null || label.isBlank()) label = truncateLabel(value);
-                        String templateUrl = PublishPage.MOUNT_PATH + "?template=" + Utils.urlEncode(value) + "&template-version=latest";
+                        String templateUrl = PublishPage.MOUNT_PATH + "?template=" + Utils.urlEncode(value) + "&template-version=latest" + templateLinkContextParam();
                         String html = "<a href=\"" + Strings.escapeMarkup(templateUrl) + "\">" + Strings.escapeMarkup(label) + "</a>";
                         cellItem.add(new Label(componentId, html).setEscapeModelStrings(false));
                     } else if (value.matches("https?://.+")) {
@@ -416,7 +417,7 @@ public class QueryResultTable extends QueryResult {
                         if (litLabel != null && !litLabel.isBlank() && !litLabel.equals(value)) {
                             // Separate display label for a (non-IRI) literal value; the full
                             // literal is shown on hover via the standard styled tooltip.
-                            String labelHtml = Utils.looksLikeHtml(litLabel) ? Utils.sanitizeHtml(litLabel) : Strings.escapeMarkup(litLabel).toString();
+                            String labelHtml = Utils.looksLikeHtml(litLabel) ? withContextInHtmlLinks(Utils.sanitizeHtml(litLabel)) : Strings.escapeMarkup(litLabel).toString();
                             String html = "<span class=\"tooltip\"><span class=\"tooltiptext tooltiptext-auto\">" + Strings.escapeMarkup(value) + "</span>" + labelHtml + "</span>";
                             cellItem.add(new Label(componentId, html).setEscapeModelStrings(false));
                         } else if (key.startsWith("pubkey")) {
@@ -427,7 +428,7 @@ public class QueryResultTable extends QueryResult {
                         } else {
                             Label cellLabel;
                             if (Utils.looksLikeHtml(value)) {
-                                cellLabel = (Label) new Label(componentId, Utils.sanitizeHtml(value))
+                                cellLabel = (Label) new Label(componentId, withContextInHtmlLinks(Utils.sanitizeHtml(value)))
                                         .setEscapeModelStrings(false)
                                         .add(new AttributeAppender("class", "cell-data-html"));
                             } else {

--- a/src/main/java/com/knowledgepixels/nanodash/component/TemplateItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/TemplateItem.java
@@ -1,7 +1,9 @@
 package com.knowledgepixels.nanodash.component;
 
 import com.knowledgepixels.nanodash.domain.User;
+import com.knowledgepixels.nanodash.NavigationContext;
 import com.knowledgepixels.nanodash.Utils;
+import com.knowledgepixels.nanodash.page.NanodashPage;
 import com.knowledgepixels.nanodash.page.PublishPage;
 import com.knowledgepixels.nanodash.template.Template;
 import net.trustyuri.TrustyUriUtils;
@@ -30,6 +32,20 @@ public class TemplateItem extends Panel {
     private static final Logger logger = LoggerFactory.getLogger(TemplateItem.class);
 
     /**
+     * Parameters of the publish link, kept so the page's navigation context can be
+     * added in {@link #onInitialize()} (the page is not available in the constructor).
+     */
+    private PageParameters publishLinkParams;
+
+    @Override
+    protected void onInitialize() {
+        super.onInitialize();
+        if (getPage() instanceof NanodashPage nanodashPage) {
+            NavigationContext.withContext(publishLinkParams, nanodashPage.getContextId());
+        }
+    }
+
+    /**
      * A single template item in a list, showing the template name, user, and timestamp.
      *
      * @param id    the wicket id of this component
@@ -53,6 +69,7 @@ public class TemplateItem extends Panel {
         params.set("template", entry.get("np"));
         params.set("template-version", "latest");
         if (additionalParams != null) params.mergeWith(additionalParams);
+        publishLinkParams = params;
         BookmarkablePageLink<Void> l = new BookmarkablePageLink<Void>("link", PublishPage.class, params);
         String label = entry.get("label");
         if (label == null || label.isBlank()) label = TrustyUriUtils.getArtifactCode(entry.get("np")).substring(0, 10);
@@ -102,6 +119,7 @@ public class TemplateItem extends Panel {
         params.set("template", template.getId());
         params.set("template-version", "latest");
         if (additionalParams != null) params.mergeWith(additionalParams);
+        publishLinkParams = params;
         BookmarkablePageLink<Void> l = new BookmarkablePageLink<Void>("link", PublishPage.class, params);
         l.add(new Label("name", template.getLabel()));
         add(l);

--- a/src/main/java/com/knowledgepixels/nanodash/component/TitleBar.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/TitleBar.html
@@ -33,7 +33,7 @@
 <div class="row-section">
 <div class="col-12 breadcrumb-tab-row">
 
-<span class="breadcrumb-links" wicket:id="breadcrumblinks"><a wicket:id="firstpathelement" href="."><span wicket:id="firstpathelement-label">Top Level</span></a><span wicket:id="morepathelements">
+<span class="breadcrumb-links" wicket:id="backcontext-container"><span class="nextlevel">&lt;</span> <a wicket:id="backcontext" href="."><span wicket:id="backcontext-label">Home</span></a></span><span class="breadcrumb-links" wicket:id="breadcrumblinks"><a wicket:id="firstpathelement" href="."><span wicket:id="firstpathelement-label">Top Level</span></a><span wicket:id="morepathelements">
 <span class="nextlevel">&gt;</span> <a wicket:id="furtherpathelement" href="."><span wicket:id="furtherpathelement-label">Lower Level</span></a>
 </span></span><span class="tabs-container" wicket:id="tabs"></span>
 

--- a/src/main/java/com/knowledgepixels/nanodash/component/TitleBar.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/TitleBar.java
@@ -14,9 +14,14 @@ import org.apache.wicket.markup.repeater.Item;
 import org.apache.wicket.markup.repeater.data.DataView;
 import org.apache.wicket.markup.repeater.data.ListDataProvider;
 
+import org.apache.wicket.request.mapper.parameter.PageParameters;
+
 import com.knowledgepixels.nanodash.NanodashPageRef;
 import com.knowledgepixels.nanodash.NanodashPreferences;
+import com.knowledgepixels.nanodash.NavigationContext;
 import com.knowledgepixels.nanodash.Utils;
+import com.knowledgepixels.nanodash.page.ExplorePage;
+import com.knowledgepixels.nanodash.page.HomePage;
 import com.knowledgepixels.nanodash.page.NanodashPage;
 import com.knowledgepixels.nanodash.page.PublishPage;
 import com.knowledgepixels.nanodash.page.QueryListPage;
@@ -56,12 +61,20 @@ public class TitleBar extends Panel {
         // always-on "you haven't published an introduction yet" warning.
         add(new JustPublishedMessagePanel("justPublishedMessage", page.getPageParameters()));
 
-        createNavLink("users", UserListPage.class);
-        createNavLink("connectors", SpaceListPage.class);
-        createNavLink("publish", PublishPage.class).setVisible(!NanodashPreferences.get().isReadOnlyMode());
-        createNavLink("query", QueryListPage.class);
+        // Nav links carry the page's navigation context along, so e.g. publishing via
+        // the "publish" link forwards back to the space/user/resource one came from.
+        PageParameters navParams = NavigationContext.withContext(new PageParameters(), page.getContextId());
+        createNavLink("users", UserListPage.class, navParams);
+        createNavLink("connectors", SpaceListPage.class, navParams);
+        createNavLink("publish", PublishPage.class, navParams).setVisible(!NanodashPreferences.get().isReadOnlyMode());
+        createNavLink("query", QueryListPage.class, navParams);
 
         breadcrumbPath = new WebMarkupContainer("breadcrumbpath");
+        if (page.hasFullWidthContent()) {
+            // Full-width pages (e.g. query pages): the strip's row follows the
+            // content to the left edge instead of centering at the standard width.
+            breadcrumbPath.add(new AttributeAppender("class", " fullwidth"));
+        }
         WebMarkupContainer breadcrumbLinks = new WebMarkupContainer("breadcrumblinks");
         List<CrumbPart> crumbParts = buildCrumbParts(pathRefs);
         if (!crumbParts.isEmpty()) {
@@ -82,12 +95,50 @@ public class TitleBar extends Panel {
             breadcrumbLinks.setVisible(false);
         }
         breadcrumbPath.add(breadcrumbLinks);
+        // Back-to-context link: on pages without a breadcrumb of their own that are not
+        // a context resource's page, show "< XXX" pointing to the navigation context
+        // (or "< Home" if none), so the user can always get back to it.
+        WebMarkupContainer backContextContainer = new WebMarkupContainer("backcontext-container");
+        boolean backCrumbVisible = false;
+        if (crumbParts.isEmpty() && !page.isContextPage()) {
+            NanodashPageRef backRef = createBackContextRef(page);
+            if (backRef != null) {
+                backContextContainer.add(backRef.createComponent("backcontext", Utils.truncateLinkLabel(backRef.getLabel())));
+                backCrumbVisible = true;
+            }
+        }
+        backContextContainer.setVisible(backCrumbVisible);
+        breadcrumbPath.add(backContextContainer);
         // Tab strip placeholder (right side of the strip); replaced via setTabs().
         breadcrumbPath.add(new EmptyPanel("tabs").setVisible(false));
         // The strip shows when there is a breadcrumb to display; setTabs() also
         // forces it visible so a tab strip shows even without a breadcrumb.
-        breadcrumbPath.setVisible(pathRefs.length > 0);
+        breadcrumbPath.setVisible(pathRefs.length > 0 || backCrumbVisible);
         add(breadcrumbPath);
+    }
+
+    /**
+     * The target of the back-to-context link for the given page: the navigation context
+     * resource, the home page if no context is set, or an explore-page link if the
+     * context id cannot (yet) be resolved. Null when the link would point to the page
+     * itself.
+     */
+    private static NanodashPageRef createBackContextRef(NanodashPage page) {
+        String contextId = page.getContextId();
+        if (contextId == null) {
+            if (page instanceof HomePage) return null;
+            return new NanodashPageRef(HomePage.class, "Home");
+        }
+        NanodashPageRef ref = NavigationContext.getPageRef(contextId);
+        if (ref == null) {
+            // Stale or not-yet-loaded context id: link via the explore page, which
+            // forwards known resources to their own pages once the caches are warm.
+            ref = new NanodashPageRef(ExplorePage.class, new PageParameters().set("id", contextId), Utils.getShortNameFromURI(contextId));
+        }
+        if (ref.getPageClass().equals(page.getClass()) && contextId.equals(page.getPageParameters().get("id").toString(""))) {
+            return null;
+        }
+        return ref;
     }
 
     /**
@@ -263,8 +314,8 @@ public class TitleBar extends Panel {
         return this;
     }
 
-    private BookmarkablePageLink<Void> createNavLink(String id, Class<? extends WebPage> pageClass) {
-        BookmarkablePageLink<Void> link = new BookmarkablePageLink<>(id, pageClass);
+    private BookmarkablePageLink<Void> createNavLink(String id, Class<? extends WebPage> pageClass, PageParameters params) {
+        BookmarkablePageLink<Void> link = new BookmarkablePageLink<>(id, pageClass, params);
         if (id.equals(highlight)) {
             link.add(new AttributeAppender("class", "selected"));
         }

--- a/src/main/java/com/knowledgepixels/nanodash/component/menu/ActionMenu.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/menu/ActionMenu.java
@@ -4,6 +4,7 @@ import com.knowledgepixels.nanodash.*;
 import com.knowledgepixels.nanodash.action.NanopubAction;
 import com.knowledgepixels.nanodash.domain.User;
 import com.knowledgepixels.nanodash.domain.UserData;
+import com.knowledgepixels.nanodash.page.NanodashPage;
 import com.knowledgepixels.nanodash.page.PublishPage;
 import org.apache.wicket.markup.html.link.ExternalLink;
 import org.apache.wicket.markup.html.panel.Panel;
@@ -59,9 +60,13 @@ public class ActionMenu extends Panel {
                         sigkeyParam = "&sigkey=" + URLEncoder.encode(pubkey, UTF_8);
                     }
                 }
+                String contextParam = "";
+                if (getPage() instanceof NanodashPage nanodashPage && nanodashPage.getContextId() != null) {
+                    contextParam = "&context=" + Utils.urlEncode(nanodashPage.getContextId());
+                }
                 String url = location + PublishPage.MOUNT_PATH + "?template=" + Utils.urlEncode(action.getTemplateUri(n.getNanopub())) +
                              "&" + action.getParamString(n.getNanopub()) +
-                             "&template-version=latest" + sigkeyParam;
+                             "&template-version=latest" + sigkeyParam + contextParam;
                 item.add(new ExternalLink("menuitem", url, action.getLinkLabel(n.getNanopub()) + extraLabel + "..."));
             }
 

--- a/src/main/java/com/knowledgepixels/nanodash/component/menu/ViewDisplayMenu.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/menu/ViewDisplayMenu.java
@@ -3,6 +3,7 @@ package com.knowledgepixels.nanodash.component.menu;
 import com.knowledgepixels.nanodash.ApiCache;
 import com.knowledgepixels.nanodash.NanodashSession;
 import com.knowledgepixels.nanodash.NanopubElement;
+import com.knowledgepixels.nanodash.NavigationContext;
 import com.knowledgepixels.nanodash.QueryResult;
 import com.knowledgepixels.nanodash.Utils;
 import com.knowledgepixels.nanodash.ViewDisplay;
@@ -72,10 +73,12 @@ public class ViewDisplayMenu extends BaseDisplayMenu {
         for (var entry : queryRef.getParams().entries()) {
             showQueryParams.add("queryparam_" + entry.getKey(), entry.getValue());
         }
-        addEntry("showQuery", new BookmarkablePageLink<Void>("showQuery", QueryPage.class, showQueryParams));
+        addEntry("showQuery", new BookmarkablePageLink<Void>("showQuery", QueryPage.class, showQueryParams)
+                .add(NavigationContext.pageContextFallback()));
 
         addEntry("showView", new BookmarkablePageLink<Void>("showView", ExplorePage.class,
-                new PageParameters().set("id", viewDisplay.getView().getNanopub().getUri())));
+                new PageParameters().set("id", viewDisplay.getView().getNanopub().getUri()))
+                .add(NavigationContext.pageContextFallback()));
 
         IRI nanopubId = viewDisplay.getNanopubId();
 
@@ -168,6 +171,7 @@ public class ViewDisplayMenu extends BaseDisplayMenu {
 
         BookmarkablePageLink<Void> viewDeclarationLink = new BookmarkablePageLink<>("viewDeclaration", ExplorePage.class,
                 new PageParameters().set("id", nanopubId));
+        viewDeclarationLink.add(NavigationContext.pageContextFallback());
         viewDeclarationLink.setVisible(viewDisplay.getId() != null);
         addEntry("viewDeclaration", viewDeclarationLink);
     }

--- a/src/main/java/com/knowledgepixels/nanodash/page/ExplorePage.html
+++ b/src/main/java/com/knowledgepixels/nanodash/page/ExplorePage.html
@@ -40,7 +40,6 @@
       <span wicket:id="urilink"></span>
       <div wicket:id="statusLine">[Status]</div>
       <p>
-        <a class="button" href="." wicket:id="back-to-context-link">back to context</a>
         <a class="button" href="." wicket:id="to-specific-page-link">to specific page</a>
       </p>
     </div>

--- a/src/main/java/com/knowledgepixels/nanodash/page/ExplorePage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/ExplorePage.java
@@ -16,7 +16,6 @@ import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.link.BookmarkablePageLink;
 import org.apache.wicket.markup.html.link.ExternalLink;
-import org.apache.wicket.model.LoadableDetachableModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.request.flow.RedirectToUrlException;
 import org.apache.wicket.request.mapper.parameter.INamedParameters.NamedPair;
@@ -151,22 +150,6 @@ public class ExplorePage extends NanodashPage {
         ResourceTabs.Tab activeTab = ResourceTabs.activeFromParam(parameters);
         TitleBar titleBar = new TitleBar("titlebar", this, null);
         add(titleBar);
-
-        if (SpaceRepository.get().findById(contextId) != null) {
-            add(new BookmarkablePageLink<Void>("back-to-context-link", SpacePage.class, new PageParameters().set("id", contextId)).setBody(LoadableDetachableModel.of(() -> {
-                var space = SpaceRepository.get().findById(contextId);
-                return "back to " + Utils.truncateLinkLabel(space == null ? contextId : space.getLabel());
-            })));
-        } else if (MaintainedResourceRepository.get().findById(contextId) != null) {
-            add(new BookmarkablePageLink<Void>("back-to-context-link", MaintainedResourcePage.class, new PageParameters().set("id", contextId)).setBody(LoadableDetachableModel.of(() -> {
-                var resource = MaintainedResourceRepository.get().findById(contextId);
-                return "back to " + Utils.truncateLinkLabel(resource == null ? contextId : resource.getLabel());
-            })));
-        } else if (IndividualAgent.isUser(contextId)) {
-            add(new BookmarkablePageLink<Void>("back-to-context-link", UserPage.class, new PageParameters().set("id", contextId)).setBody(LoadableDetachableModel.of(() -> "back to " + Utils.truncateLinkLabel(User.getShortDisplayName(Utils.vf.createIRI(contextId))))));
-        } else {
-            add(new Label("back-to-context-link").setVisible(false));
-        }
 
         if (User.getUserData().isUser(tempRef)) {
             add(new BookmarkablePageLink<Void>("to-specific-page-link", UserPage.class, parameters).setBody(Model.of("go to user page")));
@@ -323,7 +306,8 @@ public class ExplorePage extends NanodashPage {
             raw.add(createAssertionLink("a-rdfxml-txt", npUri, "rdfxml", true));
             nanopubSection.add(raw);
             if (Utils.isNanopubOfClass(np, NTEMPLATE.ASSERTION_TEMPLATE)) {
-                nanopubSection.add(new WebMarkupContainer("use-template").add(new BookmarkablePageLink<Void>("template-link", PublishPage.class, new PageParameters().set("template", np.getUri()))));
+                nanopubSection.add(new WebMarkupContainer("use-template").add(new BookmarkablePageLink<Void>("template-link", PublishPage.class,
+                        NavigationContext.withContext(new PageParameters().set("template", np.getUri()), getContextId()))));
             } else {
                 nanopubSection.add(new WebMarkupContainer("use-template").setVisible(false));
             }

--- a/src/main/java/com/knowledgepixels/nanodash/page/MaintainedResourcePage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/MaintainedResourcePage.java
@@ -42,6 +42,16 @@ public class MaintainedResourcePage extends NanodashPage {
         return MOUNT_PATH;
     }
 
+    @Override
+    public String getContextId() {
+        return resourceId;
+    }
+
+    @Override
+    public boolean isContextPage() {
+        return true;
+    }
+
     /**
      * Id of the maintained resource shown on this page. Only the id is held in
      * the page state; the {@link MaintainedResource} itself is re-fetched from

--- a/src/main/java/com/knowledgepixels/nanodash/page/NanodashPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/NanodashPage.java
@@ -2,6 +2,7 @@ package com.knowledgepixels.nanodash.page;
 
 import com.knowledgepixels.nanodash.ApiCache;
 import com.knowledgepixels.nanodash.NanodashPreferences;
+import com.knowledgepixels.nanodash.NavigationContext;
 import com.knowledgepixels.nanodash.NanodashThreadPool;
 import com.knowledgepixels.nanodash.Utils;
 import com.knowledgepixels.nanodash.WicketApplication;
@@ -111,6 +112,39 @@ public abstract class NanodashPage extends WebPage {
      * @return true if auto-refresh is enabled, false otherwise
      */
     protected boolean hasAutoRefreshEnabled() {
+        return false;
+    }
+
+    /**
+     * The navigation context id (space/user/maintained resource) this page was reached
+     * under. Pages showing a context resource override this to return their own resource
+     * id, so links from them carry the context even without a {@code context} parameter.
+     *
+     * @return the context resource id, or null if none
+     */
+    public String getContextId() {
+        return NavigationContext.getContextId(getPageParameters());
+    }
+
+    /**
+     * Whether this page shows a context resource itself (space, user, maintained
+     * resource, or resource part). Such pages have their own breadcrumb or tab strip and
+     * don't get the title bar's back-to-context link.
+     *
+     * @return true if this is a context resource's own page
+     */
+    public boolean isContextPage() {
+        return false;
+    }
+
+    /**
+     * Whether this page's content pane runs the full viewport width (class
+     * {@code full}), so the title bar's breadcrumb strip should too instead of
+     * centering at the standard content width.
+     *
+     * @return true if this page has full-width content
+     */
+    public boolean hasFullWidthContent() {
         return false;
     }
 

--- a/src/main/java/com/knowledgepixels/nanodash/page/PreviewPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/PreviewPage.java
@@ -2,15 +2,13 @@ package com.knowledgepixels.nanodash.page;
 
 import com.knowledgepixels.nanodash.NanodashSession;
 import com.knowledgepixels.nanodash.NanopubElement;
+import com.knowledgepixels.nanodash.NavigationContext;
 import com.knowledgepixels.nanodash.Utils;
 import com.knowledgepixels.nanodash.WicketApplication;
 import com.knowledgepixels.nanodash.domain.AbstractResourceWithProfile;
 import com.knowledgepixels.nanodash.component.NanopubItem;
 import com.knowledgepixels.nanodash.component.TemplateFormPreview;
 import com.knowledgepixels.nanodash.component.TitleBar;
-import com.knowledgepixels.nanodash.domain.IndividualAgent;
-import com.knowledgepixels.nanodash.repository.MaintainedResourceRepository;
-import com.knowledgepixels.nanodash.repository.SpaceRepository;
 import org.apache.wicket.Page;
 import org.apache.wicket.PageReference;
 import org.apache.wicket.RestartResponseException;
@@ -106,32 +104,15 @@ public class PreviewPage extends NanodashPage {
                             && AbstractResourceWithProfile.isResourceWithProfile(contextId)) {
                         WicketApplication.get().notifyNanopubPublished(signedNp, contextId, 5 * 1000);
                     }
-                    String partId = pageParams.get("part").toString("");
-                    if (!contextId.isEmpty()) {
-                        PageParameters redirectParams = new PageParameters().set("just-published", signedNp.getUri().stringValue());
-                        if (!partId.isEmpty()) {
-                            redirectParams.set("id", partId).set("context", contextId);
-                            throw new RestartResponseException(ResourcePartPage.class, redirectParams);
-                        }
-                        redirectParams.set("id", contextId);
-                        // Return to the tab the action asked for (default Content).
-                        String postpubTab = pageParams.get("postpub-tab").toString("");
-                        if (!postpubTab.isEmpty()) redirectParams.set("tab", postpubTab);
-                        if (SpaceRepository.get().findById(contextId) != null) {
-                            throw new RestartResponseException(SpacePage.class, redirectParams);
-                        }
-                        if (MaintainedResourceRepository.get().findById(contextId) != null) {
-                            throw new RestartResponseException(MaintainedResourcePage.class, redirectParams);
-                        }
-                        if (IndividualAgent.isUser(contextId)) {
-                            throw new RestartResponseException(UserPage.class, redirectParams);
-                        }
+                    if (confirmPageClass != null) {
+                        // Connector flow: show the connector's own confirmation page.
+                        throw new RestartResponseException(
+                                confirmPageClass,
+                                new PageParameters(pageParams).set("id", signedNp.getUri().stringValue())
+                        );
                     }
-
-                    throw new RestartResponseException(
-                            confirmPageClass,
-                            new PageParameters(pageParams).set("id", signedNp.getUri().stringValue())
-                    );
+                    // Forward to the context resource's page, or home if no context; always throws.
+                    NavigationContext.redirectAfterPublish(signedNp, pageParams);
                 } catch (RestartResponseException | RedirectToUrlException ex) {
                     throw ex;
                 } catch (Exception ex) {

--- a/src/main/java/com/knowledgepixels/nanodash/page/PublishPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/PublishPage.java
@@ -46,7 +46,9 @@ public class PublishPage extends NanodashPage {
             if (!parameters.get("sigkey").isNull() && !parameters.get("sigkey").toString().equals(session.getPubkeyString())) {
                 add(new DifferentKeyErrorItem("form", parameters));
             } else {
-                add(new PublishForm("form", parameters, getClass(), ExplorePage.class));
+                // No confirm page: after publishing, the form forwards to the context
+                // resource (or home), showing the new nanopub in the title bar message.
+                add(new PublishForm("form", parameters, getClass(), null));
             }
             add(new Label("templatelist").setVisible(false));
         } else {

--- a/src/main/java/com/knowledgepixels/nanodash/page/QueryPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/QueryPage.java
@@ -65,6 +65,11 @@ public class QueryPage extends NanodashPage {
         return MOUNT_PATH;
     }
 
+    @Override
+    public boolean hasFullWidthContent() {
+        return true;
+    }
+
     /**
      * Constructor for the QueryPage.
      *

--- a/src/main/java/com/knowledgepixels/nanodash/page/ResourcePartPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/ResourcePartPage.java
@@ -51,6 +51,12 @@ public class ResourcePartPage extends NanodashPage {
         return MOUNT_PATH;
     }
 
+    // getContextId() is inherited: the context param holds the maintaining resource.
+    @Override
+    public boolean isContextPage() {
+        return true;
+    }
+
     /**
      * Resource with profile (Space or MaintainedResource) object with the data shown on this page.
      */

--- a/src/main/java/com/knowledgepixels/nanodash/page/ResultTablePage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/ResultTablePage.java
@@ -27,6 +27,11 @@ public class ResultTablePage extends NanodashPage {
         return MOUNT_PATH;
     }
 
+    @Override
+    public boolean hasFullWidthContent() {
+        return true;
+    }
+
     /**
      * Constructor for ResultTablePage.
      *

--- a/src/main/java/com/knowledgepixels/nanodash/page/SpacePage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/SpacePage.java
@@ -42,6 +42,16 @@ public class SpacePage extends NanodashPage {
         return MOUNT_PATH;
     }
 
+    @Override
+    public String getContextId() {
+        return spaceId;
+    }
+
+    @Override
+    public boolean isContextPage() {
+        return true;
+    }
+
     /**
      * Id of the space shown on this page. Only the id is held in the page
      * state; the {@link Space} itself is re-fetched from the repository on

--- a/src/main/java/com/knowledgepixels/nanodash/page/UserListPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/UserListPage.java
@@ -1,5 +1,6 @@
 package com.knowledgepixels.nanodash.page;
 
+import com.knowledgepixels.nanodash.Utils;
 import com.knowledgepixels.nanodash.View;
 import com.knowledgepixels.nanodash.ViewDisplay;
 import com.knowledgepixels.nanodash.component.QueryResultItemListBuilder;
@@ -76,7 +77,8 @@ public class UserListPage extends NanodashPage {
         add(QueryResultItemListBuilder.create("other-users",
                 new QueryRef(nonApprovedUsersView.getQuery().getQueryId()), new ViewDisplay(nonApprovedUsersView)).build());
 
-        add(new ExternalLink("approve", PublishPage.MOUNT_PATH + "?template=http://purl.org/np/RA6TVVSnZChEwyxjvFDNAujk1i8sSPnQx60ZQjldtiDkw&template-version=latest", "approve somebody else..."));
+        String contextParam = getContextId() == null ? "" : "&context=" + Utils.urlEncode(getContextId());
+        add(new ExternalLink("approve", PublishPage.MOUNT_PATH + "?template=http://purl.org/np/RA6TVVSnZChEwyxjvFDNAujk1i8sSPnQx60ZQjldtiDkw&template-version=latest" + contextParam, "approve somebody else..."));
         //add(new ExternalLink("newgroup", PublishPage.MOUNT_PATH + "?template=http://purl.org/np/RAJz6w5cvlsFGkCDtWOUXt2VwEQ3tVGtPdy3atPj_DUhk&template-version=latest", "new group"));
     }
 

--- a/src/main/java/com/knowledgepixels/nanodash/page/UserPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/UserPage.java
@@ -47,6 +47,16 @@ public class UserPage extends NanodashPage {
         return MOUNT_PATH;
     }
 
+    @Override
+    public String getContextId() {
+        return userIri.stringValue();
+    }
+
+    @Override
+    public boolean isContextPage() {
+        return true;
+    }
+
     private IRI userIri;
     private String pubkeyHashes = "";
 

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -1188,6 +1188,24 @@ select {
   padding-bottom: 0;
 }
 
+/* Full-width pages (#content-pane.full, e.g. query pages): the strip's row follows
+   the content to the left edge instead of centering at the standard width. The 25px
+   here plus the col's 15px padding matches the content start of #content-pane.full
+   (20px margin + 20px padding). */
+.breadcrumbpath.fullwidth .row-section {
+  max-width: none;
+  padding-left: 25px;
+  padding-right: 25px;
+}
+
+@media screen and (max-width: 768px) {
+  /* #content-pane.full drops to 10px margin + 10px padding on mobile. */
+  .breadcrumbpath.fullwidth .row-section {
+    padding-left: 5px;
+    padding-right: 5px;
+  }
+}
+
 .breadcrumbpath .nextlevel {
   font-size: 24px;
   margin: -10px 0;


### PR DESCRIPTION
Implements #534: always keep a `context` field (space, user, or maintained resource) and direct back to it.

## What this does

- **Context propagation**: the existing `context` URL parameter now follows navigation everywhere. New `NavigationContext` utility centralizes the semantics: resolving a context id, stamping it onto links (`withContext`, plus a render-time fallback behavior for links built without the context at hand — nanopub cards, menu entries, source links), and rewriting app-internal links inside data-borne result-cell HTML (queries/templates emitting ready-made `<a href>` strings). Context pages themselves (space/user/maintained-resource/part) are the context origin via `NanodashPage.getContextId()` overrides.
- **Breadcrumb back-link**: pages that are not a context resource's own page show `< XXX` in the (previously unused) breadcrumb area, linking back to the context — `< Home` if none is set. The `<` glyph is a separator outside the link, matching the existing `>`. Stale/unresolvable context ids degrade to an explore-page link instead of throwing. On full-width pages (query pages), the strip follows the content to the left edge. ExplorePage's body "back to context" button is superseded by this and removed.
- **Post-publish forwarding**: publishing forwards to the context resource (or its part) with the just-published nanopub shown only in the title bar message; with no context it forwards to the home page instead of the ExplorePage confirmation. `PublishForm` and `PreviewPage` now share one redirect helper; the connector (Gen*) flow keeps its own confirmation page unchanged.

## Notes for review

- `ExplorePage(Nanopub, PageParameters)` and its hidden publish-confirm panel are now unreachable; removal is left for a follow-up to keep this diff reviewable.
- Nav links (Users/Spaces/Query/Publish) all carry the context; trimming that to just Publish would be a two-line change.
- Verified by click-through on a dev instance (context/no-context publish targets, user/space/query/template link flows, stale context, connector breadcrumbs); `mvn test` green (739 tests).

Closes #534

🤖 Generated with [Claude Code](https://claude.com/claude-code)