### PR TITLE
feat: replace template-form '^' source links with dropdown menus

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/component/PublishForm.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/PublishForm.html
@@ -48,7 +48,7 @@
 
 <p class="graphsubheader">
 <strong wicket:id="templatename" class="templatename">Assertion template name</strong>
-<a href="#" wicket:id="templatelink">^</a>
+<span wicket:id="templatelink"></span>
 </p>
 
 <div class="message plain collapse-overflow">
@@ -79,7 +79,7 @@
 </p>
 <p class="graphsubheader advanced">
 <span class="templatename"><select wicket:id="prtemplate" class="provselect"></select></span>
-<a href="#" wicket:id="prtemplatelink">^</a>
+<span wicket:id="prtemplatelink"></span>
 </p>
 
 <div class="nanopub">
@@ -104,7 +104,7 @@
 <p class="graphsubheader advanced">
 <span wicket:id="pitemplatename" class="templatename">Pubinfo template name</span>
 <span wicket:id="piremove" class="smallbutton">&times;</span>
-<a href="#" wicket:id="pitemplatelink">^</a>
+<span wicket:id="pitemplatelink"></span>
 </p>
 
 <div class="nanopub">

--- a/src/main/java/com/knowledgepixels/nanodash/component/PublishForm.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/PublishForm.java
@@ -4,6 +4,7 @@ import com.knowledgepixels.nanodash.*;
 import com.knowledgepixels.nanodash.domain.AbstractResourceWithProfile;
 import com.knowledgepixels.nanodash.vocabulary.KPXL_TERMS;
 import com.knowledgepixels.nanodash.domain.User;
+import com.knowledgepixels.nanodash.component.menu.EntryActionMenu;
 import com.knowledgepixels.nanodash.page.*;
 import com.knowledgepixels.nanodash.template.*;
 import org.apache.commons.lang3.Strings;
@@ -530,7 +531,7 @@ public class PublishForm extends Panel {
 
         //form.add(new Label("nanopub-namespace", targetNamespaceLabel));
 
-        form.add(new BookmarkablePageLink<Void>("templatelink", ExplorePage.class, new PageParameters().set("id", assertionContext.getTemplate().getId())));
+        form.add(newSourceMenu("templatelink", assertionContext.getTemplate().getId()));
         form.add(new Label("templatename", assertionContext.getTemplate().getLabel()));
         String description = assertionContext.getTemplate().getLabel();
         form.add(new Label("templatedesc", assertionContext.getTemplate().getDescription()).setEscapeModelStrings(false));
@@ -815,6 +816,13 @@ public class PublishForm extends Panel {
         add(feedbackPanel);
     }
 
+    static EntryActionMenu newSourceMenu(String id, String templateId) {
+        BookmarkablePageLink<Void> sourceLink = new BookmarkablePageLink<>("link", ExplorePage.class, new PageParameters().set("id", templateId));
+        sourceLink.add(NavigationContext.pageContextFallback());
+        sourceLink.setBody(Model.of("<span class=\"actionmenu-icon\">↗︎</span>source")).setEscapeModelStrings(false);
+        return new EntryActionMenu(id, List.of(sourceLink));
+    }
+
     private void refreshProvenance(AjaxRequestTarget target) {
         if (target != null) {
             form.remove("prtemplatelink");
@@ -822,7 +830,7 @@ public class PublishForm extends Panel {
             target.add(form);
             target.appendJavaScript("updateElements();");
         }
-        form.add(new BookmarkablePageLink<Void>("prtemplatelink", ExplorePage.class, new PageParameters().set("id", provenanceContext.getTemplate().getId())));
+        form.add(newSourceMenu("prtemplatelink", provenanceContext.getTemplate().getId()));
         ListView<StatementItem> list = new ListView<StatementItem>("pr-statements", provenanceContext.getStatementItems()) {
 
             protected void populateItem(ListItem<StatementItem> item) {
@@ -840,7 +848,7 @@ public class PublishForm extends Panel {
             protected void populateItem(ListItem<TemplateContext> item) {
                 final TemplateContext pic = item.getModelObject();
                 item.add(new Label("pitemplatename", pic.getTemplate().getLabel()));
-                item.add(new BookmarkablePageLink<Void>("pitemplatelink", ExplorePage.class, new PageParameters().set("id", pic.getTemplate().getId())));
+                item.add(newSourceMenu("pitemplatelink", pic.getTemplate().getId()));
                 Label remove = new Label("piremove", "×");
                 item.add(remove);
                 remove.add(new AjaxEventBehavior("click") {

--- a/src/main/java/com/knowledgepixels/nanodash/component/TemplateFormPreview.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/TemplateFormPreview.html
@@ -22,7 +22,7 @@
 
 <p class="graphsubheader">
 <strong wicket:id="templatename" class="templatename">Assertion template name</strong>
-<a href="#" wicket:id="templatelink">^</a>
+<span wicket:id="templatelink"></span>
 </p>
 
 <div class="message plain collapse-overflow">
@@ -53,7 +53,7 @@
 </p>
 <p class="graphsubheader advanced">
 <span wicket:id="prtemplatename" class="templatename">Provenance template name</span>
-<a href="#" wicket:id="prtemplatelink">^</a>
+<span wicket:id="prtemplatelink"></span>
 </p>
 
 <div class="nanopub">
@@ -76,7 +76,7 @@
 <div wicket:id="pis">
 <p class="graphsubheader advanced">
 <span wicket:id="pitemplatename" class="templatename">Pubinfo template name</span>
-<a href="#" wicket:id="pitemplatelink">^</a>
+<span wicket:id="pitemplatelink"></span>
 </p>
 
 <div class="nanopub">

--- a/src/main/java/com/knowledgepixels/nanodash/component/TemplateFormPreview.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/TemplateFormPreview.java
@@ -2,18 +2,15 @@ package com.knowledgepixels.nanodash.component;
 
 import com.knowledgepixels.nanodash.NanodashSession;
 import com.knowledgepixels.nanodash.domain.User;
-import com.knowledgepixels.nanodash.page.ExplorePage;
 import com.knowledgepixels.nanodash.template.ContextType;
 import com.knowledgepixels.nanodash.template.Template;
 import com.knowledgepixels.nanodash.template.TemplateContext;
 import com.knowledgepixels.nanodash.template.TemplateData;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.form.Form;
-import org.apache.wicket.markup.html.link.BookmarkablePageLink;
 import org.apache.wicket.markup.html.list.ListItem;
 import org.apache.wicket.markup.html.list.ListView;
 import org.apache.wicket.markup.html.panel.Panel;
-import org.apache.wicket.request.mapper.parameter.PageParameters;
 import org.eclipse.rdf4j.model.IRI;
 import org.nanopub.Nanopub;
 
@@ -94,7 +91,7 @@ public class TemplateFormPreview extends Panel {
         Form<?> form = new Form<Void>("form");
 
         // Assertion section
-        form.add(new BookmarkablePageLink<Void>("templatelink", ExplorePage.class, new PageParameters().set("id", templateId)));
+        form.add(PublishForm.newSourceMenu("templatelink", templateId));
         form.add(new Label("templatename", template.getLabel()));
         form.add(new Label("templatedesc", template.getDescription()).setEscapeModelStrings(false));
 
@@ -106,7 +103,7 @@ public class TemplateFormPreview extends Panel {
 
         // Provenance section
         form.add(new Label("prtemplatename", provenanceContext.getTemplate().getLabel()));
-        form.add(new BookmarkablePageLink<Void>("prtemplatelink", ExplorePage.class, new PageParameters().set("id", provenanceContext.getTemplate().getId())));
+        form.add(PublishForm.newSourceMenu("prtemplatelink", provenanceContext.getTemplate().getId()));
 
         form.add(new ListView<StatementItem>("pr-statements", provenanceContext.getStatementItems()) {
             protected void populateItem(ListItem<StatementItem> item) {
@@ -119,7 +116,7 @@ public class TemplateFormPreview extends Panel {
             protected void populateItem(ListItem<TemplateContext> item) {
                 TemplateContext pic = item.getModelObject();
                 item.add(new Label("pitemplatename", pic.getTemplate().getLabel()));
-                item.add(new BookmarkablePageLink<Void>("pitemplatelink", ExplorePage.class, new PageParameters().set("id", pic.getTemplate().getId())));
+                item.add(PublishForm.newSourceMenu("pitemplatelink", pic.getTemplate().getId()));
                 item.add(new ListView<StatementItem>("pi-statements", pic.getStatementItems()) {
                     protected void populateItem(ListItem<StatementItem> item) {
                         item.add(item.getModelObject());

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -1100,14 +1100,16 @@ input[type=radio] + label strong {
    chevron — the border only appears on hover (as an outline, not a filled button). */
 .result-table .actionmenu,
 .inline-list .actionmenu,
-.paragraph-header .actionmenu {
+.paragraph-header .actionmenu,
+.graphsubheader .actionmenu {
   position: relative;
   top: -2px;
 }
 
 .result-table .actionmenu-button,
 .inline-list .actionmenu-button,
-.paragraph-header .actionmenu-button {
+.paragraph-header .actionmenu-button,
+.graphsubheader .actionmenu-button {
   border-color: transparent;
   /* Resting state (no border): a bare chevron at full color, matching the menu text
      and the standard dropdown button; the border outline appears on hover. */
@@ -1116,7 +1118,8 @@ input[type=radio] + label strong {
 
 .result-table .actionmenu:hover .actionmenu-button,
 .inline-list .actionmenu:hover .actionmenu-button,
-.paragraph-header .actionmenu:hover .actionmenu-button {
+.paragraph-header .actionmenu:hover .actionmenu-button,
+.graphsubheader .actionmenu:hover .actionmenu-button {
   border-color: #0B73DA;
   background-color: transparent;
   color: #0B73DA;


### PR DESCRIPTION
The three template source links (assertion, provenance, pubinfo) in the publish form still used the old `^` link pointing to the template source. They now use the standard downward-chevron dropdown (`EntryActionMenu`) with a single "↗︎ source" entry, matching the per-entry menus in the query-result views.

- `PublishForm`: the three `^` links become one-item source menus, built by a shared `newSourceMenu(id, templateId)` helper; the AJAX provenance-refresh path keeps working since component ids are unchanged.
- `TemplateFormPreview` (read-only form preview on PreviewPage/ViewPage): same conversion, reusing the helper.
- The source links now carry `NavigationContext.pageContextFallback()`, so the Explore page shows the back-crumb — consistent with the source entries elsewhere.
- CSS: `.graphsubheader` added to the borderless-at-rest chevron scope group, so the menu rests as a bare chevron and only shows the outline on hover.

Remaining literal `^` usages (`SourceNanopub` in item lists, `NanodashLink`'s data-driven caret fallback) are a different visual convention and left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)