### PR TITLE
fix: prevent action menu trigger from submitting enclosing form

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/component/menu/BaseDisplayMenu.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/menu/BaseDisplayMenu.html
@@ -3,7 +3,7 @@
 <body>
 <wicket:panel>
   <span class="actionmenu">
-    <button class="actionmenu-button" aria-label="actions"></button>
+    <button type="button" class="actionmenu-button" aria-label="actions"></button>
     <span class="actionmenu-content">
       <wicket:child/>
     </span>


### PR DESCRIPTION
Clicking the dropdown menu trigger (chevron) next to the template title on a publish page triggered the Publish action.

The trigger `<button>` in `BaseDisplayMenu.html` had no `type` attribute, so inside the publish form it defaulted to `type="submit"`. The menu itself opens purely via CSS `:hover`, so the button needs no click behavior — adding `type="button"` makes the click a no-op.

This fixes the trigger for all menus extending `BaseDisplayMenu` (ViewDisplayMenu, EntryActionMenu, ActionMenu); outside forms the behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)