### PR TITLE
feat: identify templates by embedded IRIs with dual-mode parser

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/Utils.java
+++ b/src/main/java/com/knowledgepixels/nanodash/Utils.java
@@ -144,6 +144,19 @@ public class Utils {
     }
 
     /**
+     * Strips a sub-IRI of a nanopublication (e.g. an embedded resource IRI like
+     * {@code <np-uri>/template}) down to the nanopublication ID itself, i.e. up to
+     * and including the trusty artifact code. An ID without a sub-path is returned
+     * unchanged.
+     *
+     * @param id the ID to strip
+     * @return the nanopublication ID
+     */
+    public static String stripToNanopubId(String id) {
+        return id.replaceFirst("^(.*[^A-Za-z0-9-_]RA[A-Za-z0-9-_]{43})[^A-Za-z0-9-_].*$", "$1");
+    }
+
+    /**
      * URL-encodes the string representation of the given object using UTF-8 encoding.
      *
      * @param o the object to be URL-encoded

--- a/src/main/java/com/knowledgepixels/nanodash/component/IriItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/IriItem.java
@@ -109,8 +109,8 @@ public class IriItem extends AbstractContextComponent {
                 iriString = iriString.replace(Utils.getUriPrefix(iriString), LocalUri.PREFIX);
             }
         }
-        if (iriString.startsWith(context.getTemplateId())) {
-            iriString = iriString.replace(context.getTemplateId(), "");
+        if (iriString.startsWith(context.getTemplateNanopubUri())) {
+            iriString = iriString.replace(context.getTemplateNanopubUri(), "");
             if (this.context.getExistingNanopub() != null) {
                 iriString = this.context.getExistingNanopub().getUri().stringValue() + iriString;
             }
@@ -174,7 +174,7 @@ public class IriItem extends AbstractContextComponent {
     public boolean isUnifiableWith(Value v) {
         if (!(v instanceof IRI)) return false;
         // TODO: Check that template URIs don't have regex characters:
-        String iriS = iri.stringValue().replaceFirst("^" + context.getTemplateId() + "[#/]?", LocalUri.PREFIX);
+        String iriS = iri.stringValue().replaceFirst("^" + context.getTemplateNanopubUri() + "[#/]?", LocalUri.PREFIX);
         String vs = v.stringValue();
         if (context.isReadOnly()) {
             vs = vs.replaceFirst("^" + context.getExistingNanopub().getUri() + "[#/]?", LocalUri.PREFIX);

--- a/src/main/java/com/knowledgepixels/nanodash/component/NanopubItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/NanopubItem.java
@@ -316,7 +316,7 @@ public class NanopubItem extends Panel {
                 TemplateContext piContext = new TemplateContext(ContextType.PUBINFO, s, "pubinfo-statement", n.getNanopub());
                 if (piContext.willMatchAnyTriple()) {
                     genericContexts.add(piContext);
-                } else if (piContext.getTemplateId().equals("https://w3id.org/np/RAE-zsHxw2VoE6emhSY_Fkr5p_li5Qb8FrREqUwdWdzyM")) {
+                } else if (piContext.getTemplate().hasId("https://w3id.org/np/RAE-zsHxw2VoE6emhSY_Fkr5p_li5Qb8FrREqUwdWdzyM")) {
                     // TODO: This is a work-around; check why this template doesn't give true to willMatchAnyTriple()
                     genericContexts.add(piContext);
                 } else {

--- a/src/main/java/com/knowledgepixels/nanodash/component/PublishForm.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/PublishForm.java
@@ -241,7 +241,7 @@ public class PublishForm extends Panel {
             c.setParam("np", fillNp.getUri().stringValue());
         }
         for (IRI r : assertionContext.getTemplate().getRequiredPubInfoElements()) {
-            String latestId = QueryApiAccess.getLatestVersionId(r.stringValue());
+            String latestId = td.getLatestTemplateId(r.stringValue());
             if (pubInfoContextMap.containsKey(r.stringValue()) || pubInfoContextMap.containsKey(latestId)) continue;
             TemplateContext c = new TemplateContext(ContextType.PUBINFO, r.stringValue(), "pi-statement", targetNamespace);
             pubInfoContexts.add(c);
@@ -264,7 +264,7 @@ public class PublishForm extends Panel {
         }
         if (fillNp != null && !fillOnlyAssertion) {
             for (IRI piTemplateId : td.getPubinfoTemplateIds(fillNp)) {
-                String piTemplateIdLatest = QueryApiAccess.getLatestVersionId(piTemplateId.stringValue());
+                String piTemplateIdLatest = td.getLatestTemplateId(piTemplateId.stringValue());
                 if (piTemplateIdLatest.equals(supersedesPubInfoTemplateId)) continue;
                 if (!pubInfoContextMap.containsKey(piTemplateIdLatest)) {
                     // TODO Allow for automatically using latest template version
@@ -333,7 +333,7 @@ public class PublishForm extends Panel {
             c.initStatements();
         }
 
-        String latestAssertionId = QueryApiAccess.getLatestVersionId(assertionContext.getTemplateId());
+        String latestAssertionId = td.getLatestTemplateId(assertionContext.getTemplateId());
         if (!assertionContext.getTemplateId().equals(latestAssertionId)) {
             add(new Label("newversion", "There is a new version of this assertion template:"));
             PageParameters params = new PageParameters(pageParams);
@@ -677,8 +677,11 @@ public class PublishForm extends Panel {
         recommendedPiTemplateOptionIds.add("https://w3id.org/np/RAjvEpLZUE7rMoa8q6mWSsN6utJDp-5FmgO47YGsbgw3w");
         recommendedPiTemplateOptionIds.add("http://purl.org/np/RAxuGRKID6yNg63V5Mf0ot2NjncOnodh-mkN3qT_1txGI");
         for (TemplateContext c : pubInfoContexts) {
-            String s = c.getTemplate().getId();
-            handledPiTemplates.put(s, true);
+            // Key both ID forms: the "others" dedup below compares against listing
+            // entries keyed by nanopub URI, which for a template with embedded
+            // identity differs from its canonical ID.
+            handledPiTemplates.put(c.getTemplate().getId(), true);
+            handledPiTemplates.put(c.getTemplate().getNanopub().getUri().stringValue(), true);
         }
         for (String s : recommendedPiTemplateOptionIds) {
             handledPiTemplates.put(s, true);
@@ -721,7 +724,7 @@ public class PublishForm extends Panel {
                         boolean isAlreadyUsed = false;
                         for (TemplateContext c : pubInfoContexts) {
                             // TODO: make this more efficient/nicer
-                            if (c.getTemplate().getId().equals(s)) {
+                            if (c.getTemplate().hasId(s)) {
                                 isAlreadyUsed = true;
                                 break;
                             }
@@ -738,7 +741,7 @@ public class PublishForm extends Panel {
                         boolean isAlreadyUsed = false;
                         for (TemplateContext c : pubInfoContexts) {
                             // TODO: make this more efficient/nicer
-                            if (c.getTemplate().getId().equals(s)) {
+                            if (c.getTemplate().hasId(s)) {
                                 isAlreadyUsed = true;
                                 break;
                             }
@@ -923,12 +926,14 @@ public class PublishForm extends Panel {
         npCreator.addNamespace("this", targetNamespace);
         npCreator.addNamespace("sub", targetNamespace + "/");
         npCreator.addTimestampNow();
-        IRI templateUri = assertionContext.getTemplate().getNanopub().getUri();
+        // The canonical template ID: the embedded template-node IRI for templates
+        // with embedded identity, the nanopub URI for legacy ones.
+        IRI templateUri = vf.createIRI(assertionContext.getTemplate().getId());
         npCreator.addPubinfoStatement(NTEMPLATE.WAS_CREATED_FROM_TEMPLATE, templateUri);
-        IRI prTemplateUri = provenanceContext.getTemplate().getNanopub().getUri();
+        IRI prTemplateUri = vf.createIRI(provenanceContext.getTemplate().getId());
         npCreator.addPubinfoStatement(NTEMPLATE.WAS_CREATED_FROM_PROVENANCE_TEMPLATE, prTemplateUri);
         for (TemplateContext c : pubInfoContexts) {
-            IRI piTemplateUri = c.getTemplate().getNanopub().getUri();
+            IRI piTemplateUri = vf.createIRI(c.getTemplate().getId());
             npCreator.addPubinfoStatement(NTEMPLATE.WAS_CREATED_FROM_PUBINFO_TEMPLATE, piTemplateUri);
         }
         String nanopubLabel = getNanopubLabel(npCreator);
@@ -963,8 +968,8 @@ public class PublishForm extends Panel {
         String nanopubLabel = assertionContext.getTemplate().getNanopubLabelPattern();
         while (nanopubLabel.matches(".*\\$\\{[_a-zA-Z0-9-]+\\}.*")) {
             String placeholderPostfix = nanopubLabel.replaceFirst("^.*\\$\\{([_a-zA-Z0-9-]+)\\}.*$", "$1");
-            IRI placeholderIriHash = vf.createIRI(assertionContext.getTemplateId() + "#" + placeholderPostfix);
-            IRI placeholderIriSlash = vf.createIRI(assertionContext.getTemplateId() + "/" + placeholderPostfix);
+            IRI placeholderIriHash = vf.createIRI(assertionContext.getTemplateNanopubUri() + "#" + placeholderPostfix);
+            IRI placeholderIriSlash = vf.createIRI(assertionContext.getTemplateNanopubUri() + "/" + placeholderPostfix);
             IRI placeholderIri;
             String placeholderValue = "";
             if (assertionContext.getComponentModels().get(placeholderIriSlash) != null) {

--- a/src/main/java/com/knowledgepixels/nanodash/component/TemplateFormPreview.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/TemplateFormPreview.java
@@ -36,7 +36,7 @@ public class TemplateFormPreview extends Panel {
 
         // Register the template from the nanopub so it can be looked up by TemplateContext
         Template template = td.registerTemplate(templateNanopub);
-        String templateId = templateNanopub.getUri().stringValue();
+        String templateId = template.getId();
 
         String targetNamespace = template.getTargetNamespace();
         if (targetNamespace == null) {
@@ -73,7 +73,7 @@ public class TemplateFormPreview extends Panel {
             String rId = r.stringValue();
             boolean alreadyAdded = false;
             for (TemplateContext c : pubInfoContexts) {
-                if (c.getTemplate().getId().equals(rId)) {
+                if (c.getTemplate().hasId(rId)) {
                     alreadyAdded = true;
                     break;
                 }

--- a/src/main/java/com/knowledgepixels/nanodash/template/Template.java
+++ b/src/main/java/com/knowledgepixels/nanodash/template/Template.java
@@ -43,6 +43,8 @@ public class Template implements Serializable {
 
     // TODO: Make all these maps more generic and the code simpler:
     private IRI templateIri;
+    private boolean embeddedIdentity = false;
+    private IRI templateKindIri;
     private Map<IRI, List<IRI>> typeMap = new HashMap<>();
     private Map<IRI, List<Value>> possibleValueMap = new HashMap<>();
     private Map<IRI, List<IRI>> possibleValuesToLoadMap = new HashMap<>();
@@ -94,7 +96,8 @@ public class Template implements Serializable {
      * @return true if the template is unlisted, false otherwise.
      */
     public boolean isUnlisted() {
-        return typeMap.get(templateIri).contains(NTEMPLATE.UNLISTED_TEMPLATE);
+        List<IRI> types = typeMap.get(templateIri);
+        return types != null && types.contains(NTEMPLATE.UNLISTED_TEMPLATE);
     }
 
     /**
@@ -107,12 +110,41 @@ public class Template implements Serializable {
     }
 
     /**
-     * Returns the ID of the template, which is the URI of the nanopublication.
+     * Returns the ID of the template: for a template with embedded identity (the
+     * template node is a regular embedded IRI in the assertion), that embedded IRI;
+     * for a legacy template (the template node is the assertion graph URI), the URI
+     * of the nanopublication.
      *
      * @return the ID of the template as a string.
      */
     public String getId() {
+        if (embeddedIdentity) return templateIri.stringValue();
         return nanopub.getUri().toString();
+    }
+
+    /**
+     * Checks whether the given ID refers to this template, in either form: the
+     * template's canonical ID ({@link #getId()}) or its nanopublication URI. Use
+     * this instead of comparing against {@link #getId()} when the ID to compare
+     * comes from outside (page parameters, published references), as those may
+     * carry either form.
+     *
+     * @param id the ID to check
+     * @return true if the ID refers to this template
+     */
+    public boolean hasId(String id) {
+        return id != null && (id.equals(getId()) || id.equals(nanopub.getUri().stringValue()));
+    }
+
+    /**
+     * Returns the template kind IRI, i.e. the stable identifier this template
+     * version declares itself a version of ({@code dct:isVersionOf} on the template
+     * node), or null if it doesn't declare one.
+     *
+     * @return the template kind IRI, or null
+     */
+    public IRI getTemplateKindIri() {
+        return templateKindIri;
     }
 
     /**
@@ -714,18 +746,32 @@ public class Template implements Serializable {
     }
 
     private void processTemplate(Nanopub templateNp) throws MalformedTemplateException {
-        boolean isNpTemplate = false;
+        IRI assertionUri = templateNp.getAssertionUri();
+        Set<IRI> templateNodes = new LinkedHashSet<>();
         for (Statement st : templateNp.getAssertion()) {
-            if (st.getSubject().equals(templateNp.getAssertionUri()) && st.getPredicate().equals(RDF.TYPE)) {
-                if (st.getObject().equals(NTEMPLATE.ASSERTION_TEMPLATE) || st.getObject().equals(NTEMPLATE.PROVENANCE_TEMPLATE) || st.getObject().equals(NTEMPLATE.PUBINFO_TEMPLATE)) {
-                    isNpTemplate = true;
-                    break;
-                }
+            if (!st.getPredicate().equals(RDF.TYPE)) continue;
+            if (!(st.getSubject() instanceof IRI subjIri)) continue;
+            if (st.getObject().equals(NTEMPLATE.ASSERTION_TEMPLATE) || st.getObject().equals(NTEMPLATE.PROVENANCE_TEMPLATE) || st.getObject().equals(NTEMPLATE.PUBINFO_TEMPLATE)) {
+                templateNodes.add(subjIri);
             }
         }
 
-        if (isNpTemplate) {
+        if (templateNodes.contains(assertionUri)) {
+            // Legacy shape (template node = assertion graph URI) takes precedence
+            // over any other typed node, so every template that parsed before
+            // embedded identity existed keeps parsing identically.
+            templateIri = assertionUri;
             processNpTemplate(templateNp);
+        } else if (templateNodes.size() == 1) {
+            IRI node = templateNodes.iterator().next();
+            if (!node.stringValue().startsWith(templateNp.getUri().stringValue())) {
+                throw new MalformedTemplateException("Embedded template node must be in the nanopub's namespace: " + node);
+            }
+            templateIri = node;
+            embeddedIdentity = true;
+            processNpTemplate(templateNp);
+        } else if (templateNodes.size() > 1) {
+            throw new MalformedTemplateException("Multiple embedded template nodes found");
         } else {
             // Experimental SHACL-based template:
             processShaclTemplate(templateNp);
@@ -733,7 +779,6 @@ public class Template implements Serializable {
     }
 
     private void processNpTemplate(Nanopub templateNp) {
-        templateIri = templateNp.getAssertionUri();
         for (Statement st : templateNp.getAssertion()) {
             final IRI subj = (IRI) st.getSubject();
             final IRI pred = st.getPredicate();
@@ -754,6 +799,8 @@ public class Template implements Serializable {
                         targetNamespace = objS;
                     } else if (pred.equals(NTEMPLATE.HAS_TARGET_NANOPUB_TYPE)) {
                         targetNanopubTypes.add(objIri);
+                    } else if (pred.equals(DCTERMS.IS_VERSION_OF)) {
+                        templateKindIri = objIri;
                     }
                 } else if (obj instanceof Literal) {
                     if (pred.equals(NTEMPLATE.HAS_TAG)) {

--- a/src/main/java/com/knowledgepixels/nanodash/template/TemplateContext.java
+++ b/src/main/java/com/knowledgepixels/nanodash/template/TemplateContext.java
@@ -199,6 +199,18 @@ public class TemplateContext implements Serializable {
     }
 
     /**
+     * Returns the URI of the nanopublication containing the template of this
+     * context. Placeholder and other local IRIs of a template are minted under
+     * this URI, so use it (not {@link #getTemplateId()}, which may be an embedded
+     * sub-IRI) wherever a local-IRI prefix is stripped or constructed.
+     *
+     * @return the template's nanopublication URI
+     */
+    public String getTemplateNanopubUri() {
+        return template.getNanopub().getUri().stringValue();
+    }
+
+    /**
      * Sets a parameter for this context.
      *
      * @param name  the name of the parameter

--- a/src/main/java/com/knowledgepixels/nanodash/template/TemplateData.java
+++ b/src/main/java/com/knowledgepixels/nanodash/template/TemplateData.java
@@ -2,6 +2,7 @@ package com.knowledgepixels.nanodash.template;
 
 import com.knowledgepixels.nanodash.ApiCache;
 import com.knowledgepixels.nanodash.QueryApiAccess;
+import com.knowledgepixels.nanodash.Utils;
 import net.trustyuri.TrustyUriUtils;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Statement;
@@ -110,7 +111,9 @@ public class TemplateData implements Serializable {
     }
 
     /**
-     * Returns a Template object for the given template ID.
+     * Returns a Template object for the given template ID. The ID may be either
+     * form: the nanopublication URI, or (for templates with embedded identity) the
+     * embedded template-node IRI.
      *
      * @param id the ID of the template
      * @return the Template object if found, or null if not found or invalid
@@ -118,10 +121,18 @@ public class TemplateData implements Serializable {
     public Template getTemplate(String id) {
         Template template = templateMap.get(id);
         if (template != null) return template;
-        if (TrustyUriUtils.isPotentialTrustyUri(id)) {
+        String npId = Utils.stripToNanopubId(id);
+        template = templateMap.get(npId);
+        if (template != null) {
+            templateMap.put(id, template);
+            return template;
+        }
+        if (TrustyUriUtils.isPotentialTrustyUri(npId)) {
             try {
-                Template t = new Template(id);
+                Template t = new Template(npId);
                 templateMap.put(id, t);
+                templateMap.put(npId, t);
+                templateMap.put(t.getId(), t);
                 return t;
             } catch (Exception ex) {
                 logger.error("Exception: {}", ex.getMessage());
@@ -145,11 +156,31 @@ public class TemplateData implements Serializable {
         try {
             Template t = new Template(np);
             templateMap.put(id, t);
+            templateMap.put(t.getId(), t);
             return t;
         } catch (Exception ex) {
             logger.error("Exception registering template from nanopub: {}", ex.getMessage());
             return null;
         }
+    }
+
+    /**
+     * Resolves a template ID to the ID of the latest version of that template,
+     * following the supersedes chain of the containing nanopublication. Accepts
+     * either ID form (nanopublication URI or embedded template-node IRI) and
+     * returns the latest version's canonical ID ({@link Template#getId()}) — so
+     * even when there is no newer version, the given ID is normalized to canonical
+     * form. Falls back to the given ID if the template cannot be loaded.
+     *
+     * @param templateId the ID of the template
+     * @return the canonical ID of the latest version, or the given ID as fallback
+     */
+    public String getLatestTemplateId(String templateId) {
+        String npId = Utils.stripToNanopubId(templateId);
+        String latestNpId = QueryApiAccess.getLatestVersionId(npId);
+        Template latest = getTemplate(latestNpId);
+        if (latest != null) return latest.getId();
+        return templateId;
     }
 
     /**

--- a/src/test/java/com/knowledgepixels/nanodash/template/TemplateIdentityTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/template/TemplateIdentityTest.java
@@ -1,0 +1,172 @@
+package com.knowledgepixels.nanodash.template;
+
+import com.knowledgepixels.nanodash.Utils;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.DCTERMS;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.junit.jupiter.api.Test;
+import org.nanopub.Nanopub;
+import org.nanopub.NanopubCreator;
+import org.nanopub.vocabulary.NPX;
+import org.nanopub.vocabulary.NTEMPLATE;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for the two template identity forms: legacy (template node = assertion
+ * graph URI, ID = nanopub URI) and embedded (template node = embedded IRI in the
+ * assertion, ID = that IRI).
+ */
+public class TemplateIdentityTest {
+
+    private static final ValueFactory vf = SimpleValueFactory.getInstance();
+
+    // A syntactically valid trusty URI shape (RA + 43 chars), so sub-IRIs strip correctly:
+    private static final String NP_URI = "https://w3id.org/np/RAAbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_AbCdE";
+    private static final IRI TEMPLATE_NODE = vf.createIRI(NP_URI + "/template");
+    private static final IRI KIND_IRI = vf.createIRI(NP_URI + "/test-template-kind");
+
+    private static NanopubCreator newCreator() throws Exception {
+        NanopubCreator creator = new NanopubCreator(NP_URI);
+        creator.addProvenanceStatement(vf.createStatement(creator.getAssertionUri(), RDFS.SEEALSO, creator.getAssertionUri()));
+        creator.addPubinfoStatement(vf.createStatement(creator.getNanopubUri(), RDFS.SEEALSO, creator.getNanopubUri()));
+        return creator;
+    }
+
+    /**
+     * Adds the template body (label, one reified statement with a literal
+     * placeholder) with the given IRI as the template node.
+     */
+    private static void addTemplateBody(NanopubCreator creator, IRI templateNode) throws Exception {
+        IRI st1 = vf.createIRI(NP_URI + "/st1");
+        IRI namePlaceholder = vf.createIRI(NP_URI + "/name");
+        creator.addAssertionStatement(templateNode, RDF.TYPE, NTEMPLATE.ASSERTION_TEMPLATE);
+        creator.addAssertionStatement(templateNode, RDFS.LABEL, vf.createLiteral("Test template"));
+        creator.addAssertionStatement(templateNode, DCTERMS.DESCRIPTION, vf.createLiteral("A template for testing."));
+        creator.addAssertionStatement(templateNode, NTEMPLATE.HAS_STATEMENT, st1);
+        creator.addAssertionStatement(st1, RDF.SUBJECT, vf.createIRI("http://example.com/subject"));
+        creator.addAssertionStatement(st1, RDF.PREDICATE, RDFS.LABEL);
+        creator.addAssertionStatement(st1, RDF.OBJECT, namePlaceholder);
+        creator.addAssertionStatement(namePlaceholder, RDF.TYPE, NTEMPLATE.LITERAL_PLACEHOLDER);
+        creator.addAssertionStatement(namePlaceholder, RDFS.LABEL, vf.createLiteral("name"));
+    }
+
+    private static Nanopub legacyTemplateNanopub() throws Exception {
+        NanopubCreator creator = newCreator();
+        addTemplateBody(creator, creator.getAssertionUri());
+        return creator.finalizeNanopub();
+    }
+
+    private static Nanopub embeddedTemplateNanopub() throws Exception {
+        NanopubCreator creator = newCreator();
+        addTemplateBody(creator, TEMPLATE_NODE);
+        creator.addAssertionStatement(TEMPLATE_NODE, DCTERMS.IS_VERSION_OF, KIND_IRI);
+        creator.addPubinfoStatement(vf.createStatement(creator.getNanopubUri(), NPX.EMBEDS, TEMPLATE_NODE));
+        return creator.finalizeNanopub();
+    }
+
+    @Test
+    void legacyTemplateParses() throws Exception {
+        Template t = new Template(legacyTemplateNanopub());
+        assertEquals(NP_URI, t.getId());
+        assertTrue(t.hasId(NP_URI));
+        assertFalse(t.hasId(TEMPLATE_NODE.stringValue()));
+        assertEquals("Test template", t.getLabel());
+        assertEquals(1, t.getStatementIris().size());
+        assertFalse(t.isUnlisted());
+        assertNull(t.getTemplateKindIri());
+    }
+
+    @Test
+    void embeddedIdentityTemplateParses() throws Exception {
+        Template t = new Template(embeddedTemplateNanopub());
+        assertEquals(TEMPLATE_NODE.stringValue(), t.getId());
+        assertTrue(t.hasId(TEMPLATE_NODE.stringValue()));
+        assertTrue(t.hasId(NP_URI));
+        assertEquals("Test template", t.getLabel());
+        assertEquals("A template for testing.", t.getDescription());
+        assertEquals(1, t.getStatementIris().size());
+        assertFalse(t.isUnlisted());
+        assertEquals(KIND_IRI, t.getTemplateKindIri());
+    }
+
+    @Test
+    void unlistedEmbeddedTemplate() throws Exception {
+        NanopubCreator creator = newCreator();
+        addTemplateBody(creator, TEMPLATE_NODE);
+        creator.addAssertionStatement(TEMPLATE_NODE, RDF.TYPE, NTEMPLATE.UNLISTED_TEMPLATE);
+        Template t = new Template(creator.finalizeNanopub());
+        assertTrue(t.isUnlisted());
+    }
+
+    @Test
+    void legacyTemplateKindParses() throws Exception {
+        NanopubCreator creator = newCreator();
+        addTemplateBody(creator, creator.getAssertionUri());
+        creator.addAssertionStatement(creator.getAssertionUri(), DCTERMS.IS_VERSION_OF, KIND_IRI);
+        Template t = new Template(creator.finalizeNanopub());
+        assertEquals(NP_URI, t.getId());
+        assertEquals(KIND_IRI, t.getTemplateKindIri());
+    }
+
+    @Test
+    void legacyShapeTakesPrecedenceOverOtherTypedNodes() throws Exception {
+        NanopubCreator creator = newCreator();
+        addTemplateBody(creator, creator.getAssertionUri());
+        creator.addAssertionStatement(TEMPLATE_NODE, RDF.TYPE, NTEMPLATE.ASSERTION_TEMPLATE);
+        Template t = new Template(creator.finalizeNanopub());
+        assertEquals(NP_URI, t.getId());
+    }
+
+    @Test
+    void multipleEmbeddedTemplateNodesAreMalformed() throws Exception {
+        NanopubCreator creator = newCreator();
+        addTemplateBody(creator, TEMPLATE_NODE);
+        creator.addAssertionStatement(vf.createIRI(NP_URI + "/template2"), RDF.TYPE, NTEMPLATE.ASSERTION_TEMPLATE);
+        Nanopub np = creator.finalizeNanopub();
+        assertThrows(MalformedTemplateException.class, () -> new Template(np));
+    }
+
+    @Test
+    void templateNodeOutsideNanopubNamespaceIsMalformed() throws Exception {
+        NanopubCreator creator = newCreator();
+        addTemplateBody(creator, vf.createIRI("http://example.com/external-template"));
+        Nanopub np = creator.finalizeNanopub();
+        assertThrows(MalformedTemplateException.class, () -> new Template(np));
+    }
+
+    @Test
+    void embeddedProvenanceAndPubinfoTemplateNodesAreDiscovered() throws Exception {
+        for (IRI type : new IRI[]{NTEMPLATE.PROVENANCE_TEMPLATE, NTEMPLATE.PUBINFO_TEMPLATE}) {
+            NanopubCreator creator = newCreator();
+            creator.addAssertionStatement(TEMPLATE_NODE, RDF.TYPE, type);
+            creator.addAssertionStatement(TEMPLATE_NODE, RDFS.LABEL, vf.createLiteral("Test template"));
+            Template t = new Template(creator.finalizeNanopub());
+            assertEquals(TEMPLATE_NODE.stringValue(), t.getId());
+        }
+    }
+
+    @Test
+    void stripToNanopubId() {
+        assertEquals(NP_URI, Utils.stripToNanopubId(TEMPLATE_NODE.stringValue()));
+        assertEquals(NP_URI, Utils.stripToNanopubId(NP_URI + "#name"));
+        assertEquals(NP_URI, Utils.stripToNanopubId(NP_URI));
+    }
+
+    @Test
+    void registeredTemplateResolvesUnderBothIdForms() throws Exception {
+        TemplateData td = TemplateData.get();
+        Template t = td.registerTemplate(embeddedTemplateNanopub());
+        assertEquals(TEMPLATE_NODE.stringValue(), t.getId());
+        assertTrue(t == td.getTemplate(NP_URI));
+        assertTrue(t == td.getTemplate(TEMPLATE_NODE.stringValue()));
+    }
+
+}

--- a/src/test/resources/templates/new-style-assertion-template.trig
+++ b/src/test/resources/templates/new-style-assertion-template.trig
@@ -1,0 +1,47 @@
+@prefix this: <http://purl.org/nanopub/temp/np001/> .
+@prefix sub: <http://purl.org/nanopub/temp/np001/> .
+@prefix np: <http://www.nanopub.org/nschema#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix npx: <http://purl.org/nanopub/x/> .
+@prefix nt: <https://w3id.org/np/o/ntemplate/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+
+sub:Head {
+  this: a np:Nanopublication ;
+    np:hasAssertion sub:assertion ;
+    np:hasProvenance sub:provenance ;
+    np:hasPublicationInfo sub:pubinfo .
+}
+
+sub:assertion {
+  sub:template a nt:AssertionTemplate ;
+    dct:isVersionOf sub:test-template-kind ;
+    rdfs:label "Test template with embedded identity" ;
+    dct:description "A test template whose template node is an embedded IRI (not the assertion graph URI), per docs/template-identity-and-governance.md." ;
+    nt:hasStatement sub:st01 .
+
+  sub:st01 rdf:subject sub:thing ;
+    rdf:predicate rdfs:label ;
+    rdf:object sub:name .
+
+  sub:thing a nt:UriPlaceholder ;
+    rdfs:label "URI of the thing to label" .
+
+  sub:name a nt:LiteralPlaceholder ;
+    rdfs:label "label text" .
+}
+
+sub:provenance {
+  sub:assertion prov:wasAttributedTo <https://orcid.org/0000-0002-1267-0234> .
+}
+
+sub:pubinfo {
+  this: dct:created "2026-07-08T00:00:00Z"^^xsd:dateTime ;
+    dct:creator <https://orcid.org/0000-0002-1267-0234> ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    npx:embeds sub:template ;
+    npx:introduces sub:test-template-kind .
+}


### PR DESCRIPTION
First implementation step of `docs/template-identity-and-governance.md` (part of #544): templates can now be identified by an **embedded IRI** — a regular node in the assertion typed `nt:AssertionTemplate`/`ProvenanceTemplate`/`PubinfoTemplate`, declared via `npx:embeds` — like views and queries already are, instead of overloading the assertion graph URI as the template node and the nanopub URI as the external reference.

## What's in here

- **Dual-mode node discovery** (`Template.processTemplate`): the legacy shape (assertion URI typed) takes precedence and parses bit-for-bit as before, permanently; otherwise exactly one embedded template node in the nanopub's namespace is accepted (`MalformedTemplateException` for multiple or external nodes).
- **Two-roles split** of the nanopub URI:
  - *Reference id*: `Template.getId()` returns the embedded IRI for new-style templates; it flows into `template=` page params and the emitted `nt:wasCreatedFrom*Template` pubinfo triples. New `Template.hasId()` matches either form for comparisons.
  - *Placeholder base URI*: placeholder IRIs live under the **nanopub URI** in both shapes, so `IriItem` prefix-stripping/unification and `PublishForm`'s nanopub-label placeholder construction switch to the new `TemplateContext.getTemplateNanopubUri()`.
- **Dual-form resolution**: `TemplateData.getTemplate()` accepts both id forms (new `Utils.stripToNanopubId()` before the trusty-URI gate; caches under requested/np/canonical keys); `registerTemplate` keys both forms so `_nanopub_trig` previews work; new `TemplateData.getLatestTemplateId()` follows the supersedes chain across identity styles and normalizes ids to canonical form (swapped into `PublishForm`'s three latest-version sites, fixing its dedup map-key comparisons).
- **Governance hook (inert)**: `dct:isVersionOf` on the template node is parsed into `Template.getTemplateKindIri()`, ready for the space-governance step (kind as maintained resource + `gen:governedBy`).
- **Tests + fixture**: 10 network-free parser/cache tests (`TemplateIdentityTest`) built via `NanopubCreator`, plus a hand-authored new-style TriG fixture under `src/test/resources/templates/`.

## Compatibility

Everything published today keeps working: legacy templates parse identically (permanent fallback branch), np-URI references keep resolving, and no existing template changes shape implicitly. The deliberate switch-throw is the emission change: nanopubs created from a *new-style* template record the embedded IRI in `nt:wasCreatedFromTemplate` — which old deployments can't resolve. No new-style templates exist on the network yet, so rollout is controlled by when the first one is published (see the sequencing notes in the design doc).

## Verification

- `mvn test`: 749 tests, 0 failures (including the 10 new ones; `TemplateTest`/`AllAssertionTemplatesLoadingTest` act as the legacy regression net).
- New-style fixture signed locally (not published) and previewed via `/view?_nanopub_trig=…` on the dev jetty: the form preview renders with clean placeholder labels, and local identifiers are correctly recognized (IriItem prefix-strip against the np URI).
- Legacy smoke: `/publish?template=<live legacy np URI>` renders unchanged.
- Strip-leniency: `/publish?template=<np-uri>/template` of a legacy template resolves to the same form.

## Follow-up (out of scope here)

- Confirm the registry's server-side type inference lists new-style templates in `get-assertion-templates` before migrating any real template.
- Rollout steps 3–5 from the design doc: governed resolver query, `gen:governedBy` resolution branch, first governed template pair, listing dedup.
- Coordinate the dual-mode parser into the `Template` port to nanopub-java (Nanopublication/nanopub-java#91).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
