### PR TITLE
feat: query-form views (gen:QueryFormView) with view-results page

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/View.java
+++ b/src/main/java/com/knowledgepixels/nanodash/View.java
@@ -286,6 +286,7 @@ public class View implements Serializable {
     private Map<IRI, List<String>> actionTemplateQueryMappingsMap = new HashMap<>();
     private Map<IRI, String> labelMap = new HashMap<>();
     private IRI viewType;
+    private boolean queryForm = false;
     private Map<IRI, Set<IRI>> actionVisibleToMap = new HashMap<>();
 
     private View(String id, Nanopub nanopub) {
@@ -301,6 +302,9 @@ public class View implements Serializable {
                     }
                     if (st.getObject() instanceof IRI objIri && supportedViewTypes.contains(objIri)) {
                         viewType = objIri;
+                    }
+                    if (st.getObject().equals(KPXL_TERMS.QUERY_FORM_VIEW)) {
+                        queryForm = true;
                     }
                 } else if (st.getPredicate().equals(DCTERMS.IS_VERSION_OF) && st.getObject() instanceof IRI objIri) {
                     viewKind = objIri;
@@ -647,6 +651,18 @@ public class View implements Serializable {
      */
     public IRI getViewType() {
         return viewType;
+    }
+
+    /**
+     * Whether this view is additionally typed {@code gen:QueryFormView}: on a resource
+     * page it renders as a form for the query placeholders not auto-filled from the
+     * page context, whose submission leads to the full results page. Orthogonal to
+     * {@link #getViewType()}, which then determines how those results render.
+     *
+     * @return true if this is a query-form view
+     */
+    public boolean hasQueryForm() {
+        return queryForm;
     }
 
     /**

--- a/src/main/java/com/knowledgepixels/nanodash/ViewDisplay.java
+++ b/src/main/java/com/knowledgepixels/nanodash/ViewDisplay.java
@@ -312,6 +312,19 @@ public class ViewDisplay implements Serializable, Comparable<ViewDisplay> {
         return this;
     }
 
+    /**
+     * Overrides the title shown by the result components. An empty string hides the
+     * title row entirely (used on the view-results page, where the query form above
+     * already shows the view's icon+title).
+     *
+     * @param title the title to show, or "" to hide it
+     * @return this view display, for chaining
+     */
+    public ViewDisplay withTitle(String title) {
+        this.title = title;
+        return this;
+    }
+
     public String getStructuralPosition() {
         if (structuralPosition != null) return structuralPosition;
         if (view == null) return "5.5.default";

--- a/src/main/java/com/knowledgepixels/nanodash/WicketApplication.java
+++ b/src/main/java/com/knowledgepixels/nanodash/WicketApplication.java
@@ -185,6 +185,7 @@ public class WicketApplication extends WebApplication implements NanopubPublishe
         mountPage(SpacePage.MOUNT_PATH, SpacePage.class);
         mountPage(QueryPage.MOUNT_PATH, QueryPage.class);
         mountPage(QueryListPage.MOUNT_PATH, QueryListPage.class);
+        mountPage(ViewResultsPage.MOUNT_PATH, ViewResultsPage.class);
         mountPage(ListPage.MOUNT_PATH, ListPage.class);
         mountPage(MaintainedResourcePage.MOUNT_PATH, MaintainedResourcePage.class);
         mountPage(ResourcePartPage.MOUNT_PATH, ResourcePartPage.class);

--- a/src/main/java/com/knowledgepixels/nanodash/component/NanopubResults.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/NanopubResults.html
@@ -9,6 +9,7 @@
 
 <wicket:panel>
   <div class="nanopub-item" wicket:id="nanopubs">
+    <div class="nanopub-entry-actions" wicket:id="entry-actions"></div>
     <span wicket:id="nanopub"></span>
   </div>
 

--- a/src/main/java/com/knowledgepixels/nanodash/component/NanopubResults.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/NanopubResults.java
@@ -1,10 +1,14 @@
 package com.knowledgepixels.nanodash.component;
 
+import java.io.Serializable;
 import java.util.List;
 
+import org.apache.wicket.Component;
 import org.apache.wicket.ajax.markup.html.navigation.paging.AjaxPagingNavigator;
 import org.apache.wicket.extensions.markup.html.repeater.data.table.NavigatorLabel;
 import org.apache.wicket.markup.html.WebMarkupContainer;
+import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.link.AbstractLink;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.markup.repeater.Item;
 import org.apache.wicket.markup.repeater.data.DataView;
@@ -13,11 +17,28 @@ import org.nanopub.extra.services.ApiResponse;
 import org.nanopub.extra.services.ApiResponseEntry;
 
 import com.knowledgepixels.nanodash.NanopubElement;
+import com.knowledgepixels.nanodash.component.menu.EntryActionMenu;
 
 /**
  * A panel that displays a list of nanopubs.
  */
 public class NanopubResults extends Panel {
+
+    /**
+     * Provider of per-card entry-action links (a view's {@code gen:ViewEntryAction}s
+     * applied to the card's result row); each link must use the markup id {@code "link"}.
+     */
+    public interface EntryActions extends Serializable {
+
+        /**
+         * Builds the entry-action links for one result row.
+         *
+         * @param row the result row backing the card
+         * @return the links (never null; empty for no menu)
+         */
+        List<AbstractLink> build(ApiResponseEntry row);
+
+    }
 
     /**
      * Creates a NanopubResults panel from a list of NanopubElements.
@@ -33,6 +54,7 @@ public class NanopubResults extends Panel {
             @Override
             protected void populateItem(Item<NanopubElement> item) {
                 item.add(new NanopubItem("nanopub", item.getModelObject()).setMinimal());
+                item.add(new Label("entry-actions").setVisible(false));
             }
 
         };
@@ -62,12 +84,31 @@ public class NanopubResults extends Panel {
     }
 
     public static NanopubResults fromApiResponse(String id, List<ApiResponseEntry> data, long itemPerPage) {
+        return fromApiResponse(id, data, itemPerPage, null);
+    }
+
+    /**
+     * As {@link #fromApiResponse(String, List, long)}, with a per-card dropdown of
+     * entry-action links built from each card's result row.
+     *
+     * @param id           the component id
+     * @param data         the result rows (one card per row, from its "np" column)
+     * @param itemPerPage  the number of cards per page
+     * @param entryActions the per-card entry-action provider, or null for none
+     * @return a new NanopubResults panel
+     */
+    public static NanopubResults fromApiResponse(String id, List<ApiResponseEntry> data, long itemPerPage, EntryActions entryActions) {
         NanopubResults r = new NanopubResults(id);
         DataView<ApiResponseEntry> dataView = new DataView<ApiResponseEntry>("nanopubs", new ListDataProvider<ApiResponseEntry>(data)) {
 
             @Override
             protected void populateItem(Item<ApiResponseEntry> item) {
                 item.add(new NanopubItem("nanopub", NanopubElement.get(item.getModelObject().get("np"))).setMinimal());
+                List<AbstractLink> links = (entryActions == null) ? List.of() : entryActions.build(item.getModelObject());
+                Component actionsComponent = links.isEmpty()
+                        ? new Label("entry-actions").setVisible(false)
+                        : new EntryActionMenu("entry-actions", links);
+                item.add(actionsComponent);
             }
 
         };

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryFormPanel.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryFormPanel.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html xmlns:wicket="http://wicket.apache.org">
+
+<head>
+  <link rel="stylesheet" href="../../../../../webapp/style.css?for-local-testing-only" type="text/css" media="screen"
+        title="Stylesheet"/>
+</head>
+<body>
+
+<wicket:panel>
+  <div class="paneltitlerow">
+    <h4 wicket:id="label">Query form</h4>
+    <span class="buttons"><wicket:container wicket:id="np">[np]</wicket:container></span>
+  </div>
+
+  <form wicket:id="form">
+    <div wicket:id="params">
+      <table class="paramtable">
+        <tbody>
+        <wicket:container wicket:id="paramfields">
+          <wicket:container wicket:id="paramfield">Param field</wicket:container>
+        </wicket:container>
+        </tbody>
+      </table>
+    </div>
+    <input type="submit" class="button" value="Search" style="margin: 0;"/>
+  </form>
+
+  <div wicket:id="feedback" class="negative">feedback messages will be put here</div>
+</wicket:panel>
+
+</body>
+
+</html>

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryFormPanel.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryFormPanel.java
@@ -171,6 +171,10 @@ public class QueryFormPanel extends Panel {
         });
         paramContainer.setVisible(!paramFields.isEmpty());
         form.add(paramContainer);
+        // On the standalone results page a form without any fields is redundant (the
+        // results are already shown); embedded on a resource page it stays, since its
+        // Search button is what leads to the full results page.
+        form.setVisible(!(paramFields.isEmpty() && pageResource == null));
         add(form);
 
         feedbackPanel = new FeedbackPanel("feedback");

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryFormPanel.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryFormPanel.java
@@ -4,12 +4,16 @@ import com.google.common.collect.Multimap;
 import com.knowledgepixels.nanodash.GrlcQuery;
 import com.knowledgepixels.nanodash.MagicQueryParams;
 import com.knowledgepixels.nanodash.NavigationContext;
+import com.knowledgepixels.nanodash.QueryResult;
+import com.knowledgepixels.nanodash.SpaceMemberRole;
 import com.knowledgepixels.nanodash.View;
 import com.knowledgepixels.nanodash.ViewDisplay;
 import com.knowledgepixels.nanodash.component.menu.ViewDisplayMenu;
 import com.knowledgepixels.nanodash.domain.AbstractResourceWithProfile;
 import com.knowledgepixels.nanodash.page.NanodashPage;
+import com.knowledgepixels.nanodash.page.PublishPage;
 import com.knowledgepixels.nanodash.page.ViewResultsPage;
+import com.knowledgepixels.nanodash.template.Template;
 import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.feedback.FeedbackMessage;
 import org.apache.wicket.markup.html.WebMarkupContainer;
@@ -20,6 +24,7 @@ import org.apache.wicket.markup.html.list.ListView;
 import org.apache.wicket.markup.html.panel.FeedbackPanel;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
+import org.eclipse.rdf4j.model.IRI;
 import org.nanopub.extra.services.QueryRef;
 import org.nanopub.extra.services.QueryTemplate;
 
@@ -73,7 +78,26 @@ public class QueryFormPanel extends Panel {
         add(new Label("label", viewDisplay.getTitle()));
 
         if (pageResource != null && viewDisplay.getNanopubId() != null) {
-            add(new ViewDisplayMenu("np", viewDisplay, new QueryRef(query.getQueryId(), fixedParams), pageResource, List.of()));
+            // The view's result actions become the top entries of the dropdown, as on
+            // regular view displays; the target field is pre-filled with the page's
+            // resource (there are no query results here to map values from).
+            List<QueryResult.MenuAction> menuActions = new ArrayList<>();
+            for (IRI actionIri : view.getViewResultActionList()) {
+                if (!SpaceMemberRole.isViewerEntitled(view.getActionVisibleTo(actionIri), pageResource, null)) continue;
+                Template t = view.getTemplateForAction(actionIri);
+                if (t == null) continue;
+                String targetField = view.getTemplateTargetFieldForAction(actionIri);
+                if (targetField == null) targetField = "resource";
+                String label = view.getLabelForAction(actionIri);
+                if (label == null) label = "action...";
+                if (!label.endsWith("...")) label += "...";
+                PageParameters actionParams = new PageParameters().set("template", t.getId())
+                        .set("param_" + targetField, pageResource.getId())
+                        .set("context", pageResource.getId())
+                        .set("template-version", "latest");
+                menuActions.add(new QueryResult.MenuAction(label, PublishPage.class, actionParams));
+            }
+            add(new ViewDisplayMenu("np", viewDisplay, new QueryRef(query.getQueryId(), fixedParams), pageResource, menuActions));
         } else {
             add(new Label("np").setVisible(false));
         }

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryFormPanel.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryFormPanel.java
@@ -1,0 +1,157 @@
+package com.knowledgepixels.nanodash.component;
+
+import com.google.common.collect.Multimap;
+import com.knowledgepixels.nanodash.GrlcQuery;
+import com.knowledgepixels.nanodash.MagicQueryParams;
+import com.knowledgepixels.nanodash.NavigationContext;
+import com.knowledgepixels.nanodash.View;
+import com.knowledgepixels.nanodash.ViewDisplay;
+import com.knowledgepixels.nanodash.component.menu.ViewDisplayMenu;
+import com.knowledgepixels.nanodash.domain.AbstractResourceWithProfile;
+import com.knowledgepixels.nanodash.page.NanodashPage;
+import com.knowledgepixels.nanodash.page.ViewResultsPage;
+import org.apache.wicket.AttributeModifier;
+import org.apache.wicket.feedback.FeedbackMessage;
+import org.apache.wicket.markup.html.WebMarkupContainer;
+import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.form.Form;
+import org.apache.wicket.markup.html.list.ListItem;
+import org.apache.wicket.markup.html.list.ListView;
+import org.apache.wicket.markup.html.panel.FeedbackPanel;
+import org.apache.wicket.markup.html.panel.Panel;
+import org.apache.wicket.request.mapper.parameter.PageParameters;
+import org.nanopub.extra.services.QueryRef;
+import org.nanopub.extra.services.QueryTemplate;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Panel rendering a query-form view ({@code gen:QueryFormView}): a form with a field
+ * for each of the view query's placeholders that is neither magic (session-bound) nor
+ * fixed by the page context. Submitting redirects to {@link ViewResultsPage}, where
+ * the results render according to the view's display type. The fixed parameters are
+ * carried along in the redirect.
+ */
+public class QueryFormPanel extends Panel {
+
+    private final Form<?> form;
+    private final List<QueryParamField> paramFields;
+    private final FeedbackPanel feedbackPanel;
+
+    /**
+     * Constructs a QueryFormPanel.
+     *
+     * @param id          the Wicket component ID
+     * @param viewDisplay the view display of the query-form view
+     * @param fixedParams parameter values fixed by the page context (auto-filled, not
+     *                    shown as form fields), keyed by parameter name
+     */
+    public QueryFormPanel(String id, ViewDisplay viewDisplay, Multimap<String, String> fixedParams) {
+        this(id, viewDisplay, fixedParams, null, null);
+    }
+
+    /**
+     * Constructs a QueryFormPanel with initial field values.
+     *
+     * @param id            the Wicket component ID
+     * @param viewDisplay   the view display of the query-form view
+     * @param fixedParams   parameter values fixed by the page context (auto-filled, not
+     *                      shown as form fields), keyed by parameter name
+     * @param initialValues values to pre-fill the form fields with (e.g. the previously
+     *                      submitted ones), keyed by parameter name; may be null
+     * @param pageResource  the resource whose page the panel is on; non-null makes the
+     *                      panel carry the standard view-display dropdown menu (null on
+     *                      the view-results page, where the results part carries it)
+     */
+    public QueryFormPanel(String id, ViewDisplay viewDisplay, Multimap<String, String> fixedParams, Multimap<String, String> initialValues, AbstractResourceWithProfile pageResource) {
+        super(id);
+        final View view = viewDisplay.getView();
+        GrlcQuery query = view.getQuery();
+
+        add(new Label("label", viewDisplay.getTitle()));
+
+        if (pageResource != null && viewDisplay.getNanopubId() != null) {
+            add(new ViewDisplayMenu("np", viewDisplay, new QueryRef(query.getQueryId(), fixedParams), pageResource, List.of()));
+        } else {
+            add(new Label("np").setVisible(false));
+        }
+
+        form = new Form<Void>("form") {
+
+            @Override
+            protected void onSubmit() {
+                PageParameters params = new PageParameters();
+                params.set("view", view.getId());
+                for (Map.Entry<String, String> e : fixedParams.entries()) {
+                    params.add("queryparam_" + e.getKey(), e.getValue());
+                }
+                for (QueryParamField f : paramFields) {
+                    for (String v : f.getValues()) {
+                        params.add("queryparam_" + f.getParamName(), v);
+                    }
+                }
+                // Carry the navigation context along, so the results page shows the
+                // "< [resource]" back-crumb of the page the search started from.
+                if (getPage() instanceof NanodashPage page) {
+                    NavigationContext.withContext(params, page.getContextId());
+                }
+                setResponsePage(ViewResultsPage.class, params);
+            }
+
+            @Override
+            protected void onError() {
+                // Move validation messages to the session: on a resource page this
+                // panel sits in ViewList's ListView, which recreates it on the error
+                // re-render, discarding component-scoped messages (they also wouldn't
+                // survive the auto-refresh redirect). Session-scoped ones render in
+                // the recreated panel's feedback panel and are cleared after showing.
+                for (QueryParamField f : paramFields) {
+                    for (FeedbackMessage fm : f.getFormComponent().getFeedbackMessages()) {
+                        getSession().error(String.valueOf(fm.getMessage()));
+                    }
+                    f.getFormComponent().getFeedbackMessages().clear();
+                }
+            }
+
+        };
+        form.setOutputMarkupId(true);
+
+        paramFields = new ArrayList<>();
+        for (String p : query.getPlaceholdersList()) {
+            // Magic placeholders are bound from the session, fixed ones from the page context.
+            if (MagicQueryParams.isMagic(p)) continue;
+            String paramName = QueryTemplate.getParamName(p);
+            if (fixedParams.containsKey(paramName)) continue;
+            QueryParamField field = new QueryParamField("paramfield", p);
+            if (initialValues != null) {
+                for (String v : initialValues.get(paramName)) {
+                    field.putValue(v);
+                }
+            }
+            if (!field.isOptional()) {
+                // Let the browser catch the empty-mandatory case before it reaches
+                // the server (same pattern as the basic search forms).
+                field.getFormComponent().add(AttributeModifier.replace("required", "required"));
+            }
+            paramFields.add(field);
+        }
+        WebMarkupContainer paramContainer = new WebMarkupContainer("params");
+        paramContainer.add(new ListView<QueryParamField>("paramfields", paramFields) {
+
+            protected void populateItem(ListItem<QueryParamField> item) {
+                item.add(item.getModelObject());
+            }
+
+        });
+        paramContainer.setVisible(!paramFields.isEmpty());
+        form.add(paramContainer);
+        add(form);
+
+        feedbackPanel = new FeedbackPanel("feedback");
+        feedbackPanel.setOutputMarkupId(true);
+        add(feedbackPanel);
+    }
+
+}

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryFormPanel.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryFormPanel.java
@@ -182,4 +182,14 @@ public class QueryFormPanel extends Panel {
         add(feedbackPanel);
     }
 
+    /**
+     * Hides the form part, leaving only the title row (with the dropdown menu). Used on
+     * the view-results page for views that are not query-form views: their query
+     * parameters are fixed (carried in the URL), so the fields are not user-facing —
+     * just as they are hidden when the view is shown on a resource page.
+     */
+    public void hideForm() {
+        form.setVisible(false);
+    }
+
 }

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryFormPanel.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryFormPanel.java
@@ -182,14 +182,4 @@ public class QueryFormPanel extends Panel {
         add(feedbackPanel);
     }
 
-    /**
-     * Hides the form part, leaving only the title row (with the dropdown menu). Used on
-     * the view-results page for views that are not query-form views: their query
-     * parameters are fixed (carried in the URL), so the fields are not user-facing —
-     * just as they are hidden when the view is shown on a resource page.
-     */
-    public void hideForm() {
-        form.setVisible(false);
-    }
-
 }

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultComponentFactory.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultComponentFactory.java
@@ -63,8 +63,11 @@ public class QueryResultComponentFactory {
                     .build();
         } else if (viewType.equals(KPXL_TERMS.NANOPUB_SET_VIEW)) {
             return QueryResultNanopubSetBuilder.create(markupId, queryRef, viewDisplay)
+                    .resourceWithProfile(resourceWithProfile)
                     .pageResource(resourceWithProfile)
+                    .id(id)
                     .contextId(contextId)
+                    .refRoot(refRoot)
                     .build();
         } else if (viewType.equals(KPXL_TERMS.ITEM_LIST_VIEW)) {
             return QueryResultItemListBuilder.create(markupId, queryRef, viewDisplay)
@@ -72,6 +75,7 @@ public class QueryResultComponentFactory {
                     .pageResource(resourceWithProfile)
                     .id(id)
                     .contextId(contextId)
+                    .refRoot(refRoot)
                     .build();
         }
         return null;

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultComponentFactory.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultComponentFactory.java
@@ -1,0 +1,80 @@
+package com.knowledgepixels.nanodash.component;
+
+import com.knowledgepixels.nanodash.View;
+import com.knowledgepixels.nanodash.ViewDisplay;
+import com.knowledgepixels.nanodash.domain.AbstractResourceWithProfile;
+import com.knowledgepixels.nanodash.vocabulary.KPXL_TERMS;
+import org.apache.wicket.Component;
+import org.eclipse.rdf4j.model.IRI;
+import org.nanopub.extra.services.QueryRef;
+
+/**
+ * Maps a view's display type to the matching query-result component. The single
+ * place where the display-type IRIs are dispatched to their builders, shared by
+ * {@link ViewList} (views on resource pages) and
+ * {@link com.knowledgepixels.nanodash.page.ViewResultsPage} (the standalone
+ * results page a query-form view leads to).
+ */
+public class QueryResultComponentFactory {
+
+    private QueryResultComponentFactory() {
+    }
+
+    /**
+     * Builds the result component for the given view display's display type.
+     *
+     * @param markupId            the markup ID for the component
+     * @param queryRef            the query reference to show the results of
+     * @param viewDisplay         the view display (determines display type, title, width, page size)
+     * @param resourceWithProfile the resource whose page the component is on, or null on a
+     *                            standalone page (view actions needing a resource context are
+     *                            then omitted by the builders)
+     * @param id                  the resource or part id the view is shown for, or null
+     * @param contextId           the context id, or null
+     * @param refRoot             the pinned ref's root nanopub, or null
+     * @return the component, or null if the view has no or an unrecognized display type
+     */
+    public static Component build(String markupId, QueryRef queryRef, ViewDisplay viewDisplay,
+            AbstractResourceWithProfile resourceWithProfile, String id, String contextId, String refRoot) {
+        View view = viewDisplay.getView();
+        IRI viewType = (view == null ? null : view.getViewType());
+        if (viewType == null) return null;
+        if (viewType.equals(KPXL_TERMS.LIST_VIEW)) {
+            return QueryResultListBuilder.create(markupId, queryRef, viewDisplay)
+                    .resourceWithProfile(resourceWithProfile)
+                    .pageResource(resourceWithProfile)
+                    .id(id)
+                    .contextId(contextId)
+                    .refRoot(refRoot)
+                    .build();
+        } else if (viewType.equals(KPXL_TERMS.TABULAR_VIEW)) {
+            return QueryResultTableBuilder.create(markupId, queryRef, viewDisplay)
+                    .resourceWithProfile(resourceWithProfile)
+                    .contextId(contextId)
+                    .id(id)
+                    .refRoot(refRoot)
+                    .build();
+        } else if (viewType.equals(KPXL_TERMS.PLAIN_PARAGRAPH_VIEW)) {
+            return QueryResultPlainParagraphBuilder.create(markupId, queryRef, viewDisplay)
+                    .pageResource(resourceWithProfile)
+                    .contextId(contextId)
+                    .id(id)
+                    .refRoot(refRoot)
+                    .build();
+        } else if (viewType.equals(KPXL_TERMS.NANOPUB_SET_VIEW)) {
+            return QueryResultNanopubSetBuilder.create(markupId, queryRef, viewDisplay)
+                    .pageResource(resourceWithProfile)
+                    .contextId(contextId)
+                    .build();
+        } else if (viewType.equals(KPXL_TERMS.ITEM_LIST_VIEW)) {
+            return QueryResultItemListBuilder.create(markupId, queryRef, viewDisplay)
+                    .resourceWithProfile(resourceWithProfile)
+                    .pageResource(resourceWithProfile)
+                    .id(id)
+                    .contextId(contextId)
+                    .build();
+        }
+        return null;
+    }
+
+}

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultItemList.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultItemList.html
@@ -10,7 +10,7 @@
 <wicket:panel>
   <div class="paneltitlerow listpanel">
     <h4 wicket:id="label">Query</h4>
-    <input type="text" wicket:id="filter" placeholder="Filter..." style="margin: 5px 10px; padding: 2px 5px; font-size: 12px; width: 150px;"/>
+    <input type="text" wicket:id="filter" class="panelfilter" placeholder="Filter..."/>
     <span class="buttons"><wicket:container wicket:id="np">[np]</wicket:container></span>
     <span wicket:id="buttons" class="buttons"></span>
   </div>

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultItemList.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultItemList.html
@@ -16,8 +16,8 @@
   </div>
 
   <div wicket:id="items-container">
-    <ul wicket:id="items">
-      <li wicket:id="listItem"></li>
+    <ul>
+      <li wicket:id="items"><wicket:container wicket:id="listItem"></wicket:container> <wicket:container wicket:id="entryActions"></wicket:container></li>
     </ul>
     <p wicket:id="no-records" class="no-records-note">(nothing found)</p>
     <div class="navigation" wicket:id="navigation">

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultItemList.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultItemList.java
@@ -40,7 +40,7 @@ public class QueryResultItemList extends QueryResult {
         if (viewDisplay.getTitle() != null) {
             label = viewDisplay.getTitle();
         }
-        add(new Label("label", label));
+        add(new Label("label", label).setVisible(label != null && !label.isEmpty()));
         setOutputMarkupId(true);
 
         TextField<String> filterField = new TextField<>("filter", filterModel);

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultItemList.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultItemList.java
@@ -1,11 +1,14 @@
 package com.knowledgepixels.nanodash.component;
 
 import com.knowledgepixels.nanodash.*;
+import com.knowledgepixels.nanodash.component.menu.EntryActionMenu;
 import com.knowledgepixels.nanodash.domain.IndividualAgent;
 import com.knowledgepixels.nanodash.domain.User;
 import com.knowledgepixels.nanodash.page.PublishPage;
 import com.knowledgepixels.nanodash.page.UserPage;
+import org.apache.wicket.Component;
 import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.markup.html.link.AbstractLink;
 import org.apache.wicket.ajax.markup.html.navigation.paging.AjaxPagingNavigator;
 import org.apache.wicket.extensions.markup.html.repeater.data.table.NavigatorLabel;
 import org.apache.wicket.markup.html.WebMarkupContainer;
@@ -21,6 +24,8 @@ import org.eclipse.rdf4j.model.IRI;
 import org.nanopub.extra.services.ApiResponse;
 import org.nanopub.extra.services.ApiResponseEntry;
 import org.nanopub.extra.services.QueryRef;
+
+import java.util.List;
 
 /**
  * Component for displaying query results as a vertical item list.
@@ -69,57 +74,15 @@ public class QueryResultItemList extends QueryResult {
             @Override
             protected void populateItem(Item<ApiResponseEntry> item) {
                 ApiResponseEntry entry = item.getModelObject();
-                for (String key : response.getHeader()) {
-                    if (key.endsWith("_label") || key.endsWith("_label_multi")) continue;
-                    String value = entry.get(key);
-                    if (value == null || value.isBlank()) continue;
-                    String entryLabel = entry.get(key + "_label");
-
-                    if (key.endsWith("user_iri")) {
-                        IRI userIri = Utils.vf.createIRI(value);
-                        IRI profilePicIri = User.getProfilePicture(userIri);
-                        String imgSrc;
-                        String iconClass;
-                        if (profilePicIri != null) {
-                            imgSrc = Strings.escapeMarkup(profilePicIri.stringValue()).toString();
-                            iconClass = "user-icon";
-                        } else if (IndividualAgent.isSoftware(userIri)) {
-                            imgSrc = RequestCycle.get().urlFor(new ContextRelativeResourceReference("images/bot-icon.svg", false), null).toString();
-                            iconClass = "bot-icon";
-                        } else {
-                            imgSrc = RequestCycle.get().urlFor(new ContextRelativeResourceReference("images/user-icon.svg", false), null).toString();
-                            iconClass = "user-icon";
-                        }
-                        String displayLabel = (entryLabel != null && !entryLabel.isBlank()) ? entryLabel : User.getShortDisplayName(userIri);
-                        String userUrl = UserPage.MOUNT_PATH + "?id=" + Utils.urlEncode(value);
-                        String html = "<img class=\"" + iconClass + "\" src=\"" + imgSrc + "\" /> <a href=\"" + Strings.escapeMarkup(userUrl) + "\">" + Strings.escapeMarkup(displayLabel) + "</a>";
-                        item.add(new Label("listItem", html).setEscapeModelStrings(false));
-                        return;
-                    } else if (key.endsWith("template_iri")) {
-                        String displayLabel = (entryLabel != null && !entryLabel.isBlank()) ? entryLabel : value;
-                        String templateUrl = PublishPage.MOUNT_PATH + "?template=" + Utils.urlEncode(value) + "&template-version=latest" + templateLinkContextParam();
-                        String html = "<span class=\"form-icon\"></span> <a href=\"" + Strings.escapeMarkup(templateUrl) + "\">" + Strings.escapeMarkup(displayLabel) + "</a>";
-                        item.add(new Label("listItem", html).setEscapeModelStrings(false));
-                        return;
-                    } else if (value.matches("https?://.*")) {
-                        item.add(new NanodashLink("listItem", value, null, null, entryLabel, contextId));
-                        return;
-                    } else if (entryLabel != null && !entryLabel.isBlank() && !entryLabel.equals(value)) {
-                        // Separate display label for a (non-IRI) literal value; the full
-                        // literal is shown on hover via the standard styled tooltip.
-                        String html = "<span class=\"tooltip\"><span class=\"tooltiptext tooltiptext-auto\">" + Strings.escapeMarkup(value) + "</span>" + Strings.escapeMarkup(entryLabel) + "</span>";
-                        item.add(new Label("listItem", html).setEscapeModelStrings(false));
-                        return;
-                    } else if (Utils.isDateTimeLiteral(value)) {
-                        // Show a friendly relative time (client-side); raw ISO value stays as no-script fallback.
-                        item.add(new Label("listItem", Utils.friendlyDateHtml(value, value)).setEscapeModelStrings(false));
-                        return;
-                    } else {
-                        item.add(new Label("listItem", value));
-                        return;
-                    }
+                item.add(buildItemComponent(entry));
+                List<AbstractLink> actionLinks = ViewActionMappings.buildEntryActionLinks(viewDisplay.getView(), entry,
+                        queryRef, resourceWithProfile != null ? resourceWithProfile : pageResource,
+                        contextId, partId, refRoot, postPublishTab);
+                if (actionLinks.isEmpty()) {
+                    item.add(new Label("entryActions").setVisible(false));
+                } else {
+                    item.add(new EntryActionMenu("entryActions", actionLinks));
                 }
-                item.add(new Label("listItem", ""));
             }
         };
         dataView.setItemsPerPage(viewDisplay.getPageSize());
@@ -144,5 +107,57 @@ public class QueryResultItemList extends QueryResult {
         itemsContainer.add(noRecordsLabel);
         itemsContainer.add(navigation);
         add(itemsContainer);
+    }
+
+    /**
+     * Builds the row's single linked item (markup id {@code "listItem"}) from the
+     * first non-empty result column.
+     */
+    private Component buildItemComponent(ApiResponseEntry entry) {
+        for (String key : response.getHeader()) {
+            if (key.endsWith("_label") || key.endsWith("_label_multi")) continue;
+            String value = entry.get(key);
+            if (value == null || value.isBlank()) continue;
+            String entryLabel = entry.get(key + "_label");
+
+            if (key.endsWith("user_iri")) {
+                IRI userIri = Utils.vf.createIRI(value);
+                IRI profilePicIri = User.getProfilePicture(userIri);
+                String imgSrc;
+                String iconClass;
+                if (profilePicIri != null) {
+                    imgSrc = Strings.escapeMarkup(profilePicIri.stringValue()).toString();
+                    iconClass = "user-icon";
+                } else if (IndividualAgent.isSoftware(userIri)) {
+                    imgSrc = RequestCycle.get().urlFor(new ContextRelativeResourceReference("images/bot-icon.svg", false), null).toString();
+                    iconClass = "bot-icon";
+                } else {
+                    imgSrc = RequestCycle.get().urlFor(new ContextRelativeResourceReference("images/user-icon.svg", false), null).toString();
+                    iconClass = "user-icon";
+                }
+                String displayLabel = (entryLabel != null && !entryLabel.isBlank()) ? entryLabel : User.getShortDisplayName(userIri);
+                String userUrl = UserPage.MOUNT_PATH + "?id=" + Utils.urlEncode(value);
+                String html = "<img class=\"" + iconClass + "\" src=\"" + imgSrc + "\" /> <a href=\"" + Strings.escapeMarkup(userUrl) + "\">" + Strings.escapeMarkup(displayLabel) + "</a>";
+                return new Label("listItem", html).setEscapeModelStrings(false);
+            } else if (key.endsWith("template_iri")) {
+                String displayLabel = (entryLabel != null && !entryLabel.isBlank()) ? entryLabel : value;
+                String templateUrl = PublishPage.MOUNT_PATH + "?template=" + Utils.urlEncode(value) + "&template-version=latest" + templateLinkContextParam();
+                String html = "<span class=\"form-icon\"></span> <a href=\"" + Strings.escapeMarkup(templateUrl) + "\">" + Strings.escapeMarkup(displayLabel) + "</a>";
+                return new Label("listItem", html).setEscapeModelStrings(false);
+            } else if (value.matches("https?://.*")) {
+                return new NanodashLink("listItem", value, null, null, entryLabel, contextId);
+            } else if (entryLabel != null && !entryLabel.isBlank() && !entryLabel.equals(value)) {
+                // Separate display label for a (non-IRI) literal value; the full
+                // literal is shown on hover via the standard styled tooltip.
+                String html = "<span class=\"tooltip\"><span class=\"tooltiptext tooltiptext-auto\">" + Strings.escapeMarkup(value) + "</span>" + Strings.escapeMarkup(entryLabel) + "</span>";
+                return new Label("listItem", html).setEscapeModelStrings(false);
+            } else if (Utils.isDateTimeLiteral(value)) {
+                // Show a friendly relative time (client-side); raw ISO value stays as no-script fallback.
+                return new Label("listItem", Utils.friendlyDateHtml(value, value)).setEscapeModelStrings(false);
+            } else {
+                return new Label("listItem", value);
+            }
+        }
+        return new Label("listItem", "");
     }
 }

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultItemListBuilder.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultItemListBuilder.java
@@ -19,7 +19,10 @@ public class QueryResultItemListBuilder implements Serializable {
     private final ViewDisplay viewDisplay;
     private String contextId = null;
     private final QueryRef queryRef;
+    private AbstractResourceWithProfile resourceWithProfile = null;
     private AbstractResourceWithProfile pageResource = null;
+    private String id = null;
+    private String refRoot = null;
 
     private QueryResultItemListBuilder(String markupId, QueryRef queryRef, ViewDisplay viewDisplay) {
         this.markupId = markupId;
@@ -39,10 +42,12 @@ public class QueryResultItemListBuilder implements Serializable {
     }
 
     public QueryResultItemListBuilder resourceWithProfile(AbstractResourceWithProfile resourceWithProfile) {
+        this.resourceWithProfile = resourceWithProfile;
         return this;
     }
 
     public QueryResultItemListBuilder id(String id) {
+        this.id = id;
         return this;
     }
 
@@ -51,27 +56,45 @@ public class QueryResultItemListBuilder implements Serializable {
         return this;
     }
 
+    /**
+     * Pins this list to a specific ref (root definition), so action visibility is gated
+     * against that claimant's authority rather than the resource's representative ref.
+     * Null leaves it on the representative ref.
+     *
+     * @param refRoot the ref's root nanopub, or null
+     * @return the current QueryResultItemListBuilder instance
+     */
+    public QueryResultItemListBuilder refRoot(String refRoot) {
+        this.refRoot = refRoot;
+        return this;
+    }
+
     public Component build() {
         ApiResponse response = ApiCache.retrieveResponseAsync(queryRef);
         String colClass = " col-" + viewDisplay.getDisplayWidth();
         if (response != null) {
-            QueryResultItemList result = new QueryResultItemList(markupId, queryRef, response, viewDisplay);
-            result.setContextId(contextId);
-            result.setPageResource(pageResource);
+            Component result = buildItemList(markupId, response);
             result.add(new AttributeAppender("class", colClass));
             return result;
         } else {
             ApiResultComponent comp = new ApiResultComponent(markupId, queryRef) {
                 @Override
                 public Component getApiResultComponent(String id, ApiResponse r) {
-                    QueryResultItemList result = new QueryResultItemList(id, queryRef, r, viewDisplay);
-                    result.setContextId(contextId);
-                    result.setPageResource(pageResource);
-                    return result;
+                    return buildItemList(id, r);
                 }
             };
             comp.add(new AttributeAppender("class", colClass));
             return comp;
         }
+    }
+
+    private QueryResultItemList buildItemList(String markupId, ApiResponse response) {
+        QueryResultItemList result = new QueryResultItemList(markupId, queryRef, response, viewDisplay);
+        result.setContextId(contextId);
+        result.setPageResource(pageResource);
+        result.setResourceWithProfile(resourceWithProfile);
+        result.setRefRoot(refRoot);
+        ViewActionMappings.addResultActions(result, viewDisplay, queryRef, id, contextId, resourceWithProfile, refRoot);
+        return result;
     }
 }

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultList.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultList.html
@@ -10,7 +10,7 @@
 <wicket:panel>
   <div class="paneltitlerow listpanel">
     <h4 wicket:id="label">Query</h4>
-    <input type="text" wicket:id="filter" placeholder="Filter..." style="margin: 5px 10px; padding: 2px 5px; font-size: 12px; width: 150px;"/>
+    <input type="text" wicket:id="filter" class="panelfilter" placeholder="Filter..."/>
     <span class="buttons"><wicket:container wicket:id="np">[np]</wicket:container></span>
     <span wicket:id="buttons" class="buttons"></span>
   </div>

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultList.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultList.java
@@ -3,15 +3,12 @@ package com.knowledgepixels.nanodash.component;
 import com.knowledgepixels.nanodash.*;
 import com.knowledgepixels.nanodash.component.menu.EntryActionMenu;
 import com.knowledgepixels.nanodash.domain.IndividualAgent;
-import com.knowledgepixels.nanodash.domain.MaintainedResource;
 import com.knowledgepixels.nanodash.domain.User;
 import com.knowledgepixels.nanodash.page.ExplorePage;
 import com.knowledgepixels.nanodash.page.NanodashPage;
 import com.knowledgepixels.nanodash.page.PublishPage;
 import com.knowledgepixels.nanodash.page.QueryPage;
 import com.knowledgepixels.nanodash.page.UserPage;
-import com.knowledgepixels.nanodash.repository.MaintainedResourceRepository;
-import com.knowledgepixels.nanodash.template.Template;
 import org.apache.wicket.Component;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.markup.html.navigation.paging.AjaxPagingNavigator;
@@ -239,51 +236,8 @@ public class QueryResultList extends QueryResult {
                         }
                     }
                 }
-                View view = viewDisplay.getView();
-                List<AbstractLink> actionLinks = new ArrayList<>();
-                if (view != null) {
-                    for (IRI actionIri : view.getViewEntryActionList()) {
-                        // Per-action role gating (docs/role-specific-views.md): skip an
-                        // action whose gen:isVisibleTo the viewer does not satisfy.
-                        if (!SpaceMemberRole.isViewerEntitled(view.getActionVisibleTo(actionIri), resourceWithProfile, refRoot)) continue;
-                        // TODO Copied code and adjusted from QueryResultTableBuilder:
-                        Template t = view.getTemplateForAction(actionIri);
-                        if (t == null) continue;
-                        String targetField = view.getTemplateTargetFieldForAction(actionIri);
-                        if (targetField == null) targetField = "resource";
-                        String labelForAction = view.getLabelForAction(actionIri);
-                        if (labelForAction == null) labelForAction = "action...";
-                        if (!labelForAction.endsWith("...")) labelForAction += "...";
-                        PageParameters params = new PageParameters().set("template", t.getId())
-                                .set("param_" + targetField, contextId)
-                                .set("context", contextId)
-                                .set("template-version", "latest");
-                        String partField = view.getTemplatePartFieldForAction(actionIri);
-                        if (partField != null) {
-                            // TODO Find a better way to pass the MaintainedResource object to this method:
-                            MaintainedResource r = MaintainedResourceRepository.get().findById(contextId);
-                            if (r != null && r.getNamespace() != null) {
-                                params.set("param_" + partField, r.getNamespace() + "<SET-SUFFIX>");
-                            }
-                        }
-                        // Apply the action's query mappings; hide the button for this row
-                        // if any required mapped value is empty (docs/magic-query-params.md).
-                        if (!ViewActionMappings.applyEntryMappings(view, actionIri, entry, params)) {
-                            continue;
-                        }
-                        params.set("refresh-upon-publish", queryRef.getAsUrlString());
-                        if (postPublishTab != null) params.set("postpub-tab", postPublishTab);
-                        AbstractLink button = new BookmarkablePageLink<NanodashPage>("link", PublishPage.class, params);
-                        // A label that starts with a leading symbol/emoji renders that as the entry icon.
-                        String iconBody = Utils.menuEntryIconBodyHtml(labelForAction);
-                        if (iconBody != null) {
-                            button.setBody(Model.of(iconBody)).setEscapeModelStrings(false);
-                        } else {
-                            button.setBody(Model.of(labelForAction));
-                        }
-                        actionLinks.add(button);
-                    }
-                }
+                List<AbstractLink> actionLinks = ViewActionMappings.buildEntryActionLinks(viewDisplay.getView(), entry,
+                        queryRef, resourceWithProfile, contextId, partId, refRoot, postPublishTab);
                 // The former "^" source link joins the same dropdown, as a "source" entry.
                 if (sourceUri != null) {
                     AbstractLink sourceLink = new BookmarkablePageLink<NanodashPage>("link", ExplorePage.class,

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultList.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultList.java
@@ -69,7 +69,7 @@ public class QueryResultList extends QueryResult {
         if (viewDisplay.getTitle() != null) {
             label = viewDisplay.getTitle();
         }
-        add(new Label("label", label));
+        add(new Label("label", label).setVisible(label != null && !label.isEmpty()));
         setOutputMarkupId(true);
 
         TextField<String> filterField = new TextField<>("filter", filterModel);

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultListBuilder.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultListBuilder.java
@@ -236,6 +236,7 @@ public class QueryResultListBuilder implements Serializable {
                 QueryResultList resultList = new QueryResultList(markupId, queryRef, response, viewDisplay);
                 resultList.setPageResource(pageResource);
                 resultList.setContextId(contextId);
+                ViewActionMappings.addResultActions(resultList, viewDisplay, queryRef, id, contextId, null, refRoot);
                 resultList.add(new AttributeAppender("class", colClass));
                 return resultList;
             } else {
@@ -245,6 +246,7 @@ public class QueryResultListBuilder implements Serializable {
                         QueryResultList resultList = new QueryResultList(markupId, queryRef, response, viewDisplay);
                         resultList.setPageResource(pageResource);
                         resultList.setContextId(contextId);
+                        ViewActionMappings.addResultActions(resultList, viewDisplay, queryRef, id, contextId, null, refRoot);
                         return resultList;
                     }
                 };

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultNanopubSet.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultNanopubSet.java
@@ -57,6 +57,9 @@ public class QueryResultNanopubSet extends QueryResult {
             titleLabel = viewDisplay.getTitle();
         }
         add(new Label("title", titleLabel));
+        if (titleLabel == null || titleLabel.isEmpty()) {
+            setTitleVisible(false);
+        }
 
         TextField<String> filterField = new TextField<>("filter", filterModel);
         filterField.setOutputMarkupId(true);

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultNanopubSet.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultNanopubSet.java
@@ -107,7 +107,13 @@ public class QueryResultNanopubSet extends QueryResult {
     }
 
     private NanopubResults buildNanopubResults() {
-        NanopubResults nanopubResults = NanopubResults.fromApiResponse("nanopubs", filteredDataProvider.getFilteredData(), itemsPerPage);
+        // Each card carries the view's entry actions (applied to its result row) as a
+        // dropdown in its top-right corner, matching the per-row menus of the other
+        // view types.
+        NanopubResults nanopubResults = NanopubResults.fromApiResponse("nanopubs", filteredDataProvider.getFilteredData(), itemsPerPage,
+                row -> ViewActionMappings.buildEntryActionLinks(viewDisplay.getView(), row, queryRef,
+                        resourceWithProfile != null ? resourceWithProfile : pageResource,
+                        contextId, partId, refRoot, postPublishTab));
         // Tiled (grid) mode deactivated for now — always render this view as a list,
         // regardless of the session's view-mode setting.
         nanopubResults.add(AttributeAppender.append("class", NanopubResults.ViewMode.LIST.getValue()));

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultNanopubSet.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultNanopubSet.java
@@ -29,6 +29,10 @@ public class QueryResultNanopubSet extends QueryResult {
     private Model<String> filterModel = Model.of("");
     private WebMarkupContainer nanopubsContainer;
 
+    // An empty title override (ViewDisplay.withTitle("")) hides the title row; kept as
+    // a flag so the builder's later setTitleVisible(true) doesn't re-show an empty h4.
+    private boolean emptyTitle = false;
+
     /**
      * Constructor for QueryResultList.
      *
@@ -56,10 +60,8 @@ public class QueryResultNanopubSet extends QueryResult {
         if (viewDisplay.getTitle() != null) {
             titleLabel = viewDisplay.getTitle();
         }
+        emptyTitle = (titleLabel == null || titleLabel.isEmpty());
         add(new Label("title", titleLabel));
-        if (titleLabel == null || titleLabel.isEmpty()) {
-            setTitleVisible(false);
-        }
 
         TextField<String> filterField = new TextField<>("filter", filterModel);
         filterField.setOutputMarkupId(true);
@@ -122,8 +124,9 @@ public class QueryResultNanopubSet extends QueryResult {
      * @param hasTitle true to show the title, false to hide it
      */
     public void setTitleVisible(boolean hasTitle) {
-        this.get("title").setVisible(hasTitle);
-        if (!hasTitle) {
+        boolean visible = hasTitle && !emptyTitle;
+        this.get("title").setVisible(visible);
+        if (!visible) {
             viewSelector.add(AttributeAppender.append("class", " no-title"));
         }
     }

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultNanopubSetBuilder.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultNanopubSetBuilder.java
@@ -20,7 +20,10 @@ public class QueryResultNanopubSetBuilder implements Serializable {
     private String contextId = null;
     private final QueryRef queryRef;
     private boolean hasTitle = true;
+    private AbstractResourceWithProfile resourceWithProfile = null;
     private AbstractResourceWithProfile pageResource = null;
+    private String id = null;
+    private String refRoot = null;
     private Long itemsPerPage = null;
 
     private QueryResultNanopubSetBuilder(String markupId, QueryRef queryRef, ViewDisplay viewDisplay) {
@@ -59,6 +62,29 @@ public class QueryResultNanopubSetBuilder implements Serializable {
         return this;
     }
 
+    public QueryResultNanopubSetBuilder resourceWithProfile(AbstractResourceWithProfile resourceWithProfile) {
+        this.resourceWithProfile = resourceWithProfile;
+        return this;
+    }
+
+    public QueryResultNanopubSetBuilder id(String id) {
+        this.id = id;
+        return this;
+    }
+
+    /**
+     * Pins this set to a specific ref (root definition), so action visibility is gated
+     * against that claimant's authority rather than the resource's representative ref.
+     * Null leaves it on the representative ref.
+     *
+     * @param refRoot the ref's root nanopub, or null
+     * @return the current QueryResultNanopubSetBuilder instance
+     */
+    public QueryResultNanopubSetBuilder refRoot(String refRoot) {
+        this.refRoot = refRoot;
+        return this;
+    }
+
     public QueryResultNanopubSetBuilder setItemsPerPage(long itemsPerPage) {
         this.itemsPerPage = itemsPerPage;
         return this;
@@ -84,28 +110,33 @@ public class QueryResultNanopubSetBuilder implements Serializable {
         String colClass = " col-" + viewDisplay.getDisplayWidth();
         long resolvedItemsPerPage = itemsPerPage != null ? itemsPerPage : viewDisplay.getPageSize();
         if (response != null) {
-            QueryResultNanopubSet queryResultNanopubSet = new QueryResultNanopubSet(markupId, queryRef, response, viewDisplay, resolvedItemsPerPage);
-            queryResultNanopubSet.setContextId(contextId);
-            queryResultNanopubSet.setPageResource(pageResource);
-            queryResultNanopubSet.populateComponent();
-            queryResultNanopubSet.setTitleVisible(hasTitle);
+            QueryResultNanopubSet queryResultNanopubSet = buildNanopubSet(markupId, response, resolvedItemsPerPage);
             queryResultNanopubSet.add(new AttributeAppender("class", colClass));
             return queryResultNanopubSet;
         } else {
             ApiResultComponent comp = new ApiResultComponent(markupId, queryRef) {
                 @Override
                 public Component getApiResultComponent(String markupId, ApiResponse response) {
-                    QueryResultNanopubSet queryResultNanopubSet = new QueryResultNanopubSet(markupId, queryRef, response, viewDisplay, resolvedItemsPerPage);
-                    queryResultNanopubSet.setContextId(contextId);
-                    queryResultNanopubSet.setPageResource(pageResource);
-                    queryResultNanopubSet.populateComponent();
-                    queryResultNanopubSet.setTitleVisible(hasTitle);
-                    return queryResultNanopubSet;
+                    return buildNanopubSet(markupId, response, resolvedItemsPerPage);
                 }
             };
             comp.add(new AttributeAppender("class", colClass));
             return comp;
         }
+    }
+
+    private QueryResultNanopubSet buildNanopubSet(String markupId, ApiResponse response, long resolvedItemsPerPage) {
+        QueryResultNanopubSet queryResultNanopubSet = new QueryResultNanopubSet(markupId, queryRef, response, viewDisplay, resolvedItemsPerPage);
+        queryResultNanopubSet.setContextId(contextId);
+        queryResultNanopubSet.setPageResource(pageResource);
+        queryResultNanopubSet.setResourceWithProfile(resourceWithProfile);
+        queryResultNanopubSet.setRefRoot(refRoot);
+        // Result actions become entries of the view's dropdown menu, which
+        // populateComponent() builds — so they are added first.
+        ViewActionMappings.addResultActions(queryResultNanopubSet, viewDisplay, queryRef, id, contextId, resourceWithProfile, refRoot);
+        queryResultNanopubSet.populateComponent();
+        queryResultNanopubSet.setTitleVisible(hasTitle);
+        return queryResultNanopubSet;
     }
 
 }

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultPlainParagraph.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultPlainParagraph.html
@@ -10,7 +10,7 @@
 <wicket:panel>
   <div class="paneltitlerow listpanel">
     <h4 wicket:id="label">Paragraph</h4>
-    <input type="text" wicket:id="filter" placeholder="Filter..." style="margin: 5px 10px; padding: 2px 5px; font-size: 12px; width: 150px;"/>
+    <input type="text" wicket:id="filter" class="panelfilter" placeholder="Filter..."/>
     <span class="buttons"><wicket:container wicket:id="np">[np]</wicket:container></span>
     <span wicket:id="buttons" class="buttons"></span>
   </div>

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultPlainParagraph.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultPlainParagraph.java
@@ -50,7 +50,7 @@ public class QueryResultPlainParagraph extends QueryResult {
         if (viewDisplay.getTitle() != null) {
             label = viewDisplay.getTitle();
         }
-        add(new Label("label", label));
+        add(new Label("label", label).setVisible(label != null && !label.isEmpty()));
         setOutputMarkupId(true);
 
         TextField<String> filterField = new TextField<>("filter", filterModel);

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultPlainParagraph.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultPlainParagraph.java
@@ -100,19 +100,25 @@ public class QueryResultPlainParagraph extends QueryResult {
                 WebMarkupContainer header = new WebMarkupContainer("header");
                 if (!hasTitle) header.add(new AttributeAppender("class", " no-title"));
                 header.add(new Label("title", title).setVisible(hasTitle));
+                // The view's entry actions, followed by the former "^" source link as a
+                // "source" entry, bundled into a per-paragraph dropdown as in the other
+                // view types.
+                List<AbstractLink> links = ViewActionMappings.buildEntryActionLinks(viewDisplay.getView(),
+                        item.getModelObject(), queryRef,
+                        resourceWithProfile != null ? resourceWithProfile : pageResource,
+                        contextId, partId, refRoot, postPublishTab);
                 String npId = item.getModelObject().get("np");
                 if (npId != null && !npId.isBlank()) {
-                    // The former "^" source link is now the single "source" entry of a
-                    // per-paragraph dropdown, matching the other view types.
-                    List<AbstractLink> links = new ArrayList<>();
                     BookmarkablePageLink<Void> sourceLink = new BookmarkablePageLink<>("link", ExplorePage.class,
                             new PageParameters().set("id", npId));
                     sourceLink.add(NavigationContext.pageContextFallback());
                     sourceLink.setBody(Model.of("<span class=\"actionmenu-icon\">↗︎</span>source")).setEscapeModelStrings(false);
                     links.add(sourceLink);
-                    header.add(new EntryActionMenu("pnp", links));
-                } else {
+                }
+                if (links.isEmpty()) {
                     header.add(new Label("pnp").setVisible(false));
+                } else {
+                    header.add(new EntryActionMenu("pnp", links));
                 }
                 item.add(header);
                 String content = item.getModelObject().get("content");

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultTable.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultTable.html
@@ -10,7 +10,7 @@
 <wicket:panel>
   <div class="paneltitlerow tablepanel">
     <h4 wicket:id="label">Query</h4>
-    <input type="text" wicket:id="filter" placeholder="Filter..." style="margin: 5px 10px; padding: 2px 5px; font-size: 12px; width: 150px;"/>
+    <input type="text" wicket:id="filter" class="panelfilter" placeholder="Filter..."/>
     <span class="buttons"><wicket:container wicket:id="np">[np]</wicket:container></span>
     <span wicket:id="buttons" class="buttons"></span>
   </div>

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultTable.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultTable.java
@@ -2,12 +2,9 @@ package com.knowledgepixels.nanodash.component;
 
 import com.knowledgepixels.nanodash.*;
 import com.knowledgepixels.nanodash.component.menu.EntryActionMenu;
-import com.knowledgepixels.nanodash.domain.MaintainedResource;
 import com.knowledgepixels.nanodash.page.ExplorePage;
 import com.knowledgepixels.nanodash.page.NanodashPage;
 import com.knowledgepixels.nanodash.page.PublishPage;
-import com.knowledgepixels.nanodash.repository.MaintainedResourceRepository;
-import com.knowledgepixels.nanodash.template.Template;
 import org.apache.wicket.Component;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.behavior.AttributeAppender;
@@ -265,54 +262,8 @@ public class QueryResultTable extends QueryResult {
             try {
                 View view = viewDisplay.getView();
                 if (key.equals(ACTIONS)) {
-                    List<AbstractLink> links = new ArrayList<>();
-                    if (view != null) {
-                        for (IRI actionIri : view.getViewEntryActionList()) {
-                            // Per-action role gating (docs/role-specific-views.md): skip an
-                            // action whose gen:isVisibleTo the viewer does not satisfy.
-                            // Additive — actions without gen:isVisibleTo are unaffected.
-                            if (!SpaceMemberRole.isViewerEntitled(view.getActionVisibleTo(actionIri), resourceWithProfile, refRoot)) continue;
-                            // TODO Copied code and adjusted from QueryResultTableBuilder:
-                            Template t = view.getTemplateForAction(actionIri);
-                            if (t == null) continue;
-                            String targetField = view.getTemplateTargetFieldForAction(actionIri);
-                            if (targetField == null) targetField = "resource";
-                            String label = view.getLabelForAction(actionIri);
-                            if (label == null) label = "action...";
-                            if (!label.endsWith("...")) label += "...";
-                            PageParameters params = new PageParameters().set("template", t.getId())
-                                    .set("param_" + targetField, contextId)
-                                    .set("context", contextId)
-                                    .set("template-version", "latest");
-                            if (partId != null && contextId != null && !partId.equals(contextId)) {
-                                params.set("part", partId);
-                            }
-                            String partField = view.getTemplatePartFieldForAction(actionIri);
-                            if (partField != null) {
-                                // TODO Find a better way to pass the MaintainedResource object to this method:
-                                MaintainedResource r = MaintainedResourceRepository.get().findById(contextId);
-                                if (r != null && r.getNamespace() != null) {
-                                    params.set("param_" + partField, r.getNamespace() + "<SET-SUFFIX>");
-                                }
-                            }
-                            // Apply the action's query mappings; hide the button for this row
-                            // if any required mapped value is empty (docs/magic-query-params.md).
-                            if (!ViewActionMappings.applyEntryMappings(view, actionIri, rowModel.getObject(), params)) {
-                                continue;
-                            }
-                            params.set("refresh-upon-publish", queryRef.getAsUrlString());
-                            if (postPublishTab != null) params.set("postpub-tab", postPublishTab);
-                            AbstractLink button = new BookmarkablePageLink<NanodashPage>("link", PublishPage.class, params);
-                            // A label that starts with a leading symbol/emoji renders that as the entry icon.
-                            String iconBody = Utils.menuEntryIconBodyHtml(label);
-                            if (iconBody != null) {
-                                button.setBody(Model.of(iconBody)).setEscapeModelStrings(false);
-                            } else {
-                                button.setBody(Model.of(label));
-                            }
-                            links.add(button);
-                        }
-                    }
+                    List<AbstractLink> links = ViewActionMappings.buildEntryActionLinks(view, rowModel.getObject(),
+                            queryRef, resourceWithProfile, contextId, partId, refRoot, postPublishTab);
                     // The former "^" source link joins the same dropdown, as a "source" entry.
                     if (sourceColumnKey != null) {
                         String sourceUri = rowModel.getObject().get(sourceColumnKey);

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultTable.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultTable.java
@@ -68,7 +68,7 @@ public class QueryResultTable extends QueryResult {
             if (viewDisplay.getTitle() != null) {
                 label = viewDisplay.getTitle();
             }
-            add(new Label("label", label));
+            add(new Label("label", label).setVisible(label != null && !label.isEmpty()));
         }
 
         errorLabel = new Label("error-messages", errorMessages);

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultTableBuilder.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultTableBuilder.java
@@ -1,19 +1,10 @@
 package com.knowledgepixels.nanodash.component;
 
 import com.knowledgepixels.nanodash.ApiCache;
-import com.knowledgepixels.nanodash.SpaceMemberRole;
-import com.knowledgepixels.nanodash.View;
 import com.knowledgepixels.nanodash.ViewDisplay;
 import com.knowledgepixels.nanodash.domain.AbstractResourceWithProfile;
-import com.knowledgepixels.nanodash.domain.MaintainedResource;
-import com.knowledgepixels.nanodash.domain.Space;
-import com.knowledgepixels.nanodash.page.PublishPage;
-import com.knowledgepixels.nanodash.repository.MaintainedResourceRepository;
-import com.knowledgepixels.nanodash.template.Template;
 import org.apache.wicket.Component;
 import org.apache.wicket.behavior.AttributeAppender;
-import org.apache.wicket.request.mapper.parameter.PageParameters;
-import org.eclipse.rdf4j.model.IRI;
 import org.nanopub.extra.services.ApiResponse;
 import org.nanopub.extra.services.QueryRef;
 
@@ -142,7 +133,7 @@ public class QueryResultTableBuilder implements Serializable {
                 }
                 table.setResourceWithProfile(resourceWithProfile);
                 table.setPageResource(resourceWithProfile);
-                addViewActions(table, viewDisplay, queryRef, id, contextId, resourceWithProfile, refRoot);
+                ViewActionMappings.addResultActions(table, viewDisplay, queryRef, id, contextId, resourceWithProfile, refRoot);
                 table.add(new AttributeAppender("class", colClass));
                 return table;
             } else {
@@ -158,7 +149,7 @@ public class QueryResultTableBuilder implements Serializable {
                         }
                         table.setResourceWithProfile(resourceWithProfile);
                         table.setPageResource(resourceWithProfile);
-                        addViewActions(table, viewDisplay, queryRef, id, contextId, resourceWithProfile, refRoot);
+                        ViewActionMappings.addResultActions(table, viewDisplay, queryRef, id, contextId, resourceWithProfile, refRoot);
                         return table;
                     }
                 };
@@ -171,7 +162,7 @@ public class QueryResultTableBuilder implements Serializable {
                 table.setContextId(contextId);
                 table.setPostPublishTab(postPublishTab);
                 table.setRefRoot(refRoot);
-                addViewActions(table, viewDisplay, queryRef, id, contextId, resourceWithProfile, refRoot);
+                ViewActionMappings.addResultActions(table, viewDisplay, queryRef, id, contextId, resourceWithProfile, refRoot);
                 table.add(new AttributeAppender("class", colClass));
                 return table;
             } else {
@@ -182,78 +173,13 @@ public class QueryResultTableBuilder implements Serializable {
                         table.setContextId(contextId);
                         table.setPostPublishTab(postPublishTab);
                         table.setRefRoot(refRoot);
-                        addViewActions(table, viewDisplay, queryRef, id, contextId, resourceWithProfile, refRoot);
+                        ViewActionMappings.addResultActions(table, viewDisplay, queryRef, id, contextId, resourceWithProfile, refRoot);
                         return table;
                     }
                 };
                 comp.add(new AttributeAppender("class", colClass));
                 return comp;
             }
-        }
-    }
-
-    /**
-     * Adds a button to the table for each result action declared by the view, linking to the
-     * action's template on the publish page. Resource-context parameters (the target field, the
-     * context, the part, and the part field) are only set when the corresponding id/contextId is
-     * available, so this also works on resource-less listings such as the general Spaces page.
-     *
-     * @param table       the table to add the action buttons to
-     * @param viewDisplay the view display whose view declares the actions
-     * @param queryRef    the query reference backing the table (used for refresh and query mapping)
-     * @param id          the resource id, or null if there is no specific resource in context
-     * @param contextId   the context id, or null if there is no context
-     */
-    private static void addViewActions(QueryResultTable table, ViewDisplay viewDisplay, QueryRef queryRef, String id, String contextId, AbstractResourceWithProfile resourceWithProfile, String refRoot) {
-        View view = viewDisplay.getView();
-        if (view == null) return;
-        for (IRI actionIri : view.getViewResultActionList()) {
-            // Per-action role gating (docs/role-specific-views.md): skip an action
-            // whose gen:isVisibleTo the current viewer does not satisfy. Additive —
-            // actions without gen:isVisibleTo are unaffected. Gated against the pinned
-            // ref's authority on a ?root=-pinned page. See docs/space-ref-identity.md.
-            if (!SpaceMemberRole.isViewerEntitled(view.getActionVisibleTo(actionIri), resourceWithProfile, refRoot)) continue;
-            Template t = view.getTemplateForAction(actionIri);
-            if (t == null) continue;
-            String targetField = view.getTemplateTargetFieldForAction(actionIri);
-            if (targetField == null) targetField = "resource";
-            String label = view.getLabelForAction(actionIri);
-            if (label == null) label = "action...";
-            if (!label.endsWith("...")) label += "...";
-            PageParameters params = new PageParameters().set("template", t.getId())
-                    .set("template-version", "latest");
-            if (id != null) params.set("param_" + targetField, id);
-            if (contextId != null) params.set("context", contextId);
-            if (id != null && contextId != null && !id.equals(contextId)) {
-                params.set("part", id);
-            }
-            String partField = view.getTemplatePartFieldForAction(actionIri);
-            if (partField != null && contextId != null) {
-                // The part field pre-fills a namespaced child IRI (the user fills the suffix).
-                // TODO Find a better way to pass the MaintainedResource object to this method:
-                MaintainedResource r = MaintainedResourceRepository.get().findById(contextId);
-                String namespace = null;
-                if (r != null) {
-                    namespace = r.getNamespace();
-                } else if (resourceWithProfile instanceof Space) {
-                    // The Space-creation templates' `space` placeholder has a fixed
-                    // `https://w3id.org/spaces/` prefix, so the pre-fill is relative to it.
-                    // Nesting the new space's IRI under this space's path makes it a
-                    // sub-space via the prefix match.
-                    namespace = contextId.replaceFirst("https://w3id.org/spaces/", "") + "/";
-                }
-                if (namespace != null) {
-                    params.set("param_" + partField, namespace + "<SET-SUFFIX>");
-                }
-            }
-            String queryMapping = view.getTemplateQueryMapping(actionIri);
-            if (queryMapping != null && queryMapping.contains(":")) {
-                params.set("values-from-query", queryRef.getAsUrlString());
-                params.set("values-from-query-mapping", queryMapping);
-            }
-            params.set("refresh-upon-publish", queryRef.getAsUrlString());
-            if (table.getPostPublishTab() != null) params.set("postpub-tab", table.getPostPublishTab());
-            table.addButton(label, PublishPage.class, params);
         }
     }
 

--- a/src/main/java/com/knowledgepixels/nanodash/component/ViewActionMappings.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/ViewActionMappings.java
@@ -1,10 +1,19 @@
 package com.knowledgepixels.nanodash.component;
 
+import com.knowledgepixels.nanodash.QueryResult;
+import com.knowledgepixels.nanodash.SpaceMemberRole;
 import com.knowledgepixels.nanodash.View;
+import com.knowledgepixels.nanodash.ViewDisplay;
+import com.knowledgepixels.nanodash.domain.AbstractResourceWithProfile;
+import com.knowledgepixels.nanodash.domain.MaintainedResource;
+import com.knowledgepixels.nanodash.domain.Space;
+import com.knowledgepixels.nanodash.page.PublishPage;
+import com.knowledgepixels.nanodash.repository.MaintainedResourceRepository;
 import com.knowledgepixels.nanodash.template.Template;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
 import org.eclipse.rdf4j.model.IRI;
 import org.nanopub.extra.services.ApiResponseEntry;
+import org.nanopub.extra.services.QueryRef;
 
 /**
  * Applies a view entry action's per-row query mappings and decides whether the
@@ -36,6 +45,74 @@ class ViewActionMappings {
      * @param params    the link parameters to populate
      * @return true if the action button should be rendered for this row
      */
+    /**
+     * Adds a button to the result component for each result action declared by the view,
+     * linking to the action's template on the publish page. Resource-context parameters
+     * (the target field, the context, the part, and the part field) are only set when the
+     * corresponding id/contextId is available, so this also works on resource-less pages
+     * such as the general Spaces page or the standalone view-results page.
+     *
+     * @param result              the result component to add the action buttons to
+     * @param viewDisplay         the view display whose view declares the actions
+     * @param queryRef            the query reference backing the component (used for refresh and query mapping)
+     * @param id                  the resource id, or null if there is no specific resource in context
+     * @param contextId           the context id, or null if there is no context
+     * @param resourceWithProfile the resource whose page the component is on, or null
+     * @param refRoot             the pinned ref's root nanopub, or null
+     */
+    static void addResultActions(QueryResult result, ViewDisplay viewDisplay, QueryRef queryRef, String id, String contextId, AbstractResourceWithProfile resourceWithProfile, String refRoot) {
+        View view = viewDisplay.getView();
+        if (view == null) return;
+        for (IRI actionIri : view.getViewResultActionList()) {
+            // Per-action role gating (docs/role-specific-views.md): skip an action
+            // whose gen:isVisibleTo the current viewer does not satisfy. Additive —
+            // actions without gen:isVisibleTo are unaffected. Gated against the pinned
+            // ref's authority on a ?root=-pinned page. See docs/space-ref-identity.md.
+            if (!SpaceMemberRole.isViewerEntitled(view.getActionVisibleTo(actionIri), resourceWithProfile, refRoot)) continue;
+            Template t = view.getTemplateForAction(actionIri);
+            if (t == null) continue;
+            String targetField = view.getTemplateTargetFieldForAction(actionIri);
+            if (targetField == null) targetField = "resource";
+            String label = view.getLabelForAction(actionIri);
+            if (label == null) label = "action...";
+            if (!label.endsWith("...")) label += "...";
+            PageParameters params = new PageParameters().set("template", t.getId())
+                    .set("template-version", "latest");
+            if (id != null) params.set("param_" + targetField, id);
+            if (contextId != null) params.set("context", contextId);
+            if (id != null && contextId != null && !id.equals(contextId)) {
+                params.set("part", id);
+            }
+            String partField = view.getTemplatePartFieldForAction(actionIri);
+            if (partField != null && contextId != null) {
+                // The part field pre-fills a namespaced child IRI (the user fills the suffix).
+                // TODO Find a better way to pass the MaintainedResource object to this method:
+                MaintainedResource r = MaintainedResourceRepository.get().findById(contextId);
+                String namespace = null;
+                if (r != null) {
+                    namespace = r.getNamespace();
+                } else if (resourceWithProfile instanceof Space) {
+                    // The Space-creation templates' `space` placeholder has a fixed
+                    // `https://w3id.org/spaces/` prefix, so the pre-fill is relative to it.
+                    // Nesting the new space's IRI under this space's path makes it a
+                    // sub-space via the prefix match.
+                    namespace = contextId.replaceFirst("https://w3id.org/spaces/", "") + "/";
+                }
+                if (namespace != null) {
+                    params.set("param_" + partField, namespace + "<SET-SUFFIX>");
+                }
+            }
+            String queryMapping = view.getTemplateQueryMapping(actionIri);
+            if (queryMapping != null && queryMapping.contains(":")) {
+                params.set("values-from-query", queryRef.getAsUrlString());
+                params.set("values-from-query-mapping", queryMapping);
+            }
+            params.set("refresh-upon-publish", queryRef.getAsUrlString());
+            if (result.getPostPublishTab() != null) params.set("postpub-tab", result.getPostPublishTab());
+            result.addButton(label, PublishPage.class, params);
+        }
+    }
+
     static boolean applyEntryMappings(View view, IRI actionIri, ApiResponseEntry row, PageParameters params) {
         Template template = view.getTemplateForAction(actionIri);
         for (String mapping : view.getTemplateQueryMappings(actionIri)) {

--- a/src/main/java/com/knowledgepixels/nanodash/component/ViewActionMappings.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/ViewActionMappings.java
@@ -2,18 +2,26 @@ package com.knowledgepixels.nanodash.component;
 
 import com.knowledgepixels.nanodash.QueryResult;
 import com.knowledgepixels.nanodash.SpaceMemberRole;
+import com.knowledgepixels.nanodash.Utils;
 import com.knowledgepixels.nanodash.View;
 import com.knowledgepixels.nanodash.ViewDisplay;
 import com.knowledgepixels.nanodash.domain.AbstractResourceWithProfile;
 import com.knowledgepixels.nanodash.domain.MaintainedResource;
 import com.knowledgepixels.nanodash.domain.Space;
+import com.knowledgepixels.nanodash.page.NanodashPage;
 import com.knowledgepixels.nanodash.page.PublishPage;
 import com.knowledgepixels.nanodash.repository.MaintainedResourceRepository;
 import com.knowledgepixels.nanodash.template.Template;
+import org.apache.wicket.markup.html.link.AbstractLink;
+import org.apache.wicket.markup.html.link.BookmarkablePageLink;
+import org.apache.wicket.model.Model;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
 import org.eclipse.rdf4j.model.IRI;
 import org.nanopub.extra.services.ApiResponseEntry;
 import org.nanopub.extra.services.QueryRef;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Applies a view entry action's per-row query mappings and decides whether the
@@ -111,6 +119,73 @@ class ViewActionMappings {
             if (result.getPostPublishTab() != null) params.set("postpub-tab", result.getPostPublishTab());
             result.addButton(label, PublishPage.class, params);
         }
+    }
+
+    /**
+     * Builds the entry-action links of a view for one result row: one publish-page link
+     * per {@code gen:ViewEntryAction} the viewer is entitled to and whose query mappings
+     * are satisfied by the row (see {@link #applyEntryMappings}). Each link uses the
+     * markup id {@code "link"}, ready for an {@link com.knowledgepixels.nanodash.component.menu.EntryActionMenu}.
+     *
+     * @param view                the view declaring the actions, or null for none
+     * @param row                 the result row the actions apply to
+     * @param queryRef            the query reference backing the component (used for refresh and query mapping)
+     * @param entitlementResource the resource the viewer's entitlement is checked against, or null
+     * @param contextId           the context id, or null if there is no context
+     * @param partId              the part id when shown on a part page, or null
+     * @param refRoot             the pinned ref's root nanopub, or null
+     * @param postPublishTab      the tab to return to after publishing, or null for the default
+     * @return the entry-action links for this row (never null)
+     */
+    static List<AbstractLink> buildEntryActionLinks(View view, ApiResponseEntry row, QueryRef queryRef,
+            AbstractResourceWithProfile entitlementResource, String contextId, String partId, String refRoot, String postPublishTab) {
+        List<AbstractLink> links = new ArrayList<>();
+        if (view == null) return links;
+        for (IRI actionIri : view.getViewEntryActionList()) {
+            // Per-action role gating (docs/role-specific-views.md): skip an action
+            // whose gen:isVisibleTo the viewer does not satisfy.
+            if (!SpaceMemberRole.isViewerEntitled(view.getActionVisibleTo(actionIri), entitlementResource, refRoot)) continue;
+            Template t = view.getTemplateForAction(actionIri);
+            if (t == null) continue;
+            String targetField = view.getTemplateTargetFieldForAction(actionIri);
+            if (targetField == null) targetField = "resource";
+            String label = view.getLabelForAction(actionIri);
+            if (label == null) label = "action...";
+            if (!label.endsWith("...")) label += "...";
+            PageParameters params = new PageParameters().set("template", t.getId())
+                    .set("param_" + targetField, contextId)
+                    .set("context", contextId)
+                    .set("template-version", "latest");
+            if (partId != null && contextId != null && !partId.equals(contextId)) {
+                params.set("part", partId);
+            }
+            String partField = view.getTemplatePartFieldForAction(actionIri);
+            if (partField != null) {
+                // The part field pre-fills a namespaced child IRI (the user fills the suffix).
+                // TODO Find a better way to pass the MaintainedResource object to this method:
+                MaintainedResource r = MaintainedResourceRepository.get().findById(contextId);
+                if (r != null && r.getNamespace() != null) {
+                    params.set("param_" + partField, r.getNamespace() + "<SET-SUFFIX>");
+                }
+            }
+            // Apply the action's query mappings; hide the button for this row
+            // if any required mapped value is empty (docs/magic-query-params.md).
+            if (!applyEntryMappings(view, actionIri, row, params)) {
+                continue;
+            }
+            params.set("refresh-upon-publish", queryRef.getAsUrlString());
+            if (postPublishTab != null) params.set("postpub-tab", postPublishTab);
+            AbstractLink button = new BookmarkablePageLink<NanodashPage>("link", PublishPage.class, params);
+            // A label that starts with a leading symbol/emoji renders that as the entry icon.
+            String iconBody = Utils.menuEntryIconBodyHtml(label);
+            if (iconBody != null) {
+                button.setBody(Model.of(iconBody)).setEscapeModelStrings(false);
+            } else {
+                button.setBody(Model.of(label));
+            }
+            links.add(button);
+        }
+        return links;
     }
 
     static boolean applyEntryMappings(View view, IRI actionIri, ApiResponseEntry row, PageParameters params) {

--- a/src/main/java/com/knowledgepixels/nanodash/component/ViewList.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/ViewList.java
@@ -6,8 +6,8 @@ import com.knowledgepixels.nanodash.View;
 import com.knowledgepixels.nanodash.ViewDisplay;
 import com.knowledgepixels.nanodash.domain.AbstractResourceWithProfile;
 import com.knowledgepixels.nanodash.domain.Space;
-import com.knowledgepixels.nanodash.vocabulary.KPXL_TERMS;
 import org.apache.wicket.Component;
+import org.apache.wicket.behavior.AttributeAppender;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.link.AbstractLink;
@@ -146,51 +146,29 @@ public class ViewList extends Panel {
                                         queryRefParams.put("root_np", refRoot);
                                     }
                                 } else if (!QueryTemplate.isOptionalPlaceholder(p)) {
-                                    item.add(new Label("view", "<span class=\"negative\">Error: Query has non-optional parameter</span>").setEscapeModelStrings(false));
-                                    logger.error("Error: Query has non-optional parameter: {} {}", view.getQuery().getQueryId(), p);
-                                    return;
+                                    // For a query-form view, an unmatched placeholder is not an
+                                    // error: it becomes a form field the user fills in.
+                                    if (!view.hasQueryForm()) {
+                                        item.add(new Label("view", "<span class=\"negative\">Error: Query has non-optional parameter</span>").setEscapeModelStrings(false));
+                                        logger.error("Error: Query has non-optional parameter: {} {}", view.getQuery().getQueryId(), p);
+                                        return;
+                                    }
                                 }
                             }
+                            if (view.hasQueryForm()) {
+                                Component form = new QueryFormPanel("view", item.getModelObject(), queryRefParams, null, resourceWithProfile);
+                                form.add(new AttributeAppender("class", " col-" + item.getModelObject().getDisplayWidth()));
+                                item.add(form);
+                                return;
+                            }
                             QueryRef queryRef = new QueryRef(view.getQuery().getQueryId(), queryRefParams);
-                            if (view.getViewType() != null && View.getSupportedViewTypes().contains(view.getViewType())) {
-                                if (view.getViewType().equals(KPXL_TERMS.LIST_VIEW)) {
-                                    item.add(QueryResultListBuilder.create("view", queryRef, item.getModelObject())
-                                            .resourceWithProfile(resourceWithProfile)
-                                            .pageResource(resourceWithProfile)
-                                            .id(id)
-                                            .contextId(resourceWithProfile.getId())
-                                            .refRoot(refRoot)
-                                            .build());
-                                } else if (view.getViewType().equals(KPXL_TERMS.TABULAR_VIEW)) {
-                                    item.add(QueryResultTableBuilder.create("view", queryRef, item.getModelObject())
-                                            .resourceWithProfile(resourceWithProfile)
-                                            .contextId(resourceWithProfile.getId())
-                                            .id(id)
-                                            .refRoot(refRoot)
-                                            .build());
-                                } else if (view.getViewType().equals(KPXL_TERMS.PLAIN_PARAGRAPH_VIEW)) {
-                                    item.add(QueryResultPlainParagraphBuilder.create("view", queryRef, item.getModelObject())
-                                            .pageResource(resourceWithProfile)
-                                            .contextId(resourceWithProfile.getId())
-                                            .id(id)
-                                            .refRoot(refRoot)
-                                            .build());
-                                } else if (view.getViewType().equals(KPXL_TERMS.NANOPUB_SET_VIEW)) {
-                                    item.add(QueryResultNanopubSetBuilder.create("view", queryRef, item.getModelObject())
-                                            .pageResource(resourceWithProfile)
-                                            .contextId(resourceWithProfile.getId())
-                                            .build());
-                                } else if (view.getViewType().equals(KPXL_TERMS.ITEM_LIST_VIEW)) {
-                                    item.add(QueryResultItemListBuilder.create("view", queryRef, item.getModelObject())
-                                            .resourceWithProfile(resourceWithProfile)
-                                            .pageResource(resourceWithProfile)
-                                            .id(id)
-                                            .contextId(resourceWithProfile.getId())
-                                            .build());
-                                } else {
-                                    item.add(new Label("view", "<span class=\"negative\">View type \"" + view.getViewType().stringValue() + "\" is supported but its view is not implemented yet</span>").setEscapeModelStrings(false));
-                                    logger.error("View type \"{}\" is supported but its view is not implemented yet", view.getViewType().stringValue());
-                                }
+                            Component resultComponent = QueryResultComponentFactory.build("view", queryRef, item.getModelObject(),
+                                    resourceWithProfile, id, resourceWithProfile.getId(), refRoot);
+                            if (resultComponent != null) {
+                                item.add(resultComponent);
+                            } else if (view.getViewType() != null && View.getSupportedViewTypes().contains(view.getViewType())) {
+                                item.add(new Label("view", "<span class=\"negative\">View type \"" + view.getViewType().stringValue() + "\" is supported but its view is not implemented yet</span>").setEscapeModelStrings(false));
+                                logger.error("View type \"{}\" is supported but its view is not implemented yet", view.getViewType().stringValue());
                             } else {
                                 item.add(new Label("view", "<span class=\"negative\">Unsupported view type</span>").setEscapeModelStrings(false));
                                 logger.error("Unsupported view type.");

--- a/src/main/java/com/knowledgepixels/nanodash/component/menu/ViewDisplayMenu.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/menu/ViewDisplayMenu.html
@@ -12,6 +12,7 @@
   <hr wicket:id="separator" class="actionmenu-separator"/>
   <a wicket:id="showQuery">show query</a>
   <a wicket:id="showView">show view</a>
+  <a wicket:id="fullScreen"><span class="actionmenu-icon">⛶</span>full screen</a>
   <a wicket:id="adjust"><span class="actionmenu-icon">✎</span>edit view display...</a>
   <a wicket:id="deactivate"><span class="actionmenu-icon">⊘</span>deactivate view display...</a>
   <a wicket:id="addToOwn"><span class="actionmenu-icon">⊕</span>add to my own profile...</a>

--- a/src/main/java/com/knowledgepixels/nanodash/component/menu/ViewDisplayMenu.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/menu/ViewDisplayMenu.java
@@ -1,6 +1,7 @@
 package com.knowledgepixels.nanodash.component.menu;
 
 import com.knowledgepixels.nanodash.ApiCache;
+import com.knowledgepixels.nanodash.MagicQueryParams;
 import com.knowledgepixels.nanodash.NanodashSession;
 import com.knowledgepixels.nanodash.NanopubElement;
 import com.knowledgepixels.nanodash.NavigationContext;
@@ -14,6 +15,7 @@ import com.knowledgepixels.nanodash.domain.Space;
 import com.knowledgepixels.nanodash.page.ExplorePage;
 import com.knowledgepixels.nanodash.page.PublishPage;
 import com.knowledgepixels.nanodash.page.QueryPage;
+import com.knowledgepixels.nanodash.page.ViewResultsPage;
 import com.knowledgepixels.nanodash.template.TemplateData;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.link.BookmarkablePageLink;
@@ -79,6 +81,25 @@ public class ViewDisplayMenu extends BaseDisplayMenu {
         addEntry("showView", new BookmarkablePageLink<Void>("showView", ExplorePage.class,
                 new PageParameters().set("id", viewDisplay.getView().getNanopub().getUri()))
                 .add(NavigationContext.pageContextFallback()));
+
+        // Full-screen version of this view on the standalone view-results page, with the
+        // current query parameters carried along (magic ones excluded — the results page
+        // re-binds them from the session, so carrying them would duplicate the bindings).
+        PageParameters fullScreenParams = new PageParameters().set("view", viewDisplay.getView().getId());
+        for (var entry : queryRef.getParams().entries()) {
+            if (MagicQueryParams.isMagic(entry.getKey())) continue;
+            fullScreenParams.add("queryparam_" + entry.getKey(), entry.getValue());
+        }
+        BookmarkablePageLink<Void> fullScreenLink = new BookmarkablePageLink<>("fullScreen", ViewResultsPage.class, fullScreenParams) {
+            @Override
+            protected void onConfigure() {
+                super.onConfigure();
+                // Self-referential on the full-screen page itself.
+                setVisible(!(getPage() instanceof ViewResultsPage));
+            }
+        };
+        fullScreenLink.add(NavigationContext.pageContextFallback());
+        addEntry("fullScreen", fullScreenLink);
 
         IRI nanopubId = viewDisplay.getNanopubId();
 

--- a/src/main/java/com/knowledgepixels/nanodash/page/ViewResultsPage.html
+++ b/src/main/java/com/knowledgepixels/nanodash/page/ViewResultsPage.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html xmlns:wicket="http://wicket.apache.org">
+<head>
+  <wicket:remove>
+    <link rel="stylesheet" href="../../../../../webapp/style.css?for-local-testing-only" type="text/css" media="screen" title="Stylesheet" />
+</wicket:remove>
+  <wicket:head>
+    <title>View Results | nanodash</title>
+  </wicket:head>
+</head>
+<body>
+<wicket:extend>
+
+  <div class="row-section">
+    <div class="listview">
+      <div wicket:id="queryform" class="col-12">...</div>
+      <div wicket:id="results">...</div>
+    </div>
+  </div>
+
+</wicket:extend>
+</body>
+</html>

--- a/src/main/java/com/knowledgepixels/nanodash/page/ViewResultsPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/ViewResultsPage.java
@@ -63,13 +63,22 @@ public class ViewResultsPage extends NanodashPage {
             queryParams.put(param.getKey().replaceFirst("queryparam_", ""), param.getValue());
         }
 
-        add(new QueryFormPanel("queryform", new ViewDisplay(view).withDisplayWidth(12), ArrayListMultimap.create(), queryParams, null));
+        QueryFormPanel formPanel = new QueryFormPanel("queryform", new ViewDisplay(view).withDisplayWidth(12), ArrayListMultimap.create(), queryParams, null);
+        if (!view.hasQueryForm()) {
+            // For a regular view shown full-screen, the query parameters are fixed
+            // (carried in the URL by the full-screen link), so no fields are shown —
+            // just as they are hidden when the view is shown on a resource page.
+            formPanel.hideForm();
+        }
+        add(formPanel);
 
         for (String p : view.getQuery().getPlaceholdersList()) {
             if (QueryTemplate.isOptionalPlaceholder(p)) continue;
             if (MagicQueryParams.isMagic(p)) continue;
             if (!queryParams.containsKey(QueryTemplate.getParamName(p))) {
-                add(new Label("results", "Fill in the form above to see the results."));
+                add(new Label("results", view.hasQueryForm()
+                        ? "Fill in the form above to see the results."
+                        : "Query parameters are missing for this view."));
                 return;
             }
         }

--- a/src/main/java/com/knowledgepixels/nanodash/page/ViewResultsPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/ViewResultsPage.java
@@ -75,10 +75,13 @@ public class ViewResultsPage extends NanodashPage {
         }
 
         // The form above already shows the view's icon+title, so the results render
-        // without their own title row.
+        // without their own title row. The navigation context (the resource the search
+        // started from) doubles as the id, so view-level actions pre-fill their target
+        // field with it, as they do on the resource's own page.
         ViewDisplay resultsDisplay = new ViewDisplay(view).withDisplayWidth(12).withTitle("");
         QueryRef queryRef = new QueryRef(view.getQuery().getQueryId(), queryParams);
-        Component results = QueryResultComponentFactory.build("results", queryRef, resultsDisplay, null, null, getContextId(), null);
+        String contextId = getContextId();
+        Component results = QueryResultComponentFactory.build("results", queryRef, resultsDisplay, null, contextId, contextId, null);
         if (results == null) {
             // No (or unrecognized) display type on the view: fall back to the plain result table.
             results = QueryResultTableBuilder.create("results", queryRef, resultsDisplay).plain(true).build();

--- a/src/main/java/com/knowledgepixels/nanodash/page/ViewResultsPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/ViewResultsPage.java
@@ -1,0 +1,89 @@
+package com.knowledgepixels.nanodash.page;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import com.knowledgepixels.nanodash.MagicQueryParams;
+import com.knowledgepixels.nanodash.View;
+import com.knowledgepixels.nanodash.ViewDisplay;
+import com.knowledgepixels.nanodash.component.QueryFormPanel;
+import com.knowledgepixels.nanodash.component.QueryResultComponentFactory;
+import com.knowledgepixels.nanodash.component.QueryResultTableBuilder;
+import com.knowledgepixels.nanodash.component.TitleBar;
+import org.apache.wicket.Component;
+import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.request.mapper.parameter.INamedParameters.NamedPair;
+import org.apache.wicket.request.mapper.parameter.PageParameters;
+import org.apache.wicket.util.string.Strings;
+import org.nanopub.extra.services.QueryRef;
+import org.nanopub.extra.services.QueryTemplate;
+
+/**
+ * Standalone page showing the full results of a view's query, rendered according to
+ * the view's display type. This is where the form of a query-form view
+ * ({@code gen:QueryFormView}) leads on submit; the form is repeated at the top with
+ * the submitted values, so the search can be refined. Parameters: {@code view} (the
+ * view id) and {@code queryparam_<name>} for the query parameter values.
+ */
+public class ViewResultsPage extends NanodashPage {
+
+    /**
+     * The mount path for this page.
+     */
+    public static final String MOUNT_PATH = "/view-results";
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getMountPath() {
+        return MOUNT_PATH;
+    }
+
+    /**
+     * Constructor for the ViewResultsPage.
+     *
+     * @param parameters Page parameters containing the view id and the query parameter values.
+     */
+    public ViewResultsPage(final PageParameters parameters) {
+        super(parameters);
+
+        add(new TitleBar("titlebar", this, null));
+
+        String viewId = parameters.get("view").toString();
+        View view = (viewId == null ? null : View.get(viewId));
+        if (view == null) {
+            add(new Label("queryform").setVisible(false));
+            add(new Label("results", "<span class=\"negative\">View not found: " + Strings.escapeMarkup(String.valueOf(viewId)) + "</span>").setEscapeModelStrings(false));
+            return;
+        }
+
+        Multimap<String, String> queryParams = ArrayListMultimap.create();
+        for (NamedPair param : parameters.getAllNamed()) {
+            if (!param.getKey().startsWith("queryparam_")) continue;
+            queryParams.put(param.getKey().replaceFirst("queryparam_", ""), param.getValue());
+        }
+
+        add(new QueryFormPanel("queryform", new ViewDisplay(view).withDisplayWidth(12), ArrayListMultimap.create(), queryParams, null));
+
+        for (String p : view.getQuery().getPlaceholdersList()) {
+            if (QueryTemplate.isOptionalPlaceholder(p)) continue;
+            if (MagicQueryParams.isMagic(p)) continue;
+            if (!queryParams.containsKey(QueryTemplate.getParamName(p))) {
+                add(new Label("results", "Fill in the form above to see the results."));
+                return;
+            }
+        }
+
+        // The form above already shows the view's icon+title, so the results render
+        // without their own title row.
+        ViewDisplay resultsDisplay = new ViewDisplay(view).withDisplayWidth(12).withTitle("");
+        QueryRef queryRef = new QueryRef(view.getQuery().getQueryId(), queryParams);
+        Component results = QueryResultComponentFactory.build("results", queryRef, resultsDisplay, null, null, getContextId(), null);
+        if (results == null) {
+            // No (or unrecognized) display type on the view: fall back to the plain result table.
+            results = QueryResultTableBuilder.create("results", queryRef, resultsDisplay).plain(true).build();
+        }
+        add(results);
+    }
+
+}

--- a/src/main/java/com/knowledgepixels/nanodash/page/ViewResultsPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/ViewResultsPage.java
@@ -63,31 +63,33 @@ public class ViewResultsPage extends NanodashPage {
             queryParams.put(param.getKey().replaceFirst("queryparam_", ""), param.getValue());
         }
 
-        QueryFormPanel formPanel = new QueryFormPanel("queryform", new ViewDisplay(view).withDisplayWidth(12), ArrayListMultimap.create(), queryParams, null);
-        if (!view.hasQueryForm()) {
-            // For a regular view shown full-screen, the query parameters are fixed
-            // (carried in the URL by the full-screen link), so no fields are shown —
-            // just as they are hidden when the view is shown on a resource page.
-            formPanel.hideForm();
+        boolean queryForm = view.hasQueryForm();
+        if (queryForm) {
+            add(new QueryFormPanel("queryform", new ViewDisplay(view).withDisplayWidth(12), ArrayListMultimap.create(), queryParams, null));
+        } else {
+            // A regular view shown full-screen needs no separate query part: its
+            // parameters are fixed (carried in the URL by the full-screen link), so
+            // the result panel below is shown alone, with its own title row.
+            add(new Label("queryform").setVisible(false));
         }
-        add(formPanel);
 
         for (String p : view.getQuery().getPlaceholdersList()) {
             if (QueryTemplate.isOptionalPlaceholder(p)) continue;
             if (MagicQueryParams.isMagic(p)) continue;
             if (!queryParams.containsKey(QueryTemplate.getParamName(p))) {
-                add(new Label("results", view.hasQueryForm()
+                add(new Label("results", queryForm
                         ? "Fill in the form above to see the results."
                         : "Query parameters are missing for this view."));
                 return;
             }
         }
 
-        // The form above already shows the view's icon+title, so the results render
-        // without their own title row. The navigation context (the resource the search
-        // started from) doubles as the id, so view-level actions pre-fill their target
-        // field with it, as they do on the resource's own page.
-        ViewDisplay resultsDisplay = new ViewDisplay(view).withDisplayWidth(12).withTitle("");
+        // With a query form above (which shows the view's icon+title), the results
+        // render without their own title row. The navigation context (the resource the
+        // search started from) doubles as the id, so view-level actions pre-fill their
+        // target field with it, as they do on the resource's own page.
+        ViewDisplay resultsDisplay = new ViewDisplay(view).withDisplayWidth(12);
+        if (queryForm) resultsDisplay.withTitle("");
         QueryRef queryRef = new QueryRef(view.getQuery().getQueryId(), queryParams);
         String contextId = getContextId();
         Component results = QueryResultComponentFactory.build("results", queryRef, resultsDisplay, null, contextId, contextId, null);

--- a/src/main/java/com/knowledgepixels/nanodash/vocabulary/KPXL_TERMS.java
+++ b/src/main/java/com/knowledgepixels/nanodash/vocabulary/KPXL_TERMS.java
@@ -22,6 +22,16 @@ public class KPXL_TERMS {
     public static final IRI PLAIN_PARAGRAPH_VIEW = VocabUtils.createIRI(NAMESPACE, "PlainParagraphView");
     public static final IRI NANOPUB_SET_VIEW = VocabUtils.createIRI(NAMESPACE, "NanopubSetView");
     public static final IRI ITEM_LIST_VIEW = VocabUtils.createIRI(NAMESPACE, "ItemListView");
+
+    /**
+     * Marks a view as a query-form view: instead of query results, it renders a form
+     * for the query's placeholders that are not auto-filled from the page context;
+     * submitting leads to the full results page. Orthogonal to the display types
+     * above (a view can carry both), so the display type determines how the results
+     * page renders. Deliberately not part of {@link com.knowledgepixels.nanodash.View}'s
+     * supported display types.
+     */
+    public static final IRI QUERY_FORM_VIEW = VocabUtils.createIRI(NAMESPACE, "QueryFormView");
     public static final IRI VIEW_DISPLAY = VocabUtils.createIRI(NAMESPACE, "ViewDisplay");
     public static final IRI COLUMN_WIDTH_1_OF_12 = VocabUtils.createIRI(NAMESPACE, "ColumnWidth01of12");
     public static final IRI COLUMN_WIDTH_2_OF_12 = VocabUtils.createIRI(NAMESPACE, "ColumnWidth02of12");

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -2427,6 +2427,13 @@ div.navigator .goto a[disabled] {
   margin-left: 0;
 }
 
+/* Per-card entry-action dropdown on nanopub-set views, floated into the card's
+   top-right corner above the nanopub content. */
+.nanopub-item > .nanopub-entry-actions {
+  float: right;
+  margin: 2px 4px;
+}
+
 .paneltitlerow > span.buttons:has(~ span.buttons) {
   order: 1;
   margin-left: 0;

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -2409,6 +2409,24 @@ div.navigator .goto a[disabled] {
   margin-left: auto;
 }
 
+.paneltitlerow input.panelfilter {
+  margin: 5px 10px;
+  padding: 2px 5px;
+  font-size: 12px;
+  width: 150px;
+}
+
+/* With the title hidden (e.g. on the view-results page) there is no flex-stretched
+   h4 pushing the filter right, so the filter claims the free space itself and the
+   buttons' auto margin yields to it, keeping the filter next to the dropdown. */
+.paneltitlerow:not(:has(> h4)) > input.panelfilter {
+  margin-left: auto;
+}
+
+.paneltitlerow:not(:has(> h4)):has(> input.panelfilter) > span.buttons {
+  margin-left: 0;
+}
+
 .paneltitlerow > span.buttons:has(~ span.buttons) {
   order: 1;
   margin-left: 0;


### PR DESCRIPTION
## Summary

Adds a new orthogonal view aspect `gen:QueryFormView`: a view carrying this type (in addition to its display type, e.g. `gen:ListView`) renders on resource pages as a **search form** for the query placeholders that are not auto-filled from the page context, instead of showing results directly. Submitting leads to the new standalone **`/view-results`** page, where the results render according to the view's display type.

### How it works
- **`View`/`KPXL_TERMS`**: `gen:QueryFormView` is parsed into a `hasQueryForm()` flag, deliberately kept out of the display-type set so it composes with any of the five display types (last-statement-wins there would otherwise clobber the display type).
- **`QueryFormPanel`** (new): one `QueryParamField` per placeholder that is neither magic (session-bound) nor fixed by the page context; fixed params travel along in the redirect as `queryparam_*`, together with the navigation context (so the results page shows the "< [resource]" back-crumb). On resource pages the panel carries the standard view-display dropdown menu. Mandatory fields get the client-side `required` attribute; remaining validation errors go to session-scoped feedback, since the embedding ListView recreates the panel on the error re-render.
- **`ViewResultsPage`** (new, `/view-results?view=<id>&queryparam_<name>=…`): repeats the prefilled form on top for refining, renders results below in the same row-section, title-less (the form already shows the view's icon+title) via the new `ViewDisplay.withTitle("")`; falls back to the plain table for views without a display type and shows a hint when a mandatory parameter is missing.
- **`QueryResultComponentFactory`** (new): the display-type → result-component dispatch extracted from `ViewList`, shared by ViewList and the results page.
- **CSS**: filter inputs get a `panelfilter` class; with the title h4 hidden (the flex spacer), the filter claims the auto margin itself so it stays right-aligned next to the dropdown.

### Try it
A published "🔍 Full-text Search" view carries the new type: [`RAd-mlgI…/fulltext-search-view`](https://w3id.org/np/RAd-mlgIjUnhCV0r5Rn_T3CwaFxxGAGJLiTXsVfft-PkA), pointing at the existing fulltext-search query. E.g. `/view-results?view=https://w3id.org/np/RAd-mlgIjUnhCV0r5Rn_T3CwaFxxGAGJLiTXsVfft-PkA/fulltext-search-view`, or via the view display attached to `https://w3id.org/spaces/test/group`.

### Verified
Exercised live on a dev instance: form rendering (mandatory/optional fields), submit → redirect → prefilled form + list results, context carry-over, validation errors on both the embedded and standalone form, dropdown menus, and no regression on existing resource-page views (the dispatch refactor path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)