### PR TITLE
fix: prevent ApiCache metadata wipe on entry replacement causing home page hang

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/ApiCache.java
+++ b/src/main/java/com/knowledgepixels/nanodash/ApiCache.java
@@ -2,6 +2,8 @@ package com.knowledgepixels.nanodash;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.RemovalCause;
+import com.google.common.cache.RemovalNotification;
 import org.apache.wicket.MetaDataKey;
 import org.apache.wicket.request.cycle.RequestCycle;
 import org.eclipse.rdf4j.model.Model;
@@ -50,23 +52,33 @@ public class ApiCache {
     private static final Cache<String, ApiResponse> cachedResponses = CacheBuilder.newBuilder()
         .maximumSize(MAX_CACHE_ENTRIES)
         .expireAfterAccess(24, TimeUnit.HOURS)
-        .removalListener(n -> cleanupMetadata(n.getKey().toString()))
+        .removalListener(ApiCache::cleanupMetadataOnRemoval)
         .build();
     private static final Cache<String, Model> cachedRdfModels = CacheBuilder.newBuilder()
         .maximumSize(MAX_CACHE_ENTRIES)
         .expireAfterAccess(24, TimeUnit.HOURS)
-        .removalListener(n -> cleanupMetadata(n.getKey().toString()))
+        .removalListener(ApiCache::cleanupMetadataOnRemoval)
         .build();
     private transient static ConcurrentMap<String, Integer> failed = new ConcurrentHashMap<>();
     private static final Cache<String, Map<String, String>> cachedMaps = CacheBuilder.newBuilder()
         .maximumSize(MAX_CACHE_ENTRIES)
         .expireAfterAccess(24, TimeUnit.HOURS)
-        .removalListener(n -> cleanupMetadata(n.getKey().toString()))
+        .removalListener(ApiCache::cleanupMetadataOnRemoval)
         .build();
     private transient static ConcurrentMap<String, Long> lastRefresh = new ConcurrentHashMap<>();
     private transient static ConcurrentMap<String, Long> refreshStart = new ConcurrentHashMap<>();
     private transient static ConcurrentMap<String, Long> runAfter = new ConcurrentHashMap<>();
     private static final Logger logger = LoggerFactory.getLogger(ApiCache.class);
+
+    // Guava fires removal notifications also when an entry is REPLACED (every routine
+    // refresh's put), and processes them lazily during later cache operations. Cleaning
+    // up on a replacement would wipe the metadata of a still-cached entry — in
+    // particular a missing lastRefresh timestamp used to make retrieveResponseSync
+    // throw an NPE on every call until the entry expired.
+    private static void cleanupMetadataOnRemoval(RemovalNotification<String, ?> n) {
+        if (n.getCause() == RemovalCause.REPLACED) return;
+        cleanupMetadata(n.getKey());
+    }
 
     private static void cleanupMetadata(String cacheId) {
         lastRefresh.remove(cacheId);
@@ -151,13 +163,16 @@ public class ApiCache {
     public static ApiResponse retrieveResponseSync(QueryRef queryRef, boolean forced) {
         long timeNow = System.currentTimeMillis();
         String cacheId = queryRef.getAsUrlString();
-        logger.info("Retrieving cached API response synchronously for {}", cacheId);
+        logger.debug("Retrieving cached API response synchronously for {}", cacheId);
         boolean needsRefresh = true;
         if (cachedResponses.getIfPresent(cacheId) != null) {
-            long cacheAge = timeNow - lastRefresh.get(cacheId);
-            needsRefresh = cacheAge > REFRESH_AGE_THRESHOLD_MS;
+            // lastRefresh can be missing for a cached entry (racing invalidation or
+            // refresh); treat that as stale rather than NPEing on the unboxing.
+            Long lastRefreshTime = lastRefresh.get(cacheId);
+            needsRefresh = lastRefreshTime == null || timeNow - lastRefreshTime > REFRESH_AGE_THRESHOLD_MS;
         }
-        if (failed.get(cacheId) != null && failed.get(cacheId) > 2) {
+        Integer failedCount = failed.get(cacheId);
+        if (failedCount != null && failedCount > 2) {
             failed.remove(cacheId);
             throw new RuntimeException("Query failed: " + cacheId);
         }
@@ -165,8 +180,9 @@ public class ApiCache {
             logger.info("Refreshing cache for {}", cacheId);
             refreshStart.put(cacheId, timeNow);
             try {
-                if (runAfter.containsKey(cacheId)) {
-                    while (System.currentTimeMillis() < runAfter.get(cacheId)) {
+                Long after = runAfter.get(cacheId);
+                if (after != null) {
+                    while (System.currentTimeMillis() < after) {
                         Thread.sleep(100);
                     }
                     runAfter.remove(cacheId);
@@ -222,7 +238,7 @@ public class ApiCache {
     public static ApiResponse retrieveResponseAsync(QueryRef queryRef) {
         long timeNow = System.currentTimeMillis();
         String cacheId = queryRef.getAsUrlString();
-        logger.info("Retrieving cached API response asynchronously for {}", cacheId);
+        logger.debug("Retrieving cached API response asynchronously for {}", cacheId);
         if (isForcedReload(cacheId)) {
             cachedResponses.invalidate(cacheId);
             lastRefresh.remove(cacheId);
@@ -230,11 +246,12 @@ public class ApiCache {
         boolean isCached = false;
         boolean needsRefresh = true;
         if (cachedResponses.getIfPresent(cacheId) != null) {
-            long cacheAge = timeNow - lastRefresh.get(cacheId);
-            isCached = cacheAge < MAX_CACHE_AGE_MS;
-            needsRefresh = cacheAge > REFRESH_AGE_THRESHOLD_MS;
+            Long lastRefreshTime = lastRefresh.get(cacheId);
+            isCached = lastRefreshTime != null && timeNow - lastRefreshTime < MAX_CACHE_AGE_MS;
+            needsRefresh = lastRefreshTime == null || timeNow - lastRefreshTime > REFRESH_AGE_THRESHOLD_MS;
         }
-        if (failed.get(cacheId) != null && failed.get(cacheId) > 2) {
+        Integer failedCount = failed.get(cacheId);
+        if (failedCount != null && failedCount > 2) {
             failed.remove(cacheId);
             throw new RuntimeException("Query failed: " + cacheId);
         }
@@ -242,8 +259,9 @@ public class ApiCache {
             NanodashThreadPool.submit(() -> {
                 refreshStart.put(cacheId, System.currentTimeMillis());
                 try {
-                    if (runAfter.containsKey(cacheId)) {
-                        while (System.currentTimeMillis() < runAfter.get(cacheId)) {
+                    Long after = runAfter.get(cacheId);
+                    if (after != null) {
+                        while (System.currentTimeMillis() < after) {
                             Thread.sleep(100);
                         }
                         runAfter.remove(cacheId);
@@ -312,16 +330,17 @@ public class ApiCache {
         boolean isCached = false;
         boolean needsRefresh = true;
         if (cachedMaps.getIfPresent(cacheId) != null) {
-            long cacheAge = timeNow - lastRefresh.get(cacheId);
-            isCached = cacheAge < MAX_CACHE_AGE_MS;
-            needsRefresh = cacheAge > REFRESH_AGE_THRESHOLD_MS;
+            Long lastRefreshTime = lastRefresh.get(cacheId);
+            isCached = lastRefreshTime != null && timeNow - lastRefreshTime < MAX_CACHE_AGE_MS;
+            needsRefresh = lastRefreshTime == null || timeNow - lastRefreshTime > REFRESH_AGE_THRESHOLD_MS;
         }
         if (needsRefresh && !isRunning(cacheId)) {
             NanodashThreadPool.submit(() -> {
                 refreshStart.put(cacheId, System.currentTimeMillis());
                 try {
-                    if (runAfter.containsKey(cacheId)) {
-                        while (System.currentTimeMillis() < runAfter.get(cacheId)) {
+                    Long after = runAfter.get(cacheId);
+                    if (after != null) {
+                        while (System.currentTimeMillis() < after) {
                             Thread.sleep(100);
                         }
                         runAfter.remove(cacheId);
@@ -379,7 +398,7 @@ public class ApiCache {
     public static Model retrieveRdfModelAsync(QueryRef queryRef) {
         long timeNow = System.currentTimeMillis();
         String cacheId = queryRef.getAsUrlString();
-        logger.info("Retrieving cached RDF model asynchronously for {}", cacheId);
+        logger.debug("Retrieving cached RDF model asynchronously for {}", cacheId);
         if (isForcedReload(cacheId)) {
             cachedRdfModels.invalidate(cacheId);
             lastRefresh.remove(cacheId);
@@ -387,11 +406,12 @@ public class ApiCache {
         boolean isCached = false;
         boolean needsRefresh = true;
         if (cachedRdfModels.getIfPresent(cacheId) != null) {
-            long cacheAge = timeNow - lastRefresh.get(cacheId);
-            isCached = cacheAge < MAX_CACHE_AGE_MS;
-            needsRefresh = cacheAge > REFRESH_AGE_THRESHOLD_MS;
+            Long lastRefreshTime = lastRefresh.get(cacheId);
+            isCached = lastRefreshTime != null && timeNow - lastRefreshTime < MAX_CACHE_AGE_MS;
+            needsRefresh = lastRefreshTime == null || timeNow - lastRefreshTime > REFRESH_AGE_THRESHOLD_MS;
         }
-        if (failed.get(cacheId) != null && failed.get(cacheId) > 2) {
+        Integer failedCount = failed.get(cacheId);
+        if (failedCount != null && failedCount > 2) {
             failed.remove(cacheId);
             throw new RuntimeException("Query failed: " + cacheId);
         }
@@ -399,8 +419,9 @@ public class ApiCache {
             NanodashThreadPool.submit(() -> {
                 refreshStart.put(cacheId, System.currentTimeMillis());
                 try {
-                    if (runAfter.containsKey(cacheId)) {
-                        while (System.currentTimeMillis() < runAfter.get(cacheId)) {
+                    Long after = runAfter.get(cacheId);
+                    if (after != null) {
+                        while (System.currentTimeMillis() < after) {
                             Thread.sleep(100);
                         }
                         runAfter.remove(cacheId);

--- a/src/main/java/com/knowledgepixels/nanodash/domain/AbstractResourceWithProfile.java
+++ b/src/main/java/com/knowledgepixels/nanodash/domain/AbstractResourceWithProfile.java
@@ -31,6 +31,10 @@ public abstract class AbstractResourceWithProfile implements Serializable, Resou
 
     private static final Map<Class<?>, Map<String, AbstractResourceWithProfile>> instances = new ConcurrentHashMap<>();
 
+    // Backoff after a failed data update, so a persistently failing resource
+    // doesn't respawn an update task on every page poll (~1/s per open page).
+    private static final long FAILED_UPDATE_BACKOFF_MS = 10 * 1000;
+
     private final String id;
     private Space space;
     private ResourceWithProfile data = new ResourceWithProfile();
@@ -121,17 +125,17 @@ public abstract class AbstractResourceWithProfile implements Serializable, Resou
     @Override
     public synchronized Future<?> triggerDataUpdate() {
         if (dataNeedsUpdate) {
+            // Not due yet (delayed forceRefresh or backoff after a failure): don't
+            // occupy a pool thread with sleeping; a later access re-triggers.
+            Long after = runUpdateAfter;
+            if (after != null && System.currentTimeMillis() < after) {
+                return null;
+            }
+            runUpdateAfter = null;
             logger.info("Data needs update for resource {}, starting update thread", id);
             dataNeedsUpdate = false;
             return NanodashThreadPool.submit(() -> {
                 try {
-                    if (runUpdateAfter != null) {
-                        while (System.currentTimeMillis() < runUpdateAfter) {
-                            Thread.sleep(100);
-                        }
-                        runUpdateAfter = null;
-                    }
-
                     ResourceWithProfile newData = new ResourceWithProfile();
 
                     // The query returns both standalone view displays (bound ?display) and
@@ -152,6 +156,7 @@ public abstract class AbstractResourceWithProfile implements Serializable, Resou
                     dataInitialized = true;
                 } catch (Exception ex) {
                     logger.error("Error while trying to update data for resource {}", id, ex);
+                    runUpdateAfter = System.currentTimeMillis() + FAILED_UPDATE_BACKOFF_MS;
                     dataNeedsUpdate = true;
                 }
             });

--- a/src/main/java/com/knowledgepixels/nanodash/page/HomePage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/HomePage.java
@@ -78,8 +78,7 @@ public class HomePage extends NanodashPage {
         setOutputMarkupId(true);
 
         final String homeResourceId = NanodashPreferences.get().getHomeResource();
-        final MaintainedResourceRepository resourceRepo = MaintainedResourceRepository.get();
-        final MaintainedResource homeResource = resourceRepo.findById(homeResourceId);
+        final MaintainedResource homeResource = MaintainedResourceRepository.get().findById(homeResourceId);
 
         // Rendered only for a genuine misconfiguration (see below): the resource
         // repository is warm but the configured id is not a known maintained resource.
@@ -88,7 +87,7 @@ public class HomePage extends NanodashPage {
                 "Set the <code>NANODASH_HOME_RESOURCE</code> environment variable to a valid maintained-resource IRI." +
                 "</p></div></div>";
 
-        if (homeResource == null && resourceRepo.isReady()) {
+        if (homeResource == null && MaintainedResourceRepository.get().isReady()) {
             // The repository has a full snapshot, yet the configured id isn't in it:
             // a real misconfiguration, not a cold-cache race.
             add(new Label("views", notFoundHtml).setEscapeModelStrings(false));
@@ -111,10 +110,13 @@ public class HomePage extends NanodashPage {
         // resolves, rather than declaring a hard "not found" on a transient null. If
         // the repository warms up without the configured id, the misconfig notice is
         // shown then.
+        // Resolve the repository singleton inside the anonymous classes rather than
+        // capturing it: MaintainedResourceRepository is not Serializable, and a
+        // captured reference makes the whole page fail to serialize to the page store.
         final IModel<MaintainedResource> homeResourceModel = new LoadableDetachableModel<MaintainedResource>() {
             @Override
             protected MaintainedResource load() {
-                return resourceRepo.findById(homeResourceId);
+                return MaintainedResourceRepository.get().findById(homeResourceId);
             }
         };
 
@@ -138,7 +140,7 @@ public class HomePage extends NanodashPage {
                 if (r != null) return r.isDataInitialized();
                 // Resource still unresolved: keep polling while the repository is cold,
                 // and stop (to show the misconfig notice) only once it is warm.
-                return resourceRepo.isReady();
+                return MaintainedResourceRepository.get().isReady();
             }
 
             @Override


### PR DESCRIPTION
## Problem

The live instance's home page was hanging, with the error log showing a repeating one-line `java.lang.NullPointerException` (no stack frames — JVM fast-throw, i.e. thrown thousands of times) from `AbstractResourceWithProfile`'s data-update task, plus a page-store serialization failure for `HomePage`.

Root cause: `ApiCache`'s Guava removal listener called `cleanupMetadata` on **every** removal notification, including `RemovalCause.REPLACED` — which fires (and is processed lazily, during later cache operations) each time a routine refresh `put()`s over an existing entry. When such a notification was processed after the refresh's `lastRefresh.put()`, the timestamp of a still-cached entry was deleted. From then on, `retrieveResponseSync` NPE'd on the `timeNow - lastRefresh.get(cacheId)` unboxing on **every call** — before reaching the refresh branch that would have restored the timestamp — permanently breaking that query until restart or 24h cache expiry.

When this hit the home resource's `get-view-displays` query, the failure amplified:

1. The update task NPE'd → `dataNeedsUpdate = true` with no backoff → `HomePage`'s `AjaxLazyLoadPanel` poll respawned a failing task every second (thread names showed ~18k background tasks spawned).
2. `NanodashThreadPool` (SynchronousQueue + CallerRunsPolicy) saturated → update work ran synchronously on HTTP request threads → hang.
3. Independently, `HomePage`'s anonymous `LoadableDetachableModel` captured the non-serializable `MaintainedResourceRepository` singleton, so the page failed to serialize to the page store, causing page-expired full re-renders on Ajax polls.

## Changes

**`ApiCache`**
- Skip metadata cleanup for `RemovalCause.REPLACED` notifications — only real removals (explicit invalidation, expiry, size eviction) clean up.
- Null-safe reads of `lastRefresh` (a missing timestamp now means "stale, refresh" instead of NPE), `runAfter`, and `failed` in all four retrieve methods, closing the remaining unboxing races.
- Demote the per-call "Retrieving cached…" logs from INFO to DEBUG (hundreds of lines per page render, e.g. via the per-link repository lookups in `NanodashLink`); one-per-refresh logs stay at INFO.

**`AbstractResourceWithProfile`**
- A failed data update now sets a 10s backoff before the next attempt.
- `triggerDataUpdate()` checks `runUpdateAfter` at spawn time and returns while the delay is pending, instead of parking a sleeping task in the pool. Note: `forceRefresh(waitMillis)` consequently no longer auto-runs via a sleeping thread when the delay elapses; the update runs on the first access after the delay (every render/poll of the resource is such an access).

**`HomePage`**
- The anonymous model/panel resolve `MaintainedResourceRepository.get()` inside their methods instead of capturing the local variable, so the page serializes again.

## Testing

- Full test suite passes: 756 tests, 0 failures.
- `ApiCacheTest` and `ResourceWithProfileTest` cover the touched paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)