### PR TITLE
fix: treat home resource context as plain Home in navigation

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/NavigationContext.java
+++ b/src/main/java/com/knowledgepixels/nanodash/NavigationContext.java
@@ -13,6 +13,7 @@ import com.knowledgepixels.nanodash.page.UserPage;
 import org.apache.wicket.Component;
 import org.apache.wicket.RestartResponseException;
 import org.apache.wicket.behavior.Behavior;
+import org.apache.wicket.markup.ComponentTag;
 import org.apache.wicket.markup.html.link.BookmarkablePageLink;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
 import org.nanopub.Nanopub;
@@ -133,6 +134,28 @@ public class NavigationContext {
                         && link.getPageParameters() != null) {
                     withContext(link.getPageParameters(), page.getContextId());
                 }
+            }
+        };
+    }
+
+    /**
+     * A behavior that appends the page's navigation context to a link whose target is a
+     * URL string (e.g. from {@link com.knowledgepixels.nanodash.component.NanodashLink#getPageUrl(String)})
+     * rather than page parameters, where {@link #pageContextFallback()} cannot apply.
+     * Only internal page URLs (starting with "/") that don't carry a context yet are touched.
+     *
+     * @return the context-fallback behavior
+     */
+    public static Behavior hrefContextFallback() {
+        return new Behavior() {
+            @Override
+            public void onComponentTag(Component component, ComponentTag tag) {
+                if (!(component.getPage() instanceof NanodashPage page)) return;
+                String contextId = page.getContextId();
+                if (contextId == null) return;
+                String href = tag.getAttribute("href");
+                if (href == null || !href.startsWith("/") || href.contains(CONTEXT_PARAM + "=")) return;
+                tag.put("href", href + (href.contains("?") ? "&" : "?") + CONTEXT_PARAM + "=" + Utils.urlEncode(contextId));
             }
         };
     }

--- a/src/main/java/com/knowledgepixels/nanodash/NavigationContext.java
+++ b/src/main/java/com/knowledgepixels/nanodash/NavigationContext.java
@@ -77,12 +77,26 @@ public class NavigationContext {
     }
 
     /**
+     * Whether the given context id is the configured home resource, whose page is the
+     * home page itself rather than its maintained-resource page.
+     *
+     * @param contextId the context resource id
+     * @return true if it is the home resource
+     */
+    public static boolean isHomeResource(String contextId) {
+        return contextId != null && contextId.equals(NanodashPreferences.get().getHomeResource());
+    }
+
+    /**
      * A page reference (link target + label) for the given context id.
      *
      * @param contextId the context resource id
      * @return the page reference, or null if the id cannot be resolved
      */
     public static NanodashPageRef getPageRef(String contextId) {
+        if (isHomeResource(contextId)) {
+            return new NanodashPageRef(HomePage.class, "Home");
+        }
         AbstractResourceWithProfile resource = resolve(contextId);
         if (resource == null) return null;
         return new NanodashPageRef(getPageClass(resource), new PageParameters().set("id", contextId), resource.getLabel());
@@ -141,6 +155,9 @@ public class NavigationContext {
                 // User was on a part page (e.g. paper collection); redirect back to the part page
                 redirectParams.set("id", partId).set(CONTEXT_PARAM, contextId);
                 throw new RestartResponseException(ResourcePartPage.class, redirectParams);
+            }
+            if (isHomeResource(contextId)) {
+                throw new RestartResponseException(HomePage.class, redirectParams);
             }
             redirectParams.set("id", contextId);
             // Return to the tab the action asked for (e.g. "about" for a

--- a/src/main/java/com/knowledgepixels/nanodash/component/IriItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/IriItem.java
@@ -1,6 +1,7 @@
 package com.knowledgepixels.nanodash.component;
 
 import com.knowledgepixels.nanodash.LocalUri;
+import com.knowledgepixels.nanodash.NavigationContext;
 import com.knowledgepixels.nanodash.Utils;
 import com.knowledgepixels.nanodash.component.StatementItem.RepetitionGroup;
 import com.knowledgepixels.nanodash.domain.MaintainedResource;
@@ -142,6 +143,7 @@ public class IriItem extends AbstractContextComponent {
             linkLabelModel = Model.of(linkLabelBase);
         }
         ExternalLink linkComp = new ExternalLink("link", Model.of(href), linkLabelModel);
+        linkComp.add(NavigationContext.hrefContextFallback());
         if (iri.equals(NTEMPLATE.ASSERTION_PLACEHOLDER)) {
             linkComp.add(new AttributeAppender("class", " this-assertion "));
             iri = LocalUri.of("assertion");

--- a/src/main/java/com/knowledgepixels/nanodash/component/ReadonlyItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/ReadonlyItem.java
@@ -1,6 +1,7 @@
 package com.knowledgepixels.nanodash.component;
 
 import com.knowledgepixels.nanodash.LocalUri;
+import com.knowledgepixels.nanodash.NavigationContext;
 import com.knowledgepixels.nanodash.RestrictedChoice;
 import com.knowledgepixels.nanodash.domain.User;
 import com.knowledgepixels.nanodash.Utils;
@@ -203,6 +204,7 @@ public class ReadonlyItem extends AbstractContextComponent {
         if (template.isIntroducedResource(iri) || template.isEmbeddedResource(iri)) {
             linkComp.add(AttributeAppender.append("class", "introduced"));
         }
+        linkComp.add(NavigationContext.hrefContextFallback());
         add(linkComp);
         add(new Label("description", new Model<String>() {
 

--- a/src/main/java/com/knowledgepixels/nanodash/component/TitleBar.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/TitleBar.java
@@ -130,6 +130,7 @@ public class TitleBar extends Panel {
             return new NanodashPageRef(HomePage.class, "Home");
         }
         NanodashPageRef ref = NavigationContext.getPageRef(contextId);
+        if (page instanceof HomePage && ref != null && HomePage.class.equals(ref.getPageClass())) return null;
         if (ref == null) {
             // Stale or not-yet-loaded context id: link via the explore page, which
             // forwards known resources to their own pages once the caches are warm.


### PR DESCRIPTION
Follow-up to #535: links on the home page carry the configured home resource as their navigation `context`, so the back-crumb showed the resource's label (e.g. "< Nanodash Home") pointing to `/resource?id=…/r/home` instead of "< Home" pointing to `/`.

- New `NavigationContext.isHomeResource(contextId)` compares the context id against `NanodashPreferences.getHomeResource()`.
- `getPageRef` returns a `HomePage` ref labeled "Home" for that id, so the back-crumb on pages reached from home reads "< Home" and links to `/`.
- `redirectAfterPublish` forwards to `/` (with the `just-published` message) instead of the home resource's maintained-resource page.
- `TitleBar` guard: a stray `context` param on `/` itself never renders a self-pointing "< Home" crumb.

Render-verified on a second jetty: following a context-carrying link from the home page to an Explore page shows `< Home` resolving to `/`; the home page itself shows no crumb. The post-publish path is code-verified only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)