### PR TITLE
fix: make CI robust against Coveralls outages and flaky version fetch

### DIFF
--- a/.github/workflows/maven-test.yml
+++ b/.github/workflows/maven-test.yml
@@ -33,6 +33,8 @@ jobs:
         with:
           parallel: true
           flag-name: run-${{ join(matrix.*, '-') }}
+          # Coverage upload is best-effort: a Coveralls outage must not fail the build.
+          fail-on-error: false
 
   coveralls:
     needs: test
@@ -42,3 +44,4 @@ jobs:
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
         with:
           parallel-finished: true
+          fail-on-error: false

--- a/src/test/java/com/knowledgepixels/nanodash/WicketApplicationTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/WicketApplicationTest.java
@@ -6,6 +6,7 @@ import org.apache.wicket.util.tester.WicketTester;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 class WicketApplicationTest {
 
@@ -44,6 +45,9 @@ class WicketApplicationTest {
     @Test
     void getLatestVersionWhenFetchSucceeds() {
         String result = WicketApplication.getLatestVersion();
+        // The fetch hits the live GitHub API and returns null on any failure
+        // (offline, rate-limited CI runner); only assert when it succeeded.
+        assumeTrue(result != null, "latest-version fetch from GitHub API failed; skipping");
         assertTrue(result.matches("\\d+.\\d+(.\\d+)*"));
     }
 


### PR DESCRIPTION
Run 28795129547 failed twice for two unrelated reasons, both addressed here:

- **Coveralls outage**: the coverage upload got an opaque 500 from coveralls.io while all tests passed. Both Coveralls steps now set `fail-on-error: false`, making coverage upload best-effort; real test failures still fail the build via the Maven step.
- **Flaky test**: `WicketApplicationTest.getLatestVersionWhenFetchSucceeds` calls the live GitHub releases API, which is rate-limited on shared CI runners; `getLatestVersion()` then returns null and the test dies with an NPE. It is now skipped via a JUnit assumption when the fetch fails, and still asserts the version format when it succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)