### PR TITLE
fix: fail cleanly on templates with memberless grouped statements

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/component/PublishForm.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/PublishForm.java
@@ -184,8 +184,9 @@ public class PublishForm extends Panel {
 
         // TODO Properly integrate this namespace feature:
         String templateId = pageParams.get("template").toString();
-        if (td.getTemplate(templateId).getTargetNamespace() != null) {
-            targetNamespace = td.getTemplate(templateId).getTargetNamespace();
+        Template template = td.getTemplate(templateId);
+        if (template != null && template.getTargetNamespace() != null) {
+            targetNamespace = template.getTargetNamespace();
         }
         if (!pageParams.get("target-namespace").isNull()) {
             targetNamespace = pageParams.get("target-namespace").toString();

--- a/src/main/java/com/knowledgepixels/nanodash/page/PublishPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/PublishPage.java
@@ -5,6 +5,7 @@ import com.knowledgepixels.nanodash.component.DifferentKeyErrorItem;
 import com.knowledgepixels.nanodash.component.PublishForm;
 import com.knowledgepixels.nanodash.component.TemplateList;
 import com.knowledgepixels.nanodash.component.TitleBar;
+import com.knowledgepixels.nanodash.template.TemplateData;
 import org.apache.wicket.markup.head.IHeaderResponse;
 import org.apache.wicket.markup.head.JavaScriptHeaderItem;
 import org.apache.wicket.markup.html.basic.Label;
@@ -45,6 +46,8 @@ public class PublishPage extends NanodashPage {
             session.redirectToLoginIfNeeded(MOUNT_PATH, parameters);
             if (!parameters.get("sigkey").isNull() && !parameters.get("sigkey").toString().equals(session.getPubkeyString())) {
                 add(new DifferentKeyErrorItem("form", parameters));
+            } else if (TemplateData.get().getTemplate(parameters.get("template").toString()) == null) {
+                add(new Label("form", "<p class=\"negative\">Error: This template could not be loaded. It might be invalid or temporarily unavailable.</p>").setEscapeModelStrings(false));
             } else {
                 // No confirm page: after publishing, the form forwards to the context
                 // resource (or home), showing the new nanopub in the title bar message.

--- a/src/main/java/com/knowledgepixels/nanodash/template/Template.java
+++ b/src/main/java/com/knowledgepixels/nanodash/template/Template.java
@@ -791,7 +791,7 @@ public class Template implements Serializable {
         }
     }
 
-    private void processNpTemplate(Nanopub templateNp) {
+    private void processNpTemplate(Nanopub templateNp) throws MalformedTemplateException {
         for (Statement st : templateNp.getAssertion()) {
             final IRI subj = (IRI) st.getSubject();
             final IRI pred = st.getPredicate();
@@ -901,7 +901,11 @@ public class Template implements Serializable {
         // Grouped IRI are added via group, so direct link from template is redundant:
         for (IRI iri : typeMap.keySet()) {
             if (!typeMap.get(iri).contains(NTEMPLATE.GROUPED_STATEMENT)) continue;
-            for (IRI groupedIri : getStatementIris(iri)) {
+            List<IRI> memberIris = getStatementIris(iri);
+            if (memberIris == null) {
+                throw new MalformedTemplateException("Grouped statement has no member statements: " + iri);
+            }
+            for (IRI groupedIri : memberIris) {
                 statementMap.get(templateIri).remove(groupedIri);
             }
         }

--- a/src/main/java/com/knowledgepixels/nanodash/template/TemplateData.java
+++ b/src/main/java/com/knowledgepixels/nanodash/template/TemplateData.java
@@ -137,7 +137,7 @@ public class TemplateData implements Serializable {
                 templateMap.put(t.getId(), t);
                 return t;
             } catch (Exception ex) {
-                logger.error("Exception: {}", ex.getMessage());
+                logger.error("Could not load template: {}", npId, ex);
                 return null;
             }
         }


### PR DESCRIPTION
## Problem

Opening `/publish?template=…` with a template that types a statement as `nt:GroupedStatement` but declares no group→member `nt:hasStatement` links (e.g. https://w3id.org/np/RAaL0nZfLxsGAbLUvSFSA7pNu7H0e46rl9egKphYCEELk, created via the template-editor meta-template) crashed the whole page with an opaque Wicket 500:

1. The redundant-group-link cleanup in `Template.processNpTemplate` iterated `getStatementIris(groupIri)`, which is `null` for a memberless group → NPE inside the `Template` constructor.
2. `TemplateData.getTemplate` caught it, logged only the bare message (no template id, no stack trace), and returned `null`.
3. `PublishForm`'s target-namespace block dereferenced that `null` → 500.

## Fix

- **Template**: the cleanup loop now throws `MalformedTemplateException("Grouped statement has no member statements: …")` instead of NPE-ing. Tolerating the group silently isn't an option: `StatementItem` also assumes members exist, and rendering the statements ungrouped would drop the author's optional-group semantics.
- **TemplateData**: log the template id and full stack trace on load failure, so the next case is diagnosable from the log.
- **PublishPage**: when the template can't be loaded, show a red (`.negative`) error message instead of constructing a `PublishForm` that is doomed to fail.
- **PublishForm**: null-guard the template lookup in the target-namespace block.

The affected template itself needs to be republished with the group-membership links filled in; with this fix nanodash reports the problem instead of crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)