### PR TITLE
fix: show explicit query labels in full instead of truncating

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/component/NanodashLink.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/NanodashLink.java
@@ -119,7 +119,8 @@ public class NanodashLink extends Panel {
             add(link);
             add(new Label("description", "links a nanopublication to its pubinfo"));
         } else {
-            if (label == null || label.isBlank()) {
+            final boolean explicitLabel = label != null && !label.isBlank();
+            if (!explicitLabel) {
                 label = Utils.getShortNameFromURI(uri);
                 if (iriObj.equals(User.getSignatureOwnerIri(np))) {
                     // TODO We might want to introduce a "(you)" flag here at some point
@@ -149,7 +150,7 @@ public class NanodashLink extends Panel {
                 }
             }
             String shortLabel = label.replaceFirst(" - [\\s\\S]*$", "");
-            add(createLink("link", uri, shortLabel, contextId));
+            add(createLink("link", uri, shortLabel, contextId, explicitLabel));
             String description = "";
             if (np != null && uri.startsWith(np.getUri().stringValue())) {
                 description = "This is a local identifier that was minted when the nanopublication was created.";
@@ -169,7 +170,16 @@ public class NanodashLink extends Panel {
      * @return a {@link org.apache.wicket.Component} object
      */
     public static Component createLink(String markupId, String uri, String label, String contextId) {
-        Component link = createLinkComponent(markupId, uri, label, contextId);
+        return createLink(markupId, uri, label, contextId, false);
+    }
+
+    /**
+     * Like {@link #createLink(String, String, String, String)}, but with a flag telling
+     * whether the label was explicitly provided (e.g. returned by a query). Explicit
+     * labels are shown in full; only derived labels are truncated for display.
+     */
+    public static Component createLink(String markupId, String uri, String label, String contextId, boolean explicitLabel) {
+        Component link = createLinkComponent(markupId, uri, label, contextId, explicitLabel);
         // Fall back to the page's navigation context when the caller didn't supply one
         // (e.g. nanopub cards), so the target page's back-link still points back here.
         if (link instanceof BookmarkablePageLink) {
@@ -178,25 +188,26 @@ public class NanodashLink extends Panel {
         return link;
     }
 
-    private static Component createLinkComponent(String markupId, String uri, String label, String contextId) {
+    private static Component createLinkComponent(String markupId, String uri, String label, String contextId, boolean explicitLabel) {
         boolean isNp = TrustyUriUtils.isPotentialTrustyUri(uri);
         PageParameters params = new PageParameters().set("id", uri);
         if (contextId != null) params.set("context", contextId);
         // TODO Improve this
         if (isNp && uri.startsWith(DsConfig.get().getTargetNamespace())) {
-            return new BookmarkablePageLink<Void>(markupId, DsNanopubPage.class, params.set("mode", "final")).setBody(Model.of(Utils.truncateLinkLabel(label)));
+            return new BookmarkablePageLink<Void>(markupId, DsNanopubPage.class, params.set("mode", "final")).setBody(Model.of(displayLabel(label, explicitLabel)));
         } else if (isNp && uri.startsWith(BdjConfig.get().getTargetNamespace())) {
-            return new BookmarkablePageLink<Void>(markupId, BdjNanopubPage.class, params.set("mode", "final")).setBody(Model.of(Utils.truncateLinkLabel(label)));
+            return new BookmarkablePageLink<Void>(markupId, BdjNanopubPage.class, params.set("mode", "final")).setBody(Model.of(displayLabel(label, explicitLabel)));
         } else if (isNp && uri.startsWith(RioConfig.get().getTargetNamespace())) {
-            return new BookmarkablePageLink<Void>(markupId, RioNanopubPage.class, params.set("mode", "final")).setBody(Model.of(Utils.truncateLinkLabel(label)));
+            return new BookmarkablePageLink<Void>(markupId, RioNanopubPage.class, params.set("mode", "final")).setBody(Model.of(displayLabel(label, explicitLabel)));
         } else if (IndividualAgent.isUser(uri) || IndividualAgent.isOrcidIri(uri)) {
             IRI userIri = vf.createIRI(uri);
             // Prefer our own known display name; otherwise keep a label supplied by the
             // caller (e.g. a name resolved by a query) before falling back to the bare id.
             if (User.getName(userIri) != null || label == null || label.isBlank()) {
                 label = User.getShortDisplayName(userIri);
+                explicitLabel = false;
             }
-            return new BookmarkablePageLink<Void>(markupId, UserPage.class, params).setBody(Model.of(Utils.truncateLinkLabel(label)));
+            return new BookmarkablePageLink<Void>(markupId, UserPage.class, params).setBody(Model.of(displayLabel(label, explicitLabel)));
         } else if (SpaceRepository.get().findById(uri) != null) {
             label = SpaceRepository.get().findById(uri).getLabel();
             return new BookmarkablePageLink<Void>(markupId, SpacePage.class, params).setBody(Model.of(Utils.truncateLinkLabel(label)));
@@ -217,14 +228,22 @@ public class NanodashLink extends Panel {
             } else {
                 link = new BookmarkablePageLink<Void>(markupId, ExplorePage.class, params.set("forward-to-part", "true"));
             }
-            // Truncate only the displayed label; the full label stays in the page
+            // Truncate only derived labels; the full label stays in the page
             // params above so the destination page can still show it as its title.
-            link.setBody(Model.of(Utils.truncateLinkLabel(label)));
+            link.setBody(Model.of(displayLabel(label, explicitLabel)));
             // The "^" source-nanopub caret is styled like the admin lists (subtle, with
             // hover-darken), reusing SourceNanopub's `a.source` styling.
             if (isCaret) link.add(new AttributeAppender("class", "source"));
             return link;
         }
+    }
+
+    /**
+     * Explicit labels (e.g. returned by a query) are shown in full; labels derived
+     * from the URI or local repositories are truncated for display.
+     */
+    private static String displayLabel(String label, boolean explicit) {
+        return explicit ? label : Utils.truncateLinkLabel(label);
     }
 
     /**

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultTable.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultTable.java
@@ -344,8 +344,7 @@ public class QueryResultTable extends QueryResult {
                             // SPARQL coalesce often falls back to the URI string itself; treat that as no label
                             // so NanodashLink can derive a short name from the URI.
                             if (rawLabel != null && rawLabel.equals(uri)) rawLabel = null;
-                            String label = truncateLabel(rawLabel);
-                            links.add(new NanodashLink("component", uri, null, null, label, contextId));
+                            links.add(new NanodashLink("component", uri, null, null, rawLabel, contextId));
                         }
                         cellItem.add(new ComponentSequence(componentId, ", ", links));
                     } else if (key.endsWith("_multi_val")) {
@@ -359,10 +358,9 @@ public class QueryResultTable extends QueryResult {
                             String rawLabel = (labels != null && i < labels.length && !labels[i].isBlank()) ? Utils.unescapeMultiValue(labels[i]) : null;
                             if (part.matches("https?://.+")) {
                                 if (rawLabel != null && rawLabel.equals(part)) rawLabel = null;
-                                String label = truncateLabel(rawLabel);
-                                components.add(new NanodashLink("component", part, null, null, label, contextId));
+                                components.add(new NanodashLink("component", part, null, null, rawLabel, contextId));
                             } else {
-                                String label = truncateLabel(rawLabel);
+                                String label = rawLabel;
                                 String unescaped = Utils.unescapeMultiValue(part);
                                 if (label == null && Utils.isDateTimeLiteral(unescaped)) {
                                     // Friendly relative time, matching single-value cells.
@@ -404,13 +402,13 @@ public class QueryResultTable extends QueryResult {
                         }
                         cellItem.add(new ComponentSequence(componentId, ", ", components));
                     } else if (key.endsWith("template_iri")) {
-                        String label = truncateLabel(rowModel.getObject().get(key + "_label"));
+                        String label = rowModel.getObject().get(key + "_label");
                         if (label == null || label.isBlank()) label = truncateLabel(value);
                         String templateUrl = PublishPage.MOUNT_PATH + "?template=" + Utils.urlEncode(value) + "&template-version=latest" + templateLinkContextParam();
                         String html = "<a href=\"" + Strings.escapeMarkup(templateUrl) + "\">" + Strings.escapeMarkup(label) + "</a>";
                         cellItem.add(new Label(componentId, html).setEscapeModelStrings(false));
                     } else if (value.matches("https?://.+")) {
-                        String label = truncateLabel(rowModel.getObject().get(key + "_label"));
+                        String label = rowModel.getObject().get(key + "_label");
                         cellItem.add(new NanodashLink(componentId, value, null, null, label, contextId));
                     } else {
                         String litLabel = rowModel.getObject().get(key + "_label");


### PR DESCRIPTION
## Summary

Labels explicitly returned by queries (via `_label` columns) were truncated for display — to 47 characters in `NanodashLink` and pre-truncated to 100 characters in `QueryResultTable` — so full sentence labels rendered as e.g. "Only about one percent of rare earth elements i...".

Explicit query labels are now shown in full; any desired shortening can be done in SPARQL instead. Only labels the code derives itself are still truncated:

- `NanodashLink` tracks whether the label was caller-supplied (`explicitLabel`) and skips `Utils.truncateLinkLabel` for those; labels derived from the URI, or replaced by user/space/maintained-resource display names, keep the existing truncation. The old 4-arg `createLink` delegates with `explicitLabel=false`, so other callers (breadcrumbs, nanopub card headers, etc.) are unchanged.
- `QueryResultTable` no longer applies `Utils.truncateLabel` to explicit `_label`/`_label_multi` values (single-IRI, `_multi_iri`, `_multi_val`, and `template_iri` cell paths); the only remaining truncation there is the `template_iri` fallback that displays the raw IRI.

The `" - "` label–description split still applies to explicit labels (unchanged convention).

## Test plan

- `mvn compile` clean; `TripleItemTest` (exercises `NanodashLink`) passes.
- Verify a view display whose query returns long explicit labels (e.g. https://w3id.org/np/RAmqsIE2dSwiaFya1rrzTs1FFbkKFCsuqx7FXpluiNXeo) now shows the full label, wrapping in the cell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)