### PR TITLE
feat: resolve governed template versions space-based

### DIFF
--- a/docs/queries/get-latest-governed-version.trig
+++ b/docs/queries/get-latest-governed-version.trig
@@ -12,7 +12,7 @@
 sub:Head { this: a np:Nanopublication; np:hasAssertion sub:assertion; np:hasProvenance sub:provenance; np:hasPublicationInfo sub:pubinfo . }
 sub:assertion {
   sub:get-latest-governed-version a grlc:grlc-query;
-    dct:description "Resolves the canonical (latest authorized) version of a space-governed view definition, per docs/views-and-presets-as-maintained-resources.md in the nanodash repo. Takes the definition's kind IRI (its dct:isVersionOf target; kind) and the governing space IRI (space) and returns at most one row: the newest version nanopub that (a) declares dct:isVersionOf <kind> plus gen:governedBy <space>, and (b) is signed by a pubkey of a CURRENT member+ (admin/maintainer/member, not observer) of that space's governing ref -- with the kind validated as a maintained resource of the space (npa:isMaintainedBy + npa:hasGoverningSpaceRef in the materialized state graph; the two anchors that make gen:governedBy a label, not a grant). The RoleInstantiation's npa:forSpace/npa:forSpaceRef pair ties the governing ref to the given space IRI, so a multi-maintainer kind never floats across pairs. An empty result means no valid floating candidate: the caller keeps its pinned version (the pin is the floor and is not re-validated here). Versions retracted by their own signing key are skipped. Hosted on the spaces repo; the version/pubkey lookup federates to the gen:ResourceView type repo with kind and space as text-substituted constants, so the federated scan stays narrow.";
+    dct:description "Resolves the canonical (latest authorized) version of a space-governed definition -- a resource view, an assertion/provenance/pubinfo template, or any other definition whose versions follow the embeds/isVersionOf/governedBy convention -- per docs/views-and-presets-as-maintained-resources.md and docs/template-identity-and-governance.md in the nanodash repo. Takes the definition's kind IRI (its dct:isVersionOf target; kind) and the governing space IRI (space) and returns at most one row: the newest version whose nanopub (a) npx:embeds the version IRI, which declares dct:isVersionOf <kind> plus gen:governedBy <space> in the assertion, and (b) is signed by a pubkey of a CURRENT member+ (admin/maintainer/member, not observer) of that space's governing ref -- with the kind validated as a maintained resource of the space (npa:isMaintainedBy + npa:hasGoverningSpaceRef in the materialized state graph; the two anchors that make gen:governedBy a label, not a grant). The RoleInstantiation's npa:forSpace/npa:forSpaceRef pair ties the governing ref to the given space IRI, so a multi-maintainer kind never floats across pairs. An empty result means no valid floating candidate: the caller keeps its pinned version (the pin is the floor and is not re-validated here). Versions retracted by their own signing key are skipped. Hosted on the spaces repo; the version/pubkey lookup federates to the full repo with kind and space as text-substituted constants, so the federated scan stays narrow (entry via dct:isVersionOf <kind>). This version generalizes the previous view-specific one (which federated to the gen:ResourceView type repo) to definitions of any type, so the same resolver serves views and templates alike.";
     dct:license <http://www.apache.org/licenses/LICENSE-2.0>;
     rdfs:label "Get latest governed version";
     grlc:endpoint <https://w3id.org/np/l/nanopub-query-1.1/repo/spaces>;
@@ -31,7 +31,7 @@ select distinct ?version ?date ?np ("^" as ?np_label) where {
     filter(?tier = gen:AdminRole || ?tier = gen:MaintainerRole || ?tier = gen:MemberRole)
     ?acct a npa:AccountState ; npa:agent ?agent ; npa:pubkey ?pubkey .
   }
-  service <https://w3id.org/np/l/nanopub-query-1.1/repo/type/ec6722efa3b44e0a18aa63afe5964158a1fdb7f0413ea5f23bfddf5c03ca0221> {
+  service <https://w3id.org/np/l/nanopub-query-1.1/repo/full> {
     graph npa:graph {
       ?np npa:hasValidSignatureForPublicKeyHash ?pubkey ;
           dct:created ?date ;
@@ -50,5 +50,5 @@ order by desc(?date) desc(?np) limit 1""" .
 sub:provenance { sub:assertion prov:wasAttributedTo orcid:0000-0002-1267-0234 . }
 sub:pubinfo {
   orcid:0000-0002-1267-0234 foaf:name "Tobias Kuhn" .
-  this: dct:created "2026-07-03T09:59:49Z"^^xsd:dateTime; dct:creator orcid:0000-0002-1267-0234; dct:license <https://creativecommons.org/licenses/by/4.0/>; npx:embeds sub:get-latest-governed-version .
+  this: dct:created "2026-07-08T10:58:59Z"^^xsd:dateTime; dct:creator orcid:0000-0002-1267-0234; dct:license <https://creativecommons.org/licenses/by/4.0/>; npx:supersedes <https://w3id.org/np/RABmOzHjDWhpqoRJsD4XinfDoxDOxKJ8NgJA826O_I-OI>; npx:embeds sub:get-latest-governed-version .
 }

--- a/docs/template-identity-and-governance.md
+++ b/docs/template-identity-and-governance.md
@@ -1,6 +1,13 @@
 # Templates: embedded identity & space governance
 
-**Status:** design / not yet implemented
+**Status:** partly implemented — embedded identity (rollout steps 1–2) merged in PR #545;
+governed resolution (steps 3–4) live: the generalized `get-latest-governed-version` query
+(`RAPSWgzHef9bIJyCoLodFH-BWtlESf1jIstEb0kn4B5Cw`, serving views and templates), the
+`gen:governedBy` resolution branch in `TemplateData`, and a first governed test pair
+(template `RAiK3l4D…`, kind registered maintained-by knowledgepixels via `RAnUJSnd…`).
+Server-side type inference confirmed to list new-style templates. Remaining: listing-query
+updates (e.g. `get-assertion-templates` reads the label off the assertion URI, so new-style
+templates list with an empty label), migration of real templates, listing dedup (step 5).
 
 ## Goal
 

--- a/src/main/java/com/knowledgepixels/nanodash/QueryApiAccess.java
+++ b/src/main/java/com/knowledgepixels/nanodash/QueryApiAccess.java
@@ -129,7 +129,7 @@ public class QueryApiAccess {
     // the caller keeps its pinned version (the pin is the floor). Source at
     // docs/queries/get-latest-governed-version.trig; see
     // docs/views-and-presets-as-maintained-resources.md.
-    public static final String GET_LATEST_GOVERNED_VERSION = "RABmOzHjDWhpqoRJsD4XinfDoxDOxKJ8NgJA826O_I-OI/get-latest-governed-version";
+    public static final String GET_LATEST_GOVERNED_VERSION = "RAPSWgzHef9bIJyCoLodFH-BWtlESf1jIstEb0kn4B5Cw/get-latest-governed-version";
     public static final String GET_SUB_SPACE_LINKS = "RAWgoQbP9_B9h3Bnwd1FGYX1gLYPyZFOxaeqIeA3TTPSU/get-sub-space-links";
     public static final String GET_MAINTAINED_RESOURCES = "RAOOq81R84exTUKUBQT3BbgCaSJyC2lqPDXIP2XaDTosM/get-maintained-resources";
     public static final String GET_SPACE_ADMINS = "RAaHOXMQ7Kq37T9syR9at0RqushclHenlPOFRwFDn0Cfs/get-space-admins";

--- a/src/main/java/com/knowledgepixels/nanodash/template/Template.java
+++ b/src/main/java/com/knowledgepixels/nanodash/template/Template.java
@@ -45,6 +45,7 @@ public class Template implements Serializable {
     private IRI templateIri;
     private boolean embeddedIdentity = false;
     private IRI templateKindIri;
+    private IRI governingSpace;
     private Map<IRI, List<IRI>> typeMap = new HashMap<>();
     private Map<IRI, List<Value>> possibleValueMap = new HashMap<>();
     private Map<IRI, List<IRI>> possibleValuesToLoadMap = new HashMap<>();
@@ -145,6 +146,18 @@ public class Template implements Serializable {
      */
     public IRI getTemplateKindIri() {
         return templateKindIri;
+    }
+
+    /**
+     * Returns the space governing this template version ({@code gen:governedBy} on
+     * the template node), or null if it doesn't declare one. A governed version's
+     * latest-resolution floats space-based within its (kind, space) pair instead of
+     * following the supersedes chain; see docs/template-identity-and-governance.md.
+     *
+     * @return the governing space IRI, or null
+     */
+    public IRI getGoverningSpace() {
+        return governingSpace;
     }
 
     /**
@@ -801,6 +814,8 @@ public class Template implements Serializable {
                         targetNanopubTypes.add(objIri);
                     } else if (pred.equals(DCTERMS.IS_VERSION_OF)) {
                         templateKindIri = objIri;
+                    } else if (pred.equals(KPXL_TERMS.GOVERNED_BY)) {
+                        governingSpace = objIri;
                     }
                 } else if (obj instanceof Literal) {
                     if (pred.equals(NTEMPLATE.HAS_TAG)) {

--- a/src/main/java/com/knowledgepixels/nanodash/template/TemplateData.java
+++ b/src/main/java/com/knowledgepixels/nanodash/template/TemplateData.java
@@ -1,5 +1,7 @@
 package com.knowledgepixels.nanodash.template;
 
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
 import com.knowledgepixels.nanodash.ApiCache;
 import com.knowledgepixels.nanodash.QueryApiAccess;
 import com.knowledgepixels.nanodash.Utils;
@@ -165,8 +167,13 @@ public class TemplateData implements Serializable {
     }
 
     /**
-     * Resolves a template ID to the ID of the latest version of that template,
-     * following the supersedes chain of the containing nanopublication. Accepts
+     * Resolves a template ID to the ID of the latest version of that template.
+     * A version declaring {@code gen:governedBy} resolves space-based: the newest
+     * version of its (kind, space) pair signed by a current member+ of the
+     * governing space, checked server-side by the
+     * {@link QueryApiAccess#GET_LATEST_GOVERNED_VERSION} query, with the pinned
+     * version as the floor on an empty result or failure. A version without it
+     * follows the supersedes chain of the containing nanopublication. Accepts
      * either ID form (nanopublication URI or embedded template-node IRI) and
      * returns the latest version's canonical ID ({@link Template#getId()}) — so
      * even when there is no newer version, the given ID is normalized to canonical
@@ -176,11 +183,41 @@ public class TemplateData implements Serializable {
      * @return the canonical ID of the latest version, or the given ID as fallback
      */
     public String getLatestTemplateId(String templateId) {
+        Template pinned = getTemplate(templateId);
+        if (pinned != null && pinned.getGoverningSpace() != null && pinned.getTemplateKindIri() != null) {
+            String governedId = resolveGovernedTemplateId(pinned);
+            if (governedId != null) return governedId;
+            return pinned.getId();
+        }
         String npId = Utils.stripToNanopubId(templateId);
         String latestNpId = QueryApiAccess.getLatestVersionId(npId);
         Template latest = getTemplate(latestNpId);
         if (latest != null) return latest.getId();
         return templateId;
+    }
+
+    /**
+     * Resolves the latest space-governed version of the pinned template's
+     * (kind, space) pair, or null if no valid floating candidate is found (the
+     * caller then keeps the pin).
+     */
+    private String resolveGovernedTemplateId(Template pinned) {
+        try {
+            Multimap<String, String> params = ArrayListMultimap.create();
+            params.put("kind", pinned.getTemplateKindIri().stringValue());
+            params.put("space", pinned.getGoverningSpace().stringValue());
+            ApiResponse resp = ApiCache.retrieveResponseSync(new QueryRef(QueryApiAccess.GET_LATEST_GOVERNED_VERSION, params), false);
+            if (resp != null && !resp.getData().isEmpty()) {
+                String latestId = resp.getData().get(0).get("version");
+                if (latestId != null && !latestId.isEmpty()) {
+                    Template resolved = getTemplate(latestId);
+                    if (resolved != null) return resolved.getId();
+                }
+            }
+        } catch (Exception ex) {
+            logger.error("Error resolving governed version for template: {}", pinned.getId(), ex);
+        }
+        return null;
     }
 
     /**

--- a/src/test/java/com/knowledgepixels/nanodash/template/TemplateIdentityTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/template/TemplateIdentityTest.java
@@ -1,6 +1,7 @@
 package com.knowledgepixels.nanodash.template;
 
 import com.knowledgepixels.nanodash.Utils;
+import com.knowledgepixels.nanodash.vocabulary.KPXL_TERMS;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
@@ -151,6 +152,24 @@ public class TemplateIdentityTest {
             Template t = new Template(creator.finalizeNanopub());
             assertEquals(TEMPLATE_NODE.stringValue(), t.getId());
         }
+    }
+
+    @Test
+    void governingSpaceParses() throws Exception {
+        IRI space = vf.createIRI("https://w3id.org/spaces/test-space");
+        NanopubCreator creator = newCreator();
+        addTemplateBody(creator, TEMPLATE_NODE);
+        creator.addAssertionStatement(TEMPLATE_NODE, DCTERMS.IS_VERSION_OF, KIND_IRI);
+        creator.addAssertionStatement(TEMPLATE_NODE, KPXL_TERMS.GOVERNED_BY, space);
+        Template t = new Template(creator.finalizeNanopub());
+        assertEquals(space, t.getGoverningSpace());
+        assertEquals(KIND_IRI, t.getTemplateKindIri());
+    }
+
+    @Test
+    void noGoverningSpaceByDefault() throws Exception {
+        Template t = new Template(embeddedTemplateNanopub());
+        assertNull(t.getGoverningSpace());
     }
 
     @Test


### PR DESCRIPTION
Second implementation step of `docs/template-identity-and-governance.md` (#544), building on the embedded-identity parser from #545: **governed template versions now resolve space-based**, extending the `gen:governedBy` model from views (#531) to templates.

## Code

- `Template` parses `gen:governedBy` on the template node → `getGoverningSpace()`.
- `TemplateData.getLatestTemplateId()`: a pin declaring both a kind (`dct:isVersionOf`) and a governing space resolves via the `get-latest-governed-version` query — the newest version of its `(kind, space)` pair signed by a current member+ of the governing space — failing closed to the pin on an empty result or error. Non-governed templates keep the supersedes path unchanged.
- `QueryApiAccess.GET_LATEST_GOVERNED_VERSION` repointed to the republished resolver; `docs/queries/get-latest-governed-version.trig` updated to match.

## The resolver query (published live)

`get-latest-governed-version` v2 = [`RAPSWgzHef…`](https://w3id.org/np/RAPSWgzHef9bIJyCoLodFH-BWtlESf1jIstEb0kn4B5Cw), superseding the view-specific v1: the SERVICE arm now federates to the **full repo** with no type constraint, so **one resolver serves views and templates** (and any future definition kind following the embeds + `isVersionOf` + `governedBy` convention). The constant kind IRI keeps the federated scan narrow — both existing governed view pairs answer sub-second, identically to v1.

## Verified live (published test artifacts)

First governed template pair: test template [`RAiK3l4D…`](https://w3id.org/np/RAiK3l4D7biiBJzA0r_EVywfNkPc2INHvyU88WsnR0Zrc) (embedded identity, kind minted, governed by knowledgepixels) + kind registration [`RAnUJSnd…`](https://w3id.org/np/RAnUJSndGF7t5WaXnvVUH7agYqqgYuO3oXuFn5Tr0LOw4). Then the float test: v2 [`RAmo_Lwu…`](https://w3id.org/np/RAmo_LwuBmrpfcUefsCUWmJcBt1By70OoP-TTUe7d_xA4) published **without `npx:supersedes`**:

- the governed resolver floats the pair to v2's embedded IRI (~20 s after publication);
- `get-latest-version-of-np` on v1 provably stays on v1 (the float is purely space-based);
- on a dev instance, a v1 pin shows the "new version" banner linking v2, and `template-version=latest` redirects to the v2 form.

Also confirmed: server-side type inference places new-style templates in the assertion-template type repo and in `get-assertion-templates` — though with an **empty label** (the listing query reads `rdfs:label` off the assertion URI); that listing-query fix is tracked in the design doc as part of the remaining rollout.

`mvn test`: 751 tests, 0 failures (two new governance parsing tests).

## Remaining rollout (out of scope)

Listing-query label/dedup updates, and migration of real templates once production instances run the new parser (the update-locked view-creation template `RA8_hijw…` stays untouched until then).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
