### PR TITLE
feat: list templates via node-anchored listing queries

### DIFF
--- a/docs/queries/get-assertion-templates.trig
+++ b/docs/queries/get-assertion-templates.trig
@@ -1,0 +1,68 @@
+@prefix this: <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
+@prefix sub: <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
+@prefix np: <http://www.nanopub.org/nschema#> .
+@prefix grlc: <https://w3id.org/kpxl/grlc/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix nt: <https://w3id.org/np/o/ntemplate/> .
+@prefix npx: <http://purl.org/nanopub/x/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix orcid: <https://orcid.org/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+sub:Head {
+  this: a np:Nanopublication ;
+    np:hasAssertion sub:assertion ;
+    np:hasProvenance sub:provenance ;
+    np:hasPublicationInfo sub:pubinfo .
+}
+
+sub:assertion {
+  sub:get-assertion-templates a grlc:grlc-query ;
+    dct:description "Returns the basic info of all assertion templates. Supports both template identity shapes (docs/template-identity-and-governance.md in the nanodash repo): the label, tag, and unlisted flag are read off the node typed nt:AssertionTemplate in the assertion -- the assertion graph URI for legacy templates, the embedded template node for templates with embedded identity -- falling back to the assertion graph URI if no typed node is found. Derived from (not superseding) the previous version, which is signed by a different key; consumers pin query IDs explicitly, so both versions stay usable." ;
+    dct:license <http://www.apache.org/licenses/LICENSE-2.0> ;
+    rdfs:label "Get assertion templates" ;
+    grlc:endpoint <https://w3id.org/np/l/nanopub-query-1.1/repo/type/79342356d3a68063a627e83ac34b376479e438abb8a4c4b27d49f845f537dc8d> ;
+    grlc:sparql """prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix dct: <http://purl.org/dc/terms/>
+prefix np: <http://www.nanopub.org/nschema#>
+prefix npa: <http://purl.org/nanopub/admin/>
+prefix npx: <http://purl.org/nanopub/x/>
+prefix nt: <https://w3id.org/np/o/ntemplate/>
+
+select ?np ?pubkey ?pubkeyhash ?date ?label ?tag ?unlisted ?creator where {
+  graph npa:graph {
+    ?np npa:hasValidSignatureForPublicKey ?pubkey .
+    filter not exists { ?npx npx:invalidates ?np ; npa:hasValidSignatureForPublicKey ?pubkey . }
+    ?np npa:hasValidSignatureForPublicKeyHash ?pubkeyhash .
+    ?np npx:hasNanopubType nt:AssertionTemplate .
+    ?np dct:created ?date .
+    ?np np:hasAssertion ?a .
+    optional { ?np npx:signedBy ?creator . }
+  }
+  optional { graph ?a { ?tnode a nt:AssertionTemplate } }
+  bind(coalesce(?tnode, ?a) as ?t)
+  optional { graph ?a { ?t rdfs:label ?label } }
+  optional { graph ?a { ?t nt:hasTag ?tag . } }
+  bind(exists { graph ?a { ?t a nt:UnlistedTemplate } } as ?unlisted)
+} order by desc(?date)""" .
+}
+
+sub:provenance {
+  sub:assertion prov:wasDerivedFrom <https://w3id.org/np/RA6bgrU3Ezfg5VAiLru0BFYHaSj6vZU6jJTscxNl8Wqvc> ;
+    prov:wasAttributedTo orcid:0000-0002-1267-0234 .
+}
+
+sub:pubinfo {
+  orcid:0000-0002-1267-0234 foaf:name "Tobias Kuhn" .
+
+  this: dct:created "2026-07-08T13:46:21Z"^^xsd:dateTime ;
+    dct:creator orcid:0000-0002-1267-0234 ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    npx:embeds sub:get-assertion-templates ;
+    nt:wasCreatedFromProvenanceTemplate <https://w3id.org/np/RA7lSq6MuK_TIC6JMSHvLtee3lpLoZDOqLJCLXevnrPoU> ;
+    nt:wasCreatedFromPubinfoTemplate <https://w3id.org/np/RA0J4vUn_dekg-U1kK3AOEt02p9mT2WO03uGxLDec1jLw>,
+      <https://w3id.org/np/RAukAcWHRDlkqxk7H2XNSegc1WnHI569INvNr-xdptDGI> ;
+    nt:wasCreatedFromTemplate <https://w3id.org/np/RAEFAt-QcFK0ZhqfvlsmS10BnzGJA0xwOICZXkO-ai87k> .
+}

--- a/docs/queries/get-provenance-templates.trig
+++ b/docs/queries/get-provenance-templates.trig
@@ -1,0 +1,66 @@
+@prefix this: <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
+@prefix sub: <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
+@prefix np: <http://www.nanopub.org/nschema#> .
+@prefix grlc: <https://w3id.org/kpxl/grlc/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix nt: <https://w3id.org/np/o/ntemplate/> .
+@prefix npx: <http://purl.org/nanopub/x/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix orcid: <https://orcid.org/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+sub:Head {
+  this: a np:Nanopublication ;
+    np:hasAssertion sub:assertion ;
+    np:hasProvenance sub:provenance ;
+    np:hasPublicationInfo sub:pubinfo .
+}
+
+sub:assertion {
+  sub:get-provenance-templates a grlc:grlc-query ;
+    dct:description "Returns the basic info of all provenance templates. Supports both template identity shapes (docs/template-identity-and-governance.md in the nanodash repo): the label is read off the node typed nt:ProvenanceTemplate in the assertion -- the assertion graph URI for legacy templates, the embedded template node for templates with embedded identity -- falling back to the assertion graph URI if no typed node is found. Derived from (not superseding) the previous version, which is signed by a different key; consumers pin query IDs explicitly, so both versions stay usable." ;
+    dct:license <http://www.apache.org/licenses/LICENSE-2.0> ;
+    rdfs:label "Get provenance templates" ;
+    grlc:endpoint <https://w3id.org/np/l/nanopub-query-1.1/repo/type/e11939f8e3bc45a126b31e86bc07e58f9a4b50f93a5c1f3a6eb66068eb7f445f> ;
+    grlc:sparql """prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix dct: <http://purl.org/dc/terms/>
+prefix np: <http://www.nanopub.org/nschema#>
+prefix npa: <http://purl.org/nanopub/admin/>
+prefix npx: <http://purl.org/nanopub/x/>
+prefix nt: <https://w3id.org/np/o/ntemplate/>
+
+select ?np ?pubkey ?pubkeyhash ?date ?label ?creator where {
+  graph npa:graph {
+    ?np npa:hasValidSignatureForPublicKey ?pubkey .
+    filter not exists { ?npx npx:invalidates ?np ; npa:hasValidSignatureForPublicKey ?pubkey . }
+    ?np npa:hasValidSignatureForPublicKeyHash ?pubkeyhash .
+    ?np npx:hasNanopubType nt:ProvenanceTemplate .
+    ?np dct:created ?date .
+    ?np np:hasAssertion ?a .
+    optional { ?np npx:signedBy ?creator . }
+  }
+  optional { graph ?a { ?tnode a nt:ProvenanceTemplate } }
+  bind(coalesce(?tnode, ?a) as ?t)
+  graph ?a { ?t rdfs:label ?label . }
+} order by desc(?date)""" .
+}
+
+sub:provenance {
+  sub:assertion prov:wasDerivedFrom <https://w3id.org/np/RA4bt3MQRnEPC2nSsdbCJc74wT-e1w68dSCpYVyvG0274> ;
+    prov:wasAttributedTo orcid:0000-0002-1267-0234 .
+}
+
+sub:pubinfo {
+  orcid:0000-0002-1267-0234 foaf:name "Tobias Kuhn" .
+
+  this: dct:created "2026-07-08T13:46:21Z"^^xsd:dateTime ;
+    dct:creator orcid:0000-0002-1267-0234 ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    npx:embeds sub:get-provenance-templates ;
+    nt:wasCreatedFromProvenanceTemplate <https://w3id.org/np/RA7lSq6MuK_TIC6JMSHvLtee3lpLoZDOqLJCLXevnrPoU> ;
+    nt:wasCreatedFromPubinfoTemplate <https://w3id.org/np/RA0J4vUn_dekg-U1kK3AOEt02p9mT2WO03uGxLDec1jLw>,
+      <https://w3id.org/np/RAukAcWHRDlkqxk7H2XNSegc1WnHI569INvNr-xdptDGI> ;
+    nt:wasCreatedFromTemplate <https://w3id.org/np/RAEFAt-QcFK0ZhqfvlsmS10BnzGJA0xwOICZXkO-ai87k> .
+}

--- a/docs/queries/get-pubinfo-templates.trig
+++ b/docs/queries/get-pubinfo-templates.trig
@@ -1,0 +1,66 @@
+@prefix this: <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
+@prefix sub: <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
+@prefix np: <http://www.nanopub.org/nschema#> .
+@prefix grlc: <https://w3id.org/kpxl/grlc/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix nt: <https://w3id.org/np/o/ntemplate/> .
+@prefix npx: <http://purl.org/nanopub/x/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix orcid: <https://orcid.org/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+sub:Head {
+  this: a np:Nanopublication ;
+    np:hasAssertion sub:assertion ;
+    np:hasProvenance sub:provenance ;
+    np:hasPublicationInfo sub:pubinfo .
+}
+
+sub:assertion {
+  sub:get-pubinfo-templates a grlc:grlc-query ;
+    dct:description "Returns the basic info of all pubinfo templates. Supports both template identity shapes (docs/template-identity-and-governance.md in the nanodash repo): the label is read off the node typed nt:PubinfoTemplate in the assertion -- the assertion graph URI for legacy templates, the embedded template node for templates with embedded identity -- falling back to the assertion graph URI if no typed node is found. Derived from (not superseding) the previous version, which is signed by a different key; consumers pin query IDs explicitly, so both versions stay usable." ;
+    dct:license <http://www.apache.org/licenses/LICENSE-2.0> ;
+    rdfs:label "Get pubinfo templates" ;
+    grlc:endpoint <https://w3id.org/np/l/nanopub-query-1.1/repo/type/45a89137e16d91eb7c7229b4e9033f49512604f94b65c7a9e3a093759293095b> ;
+    grlc:sparql """prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix dct: <http://purl.org/dc/terms/>
+prefix np: <http://www.nanopub.org/nschema#>
+prefix npa: <http://purl.org/nanopub/admin/>
+prefix npx: <http://purl.org/nanopub/x/>
+prefix nt: <https://w3id.org/np/o/ntemplate/>
+
+select ?np ?pubkey ?pubkeyhash ?date ?label ?creator where {
+  graph npa:graph {
+    ?np npa:hasValidSignatureForPublicKey ?pubkey .
+    filter not exists { ?npx npx:invalidates ?np ; npa:hasValidSignatureForPublicKey ?pubkey . }
+    ?np npa:hasValidSignatureForPublicKeyHash ?pubkeyhash .
+    ?np npx:hasNanopubType nt:PubinfoTemplate .
+    ?np dct:created ?date .
+    ?np np:hasAssertion ?a .
+    optional { ?np npx:signedBy ?creator . }
+  }
+  optional { graph ?a { ?tnode a nt:PubinfoTemplate } }
+  bind(coalesce(?tnode, ?a) as ?t)
+  graph ?a { ?t rdfs:label ?label . }
+} order by desc(?date)""" .
+}
+
+sub:provenance {
+  sub:assertion prov:wasDerivedFrom <https://w3id.org/np/RAMcdiJpvvk8424AJIH1jsDUQVcPYOLRw0DNnZt_ND_LQ> ;
+    prov:wasAttributedTo orcid:0000-0002-1267-0234 .
+}
+
+sub:pubinfo {
+  orcid:0000-0002-1267-0234 foaf:name "Tobias Kuhn" .
+
+  this: dct:created "2026-07-08T13:46:21Z"^^xsd:dateTime ;
+    dct:creator orcid:0000-0002-1267-0234 ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    npx:embeds sub:get-pubinfo-templates ;
+    nt:wasCreatedFromProvenanceTemplate <https://w3id.org/np/RA7lSq6MuK_TIC6JMSHvLtee3lpLoZDOqLJCLXevnrPoU> ;
+    nt:wasCreatedFromPubinfoTemplate <https://w3id.org/np/RA0J4vUn_dekg-U1kK3AOEt02p9mT2WO03uGxLDec1jLw>,
+      <https://w3id.org/np/RAukAcWHRDlkqxk7H2XNSegc1WnHI569INvNr-xdptDGI> ;
+    nt:wasCreatedFromTemplate <https://w3id.org/np/RAEFAt-QcFK0ZhqfvlsmS10BnzGJA0xwOICZXkO-ai87k> .
+}

--- a/docs/template-identity-and-governance.md
+++ b/docs/template-identity-and-governance.md
@@ -5,9 +5,13 @@ governed resolution (steps 3–4) live: the generalized `get-latest-governed-ver
 (`RAPSWgzHef9bIJyCoLodFH-BWtlESf1jIstEb0kn4B5Cw`, serving views and templates), the
 `gen:governedBy` resolution branch in `TemplateData`, and a first governed test pair
 (template `RAiK3l4D…`, kind registered maintained-by knowledgepixels via `RAnUJSnd…`).
-Server-side type inference confirmed to list new-style templates. Remaining: listing-query
-updates (e.g. `get-assertion-templates` reads the label off the assertion URI, so new-style
-templates list with an empty label), migration of real templates, listing dedup (step 5).
+Server-side type inference confirmed to list new-style templates. The three template
+listing queries are node-anchored (label/tag/unlisted read off the typed template node,
+covering both identity shapes): `get-assertion-templates` `RA3hOquZ…`,
+`get-provenance-templates` `RAVLRWRl…`, `get-pubinfo-templates` `RAVRcsr1…` — derived
+from (not superseding) the originals, which are update-locked to the Nanodash-profile
+key; sources under docs/queries/. Remaining: migration of real templates (only after
+production runs the new parser), listing dedup for governed version pairs (step 5).
 
 ## Goal
 

--- a/src/main/java/com/knowledgepixels/nanodash/QueryApiAccess.java
+++ b/src/main/java/com/knowledgepixels/nanodash/QueryApiAccess.java
@@ -53,9 +53,12 @@ public class QueryApiAccess {
     public static final String GET_OWNERS = "RApiw7Z0NeP3RaLiqX6Q7Ml5CfEWbt-PysUbMNljuiLJw/get-owners";
     public static final String GET_MEMBERS = "RASyFJyADTtG-l_Qe3a5PE_e2yUJR-PydXfkZjjrBuV7U/get-members";
     public static final String GET_PARTS = "RAJmZoM0xCGE8OL6EgmQBOd1M58ggNkwZ0IUqHOAPRfvE/get-parts";
-    public static final String GET_ASSERTION_TEMPLATES = "RA6bgrU3Ezfg5VAiLru0BFYHaSj6vZU6jJTscxNl8Wqvc/get-assertion-templates";
-    public static final String GET_PROVENANCE_TEMPLATES = "RA4bt3MQRnEPC2nSsdbCJc74wT-e1w68dSCpYVyvG0274/get-provenance-templates";
-    public static final String GET_PUBINFO_TEMPLATES = "RAMcdiJpvvk8424AJIH1jsDUQVcPYOLRw0DNnZt_ND_LQ/get-pubinfo-templates";
+    // Node-anchored variants (label/tag/unlisted read off the typed template node, so
+    // templates with embedded identity list correctly); derived from, not superseding,
+    // the RA6bgrU3/RA4bt3MQ/RAMcdiJp originals, which are update-locked to another key.
+    public static final String GET_ASSERTION_TEMPLATES = "RA3hOquZde_Ngs10XbeA9eVpjgK7VtfoCb6wmloZCQk60/get-assertion-templates";
+    public static final String GET_PROVENANCE_TEMPLATES = "RAVLRWRl5qbZ_6-U6z7ANA2Iv1UEVDVH0FXtVzlvk2G-k/get-provenance-templates";
+    public static final String GET_PUBINFO_TEMPLATES = "RAVRcsr1tYPlGcRTn0ji9KJdEHCTKEYeXCYiEpF5Ivjck/get-pubinfo-templates";
     public static final String GET_FILTERED_NANOPUB_LIST = "RAeoXI4vBzLV_BM2lfI5DWkFSfm6y1z3fOk4E1IncXWUo/get-filtered-nanopub-list";
     public static final String GET_LATEST_ACCEPTED_BDJ = "RAkoDiXZG_CYt978-dZ_vffK-UTbN6e1bmtFy6qdmFzC4/get-latest-accepted-bdj";
     public static final String GET_LATEST_BIODIV_CANDIDATES = "RAgnLJH8kcI_e488VdoyQ0g3-wcumj4mSiusxPmeAYsSI/get-latest-biodiv-candidates";


### PR DESCRIPTION
Closes the listing gap from #546 (part of #544): templates with embedded identity previously listed with an **empty label** in `get-assertion-templates` — and would have been **dropped entirely** from the provenance/pubinfo template pickers, whose queries required the label on the assertion graph URI.

## The fix (published live, backwards-compatible in both directions)

Three new listing-query versions anchor label/tag/unlisted on the node **typed** `nt:AssertionTemplate`/`ProvenanceTemplate`/`PubinfoTemplate` in the assertion — the assertion graph URI for legacy templates, the embedded node for new-style — with a fallback to the assertion URI so no row is lost:

- [`RA3hOquZ…/get-assertion-templates`](https://w3id.org/np/RA3hOquZde_Ngs10XbeA9eVpjgK7VtfoCb6wmloZCQk60)
- [`RAVLRWRl…/get-provenance-templates`](https://w3id.org/np/RAVLRWRl5qbZ_6-U6z7ANA2Iv1UEVDVH0FXtVzlvk2G-k)
- [`RAVRcsr1…/get-pubinfo-templates`](https://w3id.org/np/RAVRcsr1tYPlGcRTn0ji9KJdEHCTKEYeXCYiEpF5Ivjck)

They are **derived from, not superseding**, the originals (`RA6bgrU3…`/`RA4bt3MQ…`/`RAMcdiJp…`), which are signed by the Nanodash-profile key and thus update-locked to it — the same situation (and same derive workaround) as the view-creation template. Old deployments keep calling the old query ids untouched; this PR repoints the three `QueryApiAccess` constants and adds the query sources under `docs/queries/`.

## Verification

- **No-regression diff against the live originals**: `get-assertion-templates` output differs in exactly the two published test-template rows (their labels now filled: "🧪 Test template with embedded identity (v1)"/"(v2)"); all 529 legacy rows byte-identical including tags/unlisted flags. Provenance and pubinfo outputs are byte-identical (26 and 36 rows).
- `TemplateData` loads all three lists through the new query ids; `TemplateTest` + `TemplateIdentityTest` green.

Remaining from the design doc after this: listing **dedup** for governed version pairs (both versions of a governed kind list until then — visible now for the two test-template versions), and real-template migration once production runs the new parser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
