### PR TITLE
feat: dedup governed version pairs in template listing queries

### DIFF
--- a/docs/queries/get-assertion-templates.trig
+++ b/docs/queries/get-assertion-templates.trig
@@ -20,7 +20,7 @@ sub:Head {
 
 sub:assertion {
   sub:get-assertion-templates a grlc:grlc-query ;
-    dct:description "Returns the basic info of all assertion templates. Supports both template identity shapes (docs/template-identity-and-governance.md in the nanodash repo): the label, tag, and unlisted flag are read off the node typed nt:AssertionTemplate in the assertion -- the assertion graph URI for legacy templates, the embedded template node for templates with embedded identity -- falling back to the assertion graph URI if no typed node is found. Derived from (not superseding) the previous version, which is signed by a different key; consumers pin query IDs explicitly, so both versions stay usable." ;
+    dct:description "Returns the basic info of all assertion templates. Supports both template identity shapes (docs/template-identity-and-governance.md in the nanodash repo): the label, tag, and unlisted flag are read off the node typed nt:AssertionTemplate in the assertion -- the assertion graph URI for legacy templates, the embedded template node for templates with embedded identity -- falling back to the assertion graph URI if no typed node is found. Derived from (not superseding) the previous version, which is signed by a different key; consumers pin query IDs explicitly, so both versions stay usable. Governed version pairs are deduplicated: a version declaring dct:isVersionOf plus gen:governedBy is listed only if it is the current governed winner of its (kind, space) pair -- the newest non-invalidated version signed by a current member+ of the governing space, with the kind validated as maintained by that space (computed in a run-once sub-select against the spaces repo, mirroring the get-latest-governed-version resolver). A governed version whose pair does not validate is kept (inert gen:governedBy, matching the resolver's pin-is-the-floor semantics); non-governed versions are unaffected." ;
     dct:license <http://www.apache.org/licenses/LICENSE-2.0> ;
     rdfs:label "Get assertion templates" ;
     grlc:endpoint <https://w3id.org/np/l/nanopub-query-1.1/repo/type/79342356d3a68063a627e83ac34b376479e438abb8a4c4b27d49f845f537dc8d> ;
@@ -30,6 +30,7 @@ prefix np: <http://www.nanopub.org/nschema#>
 prefix npa: <http://purl.org/nanopub/admin/>
 prefix npx: <http://purl.org/nanopub/x/>
 prefix nt: <https://w3id.org/np/o/ntemplate/>
+prefix gen: <https://w3id.org/kpxl/gen/terms/>
 
 select ?np ?pubkey ?pubkeyhash ?date ?label ?tag ?unlisted ?creator where {
   graph npa:graph {
@@ -46,6 +47,33 @@ select ?np ?pubkey ?pubkeyhash ?date ?label ?tag ?unlisted ?creator where {
   optional { graph ?a { ?t rdfs:label ?label } }
   optional { graph ?a { ?t nt:hasTag ?tag . } }
   bind(exists { graph ?a { ?t a nt:UnlistedTemplate } } as ?unlisted)
+
+  optional { graph ?a { ?t dct:isVersionOf ?kind ; gen:governedBy ?space . } }
+  optional {
+    {
+      select ?kind ?space (max(concat(str(?gDate), "|", str(?gNp))) as ?winner) where {
+        graph npa:graph {
+          ?gNp npa:hasValidSignatureForPublicKeyHash ?gPubkeyhash ;
+               dct:created ?gDate ;
+               npx:embeds ?gVersion ;
+               np:hasAssertion ?gA .
+          filter not exists { ?gInv npx:invalidates ?gNp ; npa:hasValidSignatureForPublicKeyHash ?gPubkeyhash . }
+        }
+        graph ?gA { ?gVersion dct:isVersionOf ?kind ; gen:governedBy ?space . }
+        service <https://w3id.org/np/l/nanopub-query-1.1/repo/spaces> {
+          graph npa:graph { npa:thisRepo npa:hasCurrentSpaceState ?stateG . }
+          graph ?stateG {
+            ?kind npa:isMaintainedBy ?space ; npa:hasGoverningSpaceRef ?gRef .
+            ?gRi a gen:RoleInstantiation ; npa:forSpace ?space ; npa:forSpaceRef ?gRef ;
+                 npa:hasRoleType ?gTier ; npa:forAgent ?gAgent .
+            filter(?gTier = gen:AdminRole || ?gTier = gen:MaintainerRole || ?gTier = gen:MemberRole)
+            ?gAcct a npa:AccountState ; npa:agent ?gAgent ; npa:pubkey ?gPubkeyhash .
+          }
+        }
+      } group by ?kind ?space
+    }
+  }
+  filter( !bound(?kind) || !bound(?winner) || concat(str(?date), "|", str(?np)) = ?winner )
 } order by desc(?date)""" .
 }
 
@@ -57,9 +85,10 @@ sub:provenance {
 sub:pubinfo {
   orcid:0000-0002-1267-0234 foaf:name "Tobias Kuhn" .
 
-  this: dct:created "2026-07-08T13:46:21Z"^^xsd:dateTime ;
+  this: dct:created "2026-07-09T06:11:40Z"^^xsd:dateTime ;
     dct:creator orcid:0000-0002-1267-0234 ;
     dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    npx:supersedes <https://w3id.org/np/RA3hOquZde_Ngs10XbeA9eVpjgK7VtfoCb6wmloZCQk60> ;
     npx:embeds sub:get-assertion-templates ;
     nt:wasCreatedFromProvenanceTemplate <https://w3id.org/np/RA7lSq6MuK_TIC6JMSHvLtee3lpLoZDOqLJCLXevnrPoU> ;
     nt:wasCreatedFromPubinfoTemplate <https://w3id.org/np/RA0J4vUn_dekg-U1kK3AOEt02p9mT2WO03uGxLDec1jLw>,

--- a/docs/queries/get-provenance-templates.trig
+++ b/docs/queries/get-provenance-templates.trig
@@ -20,7 +20,7 @@ sub:Head {
 
 sub:assertion {
   sub:get-provenance-templates a grlc:grlc-query ;
-    dct:description "Returns the basic info of all provenance templates. Supports both template identity shapes (docs/template-identity-and-governance.md in the nanodash repo): the label is read off the node typed nt:ProvenanceTemplate in the assertion -- the assertion graph URI for legacy templates, the embedded template node for templates with embedded identity -- falling back to the assertion graph URI if no typed node is found. Derived from (not superseding) the previous version, which is signed by a different key; consumers pin query IDs explicitly, so both versions stay usable." ;
+    dct:description "Returns the basic info of all provenance templates. Supports both template identity shapes (docs/template-identity-and-governance.md in the nanodash repo): the label is read off the node typed nt:ProvenanceTemplate in the assertion -- the assertion graph URI for legacy templates, the embedded template node for templates with embedded identity -- falling back to the assertion graph URI if no typed node is found. Derived from (not superseding) the previous version, which is signed by a different key; consumers pin query IDs explicitly, so both versions stay usable. Governed version pairs are deduplicated: a version declaring dct:isVersionOf plus gen:governedBy is listed only if it is the current governed winner of its (kind, space) pair -- the newest non-invalidated version signed by a current member+ of the governing space, with the kind validated as maintained by that space (computed in a run-once sub-select against the spaces repo, mirroring the get-latest-governed-version resolver). A governed version whose pair does not validate is kept (inert gen:governedBy, matching the resolver's pin-is-the-floor semantics); non-governed versions are unaffected." ;
     dct:license <http://www.apache.org/licenses/LICENSE-2.0> ;
     rdfs:label "Get provenance templates" ;
     grlc:endpoint <https://w3id.org/np/l/nanopub-query-1.1/repo/type/e11939f8e3bc45a126b31e86bc07e58f9a4b50f93a5c1f3a6eb66068eb7f445f> ;
@@ -30,6 +30,7 @@ prefix np: <http://www.nanopub.org/nschema#>
 prefix npa: <http://purl.org/nanopub/admin/>
 prefix npx: <http://purl.org/nanopub/x/>
 prefix nt: <https://w3id.org/np/o/ntemplate/>
+prefix gen: <https://w3id.org/kpxl/gen/terms/>
 
 select ?np ?pubkey ?pubkeyhash ?date ?label ?creator where {
   graph npa:graph {
@@ -44,6 +45,33 @@ select ?np ?pubkey ?pubkeyhash ?date ?label ?creator where {
   optional { graph ?a { ?tnode a nt:ProvenanceTemplate } }
   bind(coalesce(?tnode, ?a) as ?t)
   graph ?a { ?t rdfs:label ?label . }
+
+  optional { graph ?a { ?t dct:isVersionOf ?kind ; gen:governedBy ?space . } }
+  optional {
+    {
+      select ?kind ?space (max(concat(str(?gDate), "|", str(?gNp))) as ?winner) where {
+        graph npa:graph {
+          ?gNp npa:hasValidSignatureForPublicKeyHash ?gPubkeyhash ;
+               dct:created ?gDate ;
+               npx:embeds ?gVersion ;
+               np:hasAssertion ?gA .
+          filter not exists { ?gInv npx:invalidates ?gNp ; npa:hasValidSignatureForPublicKeyHash ?gPubkeyhash . }
+        }
+        graph ?gA { ?gVersion dct:isVersionOf ?kind ; gen:governedBy ?space . }
+        service <https://w3id.org/np/l/nanopub-query-1.1/repo/spaces> {
+          graph npa:graph { npa:thisRepo npa:hasCurrentSpaceState ?stateG . }
+          graph ?stateG {
+            ?kind npa:isMaintainedBy ?space ; npa:hasGoverningSpaceRef ?gRef .
+            ?gRi a gen:RoleInstantiation ; npa:forSpace ?space ; npa:forSpaceRef ?gRef ;
+                 npa:hasRoleType ?gTier ; npa:forAgent ?gAgent .
+            filter(?gTier = gen:AdminRole || ?gTier = gen:MaintainerRole || ?gTier = gen:MemberRole)
+            ?gAcct a npa:AccountState ; npa:agent ?gAgent ; npa:pubkey ?gPubkeyhash .
+          }
+        }
+      } group by ?kind ?space
+    }
+  }
+  filter( !bound(?kind) || !bound(?winner) || concat(str(?date), "|", str(?np)) = ?winner )
 } order by desc(?date)""" .
 }
 
@@ -55,9 +83,10 @@ sub:provenance {
 sub:pubinfo {
   orcid:0000-0002-1267-0234 foaf:name "Tobias Kuhn" .
 
-  this: dct:created "2026-07-08T13:46:21Z"^^xsd:dateTime ;
+  this: dct:created "2026-07-09T06:11:40Z"^^xsd:dateTime ;
     dct:creator orcid:0000-0002-1267-0234 ;
     dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    npx:supersedes <https://w3id.org/np/RAVLRWRl5qbZ_6-U6z7ANA2Iv1UEVDVH0FXtVzlvk2G-k> ;
     npx:embeds sub:get-provenance-templates ;
     nt:wasCreatedFromProvenanceTemplate <https://w3id.org/np/RA7lSq6MuK_TIC6JMSHvLtee3lpLoZDOqLJCLXevnrPoU> ;
     nt:wasCreatedFromPubinfoTemplate <https://w3id.org/np/RA0J4vUn_dekg-U1kK3AOEt02p9mT2WO03uGxLDec1jLw>,

--- a/docs/queries/get-pubinfo-templates.trig
+++ b/docs/queries/get-pubinfo-templates.trig
@@ -20,7 +20,7 @@ sub:Head {
 
 sub:assertion {
   sub:get-pubinfo-templates a grlc:grlc-query ;
-    dct:description "Returns the basic info of all pubinfo templates. Supports both template identity shapes (docs/template-identity-and-governance.md in the nanodash repo): the label is read off the node typed nt:PubinfoTemplate in the assertion -- the assertion graph URI for legacy templates, the embedded template node for templates with embedded identity -- falling back to the assertion graph URI if no typed node is found. Derived from (not superseding) the previous version, which is signed by a different key; consumers pin query IDs explicitly, so both versions stay usable." ;
+    dct:description "Returns the basic info of all pubinfo templates. Supports both template identity shapes (docs/template-identity-and-governance.md in the nanodash repo): the label is read off the node typed nt:PubinfoTemplate in the assertion -- the assertion graph URI for legacy templates, the embedded template node for templates with embedded identity -- falling back to the assertion graph URI if no typed node is found. Derived from (not superseding) the previous version, which is signed by a different key; consumers pin query IDs explicitly, so both versions stay usable. Governed version pairs are deduplicated: a version declaring dct:isVersionOf plus gen:governedBy is listed only if it is the current governed winner of its (kind, space) pair -- the newest non-invalidated version signed by a current member+ of the governing space, with the kind validated as maintained by that space (computed in a run-once sub-select against the spaces repo, mirroring the get-latest-governed-version resolver). A governed version whose pair does not validate is kept (inert gen:governedBy, matching the resolver's pin-is-the-floor semantics); non-governed versions are unaffected." ;
     dct:license <http://www.apache.org/licenses/LICENSE-2.0> ;
     rdfs:label "Get pubinfo templates" ;
     grlc:endpoint <https://w3id.org/np/l/nanopub-query-1.1/repo/type/45a89137e16d91eb7c7229b4e9033f49512604f94b65c7a9e3a093759293095b> ;
@@ -30,6 +30,7 @@ prefix np: <http://www.nanopub.org/nschema#>
 prefix npa: <http://purl.org/nanopub/admin/>
 prefix npx: <http://purl.org/nanopub/x/>
 prefix nt: <https://w3id.org/np/o/ntemplate/>
+prefix gen: <https://w3id.org/kpxl/gen/terms/>
 
 select ?np ?pubkey ?pubkeyhash ?date ?label ?creator where {
   graph npa:graph {
@@ -44,6 +45,33 @@ select ?np ?pubkey ?pubkeyhash ?date ?label ?creator where {
   optional { graph ?a { ?tnode a nt:PubinfoTemplate } }
   bind(coalesce(?tnode, ?a) as ?t)
   graph ?a { ?t rdfs:label ?label . }
+
+  optional { graph ?a { ?t dct:isVersionOf ?kind ; gen:governedBy ?space . } }
+  optional {
+    {
+      select ?kind ?space (max(concat(str(?gDate), "|", str(?gNp))) as ?winner) where {
+        graph npa:graph {
+          ?gNp npa:hasValidSignatureForPublicKeyHash ?gPubkeyhash ;
+               dct:created ?gDate ;
+               npx:embeds ?gVersion ;
+               np:hasAssertion ?gA .
+          filter not exists { ?gInv npx:invalidates ?gNp ; npa:hasValidSignatureForPublicKeyHash ?gPubkeyhash . }
+        }
+        graph ?gA { ?gVersion dct:isVersionOf ?kind ; gen:governedBy ?space . }
+        service <https://w3id.org/np/l/nanopub-query-1.1/repo/spaces> {
+          graph npa:graph { npa:thisRepo npa:hasCurrentSpaceState ?stateG . }
+          graph ?stateG {
+            ?kind npa:isMaintainedBy ?space ; npa:hasGoverningSpaceRef ?gRef .
+            ?gRi a gen:RoleInstantiation ; npa:forSpace ?space ; npa:forSpaceRef ?gRef ;
+                 npa:hasRoleType ?gTier ; npa:forAgent ?gAgent .
+            filter(?gTier = gen:AdminRole || ?gTier = gen:MaintainerRole || ?gTier = gen:MemberRole)
+            ?gAcct a npa:AccountState ; npa:agent ?gAgent ; npa:pubkey ?gPubkeyhash .
+          }
+        }
+      } group by ?kind ?space
+    }
+  }
+  filter( !bound(?kind) || !bound(?winner) || concat(str(?date), "|", str(?np)) = ?winner )
 } order by desc(?date)""" .
 }
 
@@ -55,9 +83,10 @@ sub:provenance {
 sub:pubinfo {
   orcid:0000-0002-1267-0234 foaf:name "Tobias Kuhn" .
 
-  this: dct:created "2026-07-08T13:46:21Z"^^xsd:dateTime ;
+  this: dct:created "2026-07-09T06:11:40Z"^^xsd:dateTime ;
     dct:creator orcid:0000-0002-1267-0234 ;
     dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    npx:supersedes <https://w3id.org/np/RAVRcsr1tYPlGcRTn0ji9KJdEHCTKEYeXCYiEpF5Ivjck> ;
     npx:embeds sub:get-pubinfo-templates ;
     nt:wasCreatedFromProvenanceTemplate <https://w3id.org/np/RA7lSq6MuK_TIC6JMSHvLtee3lpLoZDOqLJCLXevnrPoU> ;
     nt:wasCreatedFromPubinfoTemplate <https://w3id.org/np/RA0J4vUn_dekg-U1kK3AOEt02p9mT2WO03uGxLDec1jLw>,

--- a/docs/template-identity-and-governance.md
+++ b/docs/template-identity-and-governance.md
@@ -10,8 +10,13 @@ listing queries are node-anchored (label/tag/unlisted read off the typed templat
 covering both identity shapes): `get-assertion-templates` `RA3hOquZ…`,
 `get-provenance-templates` `RAVLRWRl…`, `get-pubinfo-templates` `RAVRcsr1…` — derived
 from (not superseding) the originals, which are update-locked to the Nanodash-profile
-key; sources under docs/queries/. Remaining: migration of real templates (only after
-production runs the new parser), listing dedup for governed version pairs (step 5).
+key; sources under docs/queries/. The v3 heads (`RAoEo6jL…`/`RAl2C9PT…`/`RAGxzVO9…`)
+additionally dedup governed version pairs in-SPARQL (a governed version lists only if
+it is its (kind, space) pair's current winner) — the interim Option A; nanopub-query#138
+(re-opened) would replace these per-query arms with one materialized canonical-version
+edge. Remaining: migration of real templates (only after production runs the new
+parser); dedup arms for further listing surfaces as governance adoption grows (template
+views, view listings) — or #138.
 
 ## Goal
 

--- a/src/main/java/com/knowledgepixels/nanodash/QueryApiAccess.java
+++ b/src/main/java/com/knowledgepixels/nanodash/QueryApiAccess.java
@@ -56,9 +56,13 @@ public class QueryApiAccess {
     // Node-anchored variants (label/tag/unlisted read off the typed template node, so
     // templates with embedded identity list correctly); derived from, not superseding,
     // the RA6bgrU3/RA4bt3MQ/RAMcdiJp originals, which are update-locked to another key.
-    public static final String GET_ASSERTION_TEMPLATES = "RA3hOquZde_Ngs10XbeA9eVpjgK7VtfoCb6wmloZCQk60/get-assertion-templates";
-    public static final String GET_PROVENANCE_TEMPLATES = "RAVLRWRl5qbZ_6-U6z7ANA2Iv1UEVDVH0FXtVzlvk2G-k/get-provenance-templates";
-    public static final String GET_PUBINFO_TEMPLATES = "RAVRcsr1tYPlGcRTn0ji9KJdEHCTKEYeXCYiEpF5Ivjck/get-pubinfo-templates";
+    // v3 dedups governed version pairs: a version declaring dct:isVersionOf +
+    // gen:governedBy is listed only if it is its (kind, space) pair's current governed
+    // winner (in-SPARQL Option A of the listing-dedup problem; the nanopub-query#138
+    // canonical-version edge would replace these arms).
+    public static final String GET_ASSERTION_TEMPLATES = "RAoEo6jLZlH6sJeI6Lw3CIBfirDOscT8dI8Mab58BS8Sc/get-assertion-templates";
+    public static final String GET_PROVENANCE_TEMPLATES = "RAl2C9PT3mFS7qADWmzZcxPkWlVjjaGkNE-TAll3yPUk4/get-provenance-templates";
+    public static final String GET_PUBINFO_TEMPLATES = "RAGxzVO9RO7wIoI5rPy3T33CcpbJ44pgdVgpbOPXmDmwY/get-pubinfo-templates";
     public static final String GET_FILTERED_NANOPUB_LIST = "RAeoXI4vBzLV_BM2lfI5DWkFSfm6y1z3fOk4E1IncXWUo/get-filtered-nanopub-list";
     public static final String GET_LATEST_ACCEPTED_BDJ = "RAkoDiXZG_CYt978-dZ_vffK-UTbN6e1bmtFy6qdmFzC4/get-latest-accepted-bdj";
     public static final String GET_LATEST_BIODIV_CANDIDATES = "RAgnLJH8kcI_e488VdoyQ0g3-wcumj4mSiusxPmeAYsSI/get-latest-biodiv-candidates";


### PR DESCRIPTION
Implements the interim **Option A** for the governed-pair listing dedup problem (#544; discussed after #547): a governed version has no valid `npx:supersedes` link to its predecessor — cross-key supersedes is invalid, and the space-based float deliberately doesn't need one — so the `npx:invalidates`-based filter in the listing queries never retires old governed versions, and every version of a governed template listed side by side (visible with the two 🧪 test-template rows).

## The fix (published live, supersedes our own v2s — clean chains this time)

- [`RAoEo6jL…/get-assertion-templates`](https://w3id.org/np/RAoEo6jLZlH6sJeI6Lw3CIBfirDOscT8dI8Mab58BS8Sc)
- [`RAl2C9PT…/get-provenance-templates`](https://w3id.org/np/RAl2C9PT3mFS7qADWmzZcxPkWlVjjaGkNE-TAll3yPUk4)
- [`RAGxzVO9…/get-pubinfo-templates`](https://w3id.org/np/RAGxzVO9RO7wIoI5rPy3T33CcpbJ44pgdVgpbOPXmDmwY)

Each adds a dedup arm: a **run-once sub-select** computes the current governed winner per `(kind, space)` pair — the newest non-invalidated version signed by a current member+ of the governing space, with the kind validated as maintained by it (one bound SERVICE join into the spaces repo, mirroring the `get-latest-governed-version` resolver) — and a filter keeps a governed row only if it is that winner. **Fails open** for inert `gen:governedBy` (unregistered kind, no valid member version), matching the resolver's pin-is-the-floor semantics. Non-governed rows are untouched.

This PR repoints the three `QueryApiAccess` constants and updates the `docs/queries/` sources + design-doc status.

## Verification

- **Diff against the live v2s**: assertion listing loses exactly one row — the governed loser (test template v1 `RAiK3l4D…`); the winner keeps its labeled row; all legacy rows byte-identical. Provenance/pubinfo outputs byte-identical (no governed pairs of those types yet).
- **Timing** (2 runs each, end-to-end): 0.39s / 0.11–0.12s / 0.13–0.16s — within noise of the v2 baselines; the sub-select only enumerates governed versions (currently a handful). Verified answering from two query instances (the SERVICE arm uses the generic repo prefix).
- `TemplateData` loads all three lists via the new ids; template tests green.

## Known limits (why this is "interim")

- The winner sub-select re-enumerates all governed versions per listing call — cost grows with governance adoption.
- The `max(concat(date,"|",np))` tie-break can misorder same-second versions with differently-formatted timestamps (the resolver sorts typed values and is unaffected).
- Further listing surfaces (template views, view listings) would each need the same hand-pasted arm.

All three limits disappear with the re-opened [nanopub-query#138](https://github.com/knowledgepixels/nanopub-query/issues/138) canonical-version edge, which would reduce dedup to one indexed lookup per query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
