### PR TITLE
feat: support optional statements inside statement groups

### DIFF
--- a/docs/optional-statements-in-groups.md
+++ b/docs/optional-statements-in-groups.md
@@ -1,6 +1,7 @@
 # Optional statements inside statement groups
 
-**Status:** design draft — not implemented.
+**Status:** implemented (template parsing, publish path, form UI, fill/unification);
+end-to-end verification on a live instance with a published test template still pending.
 
 ## Goal
 

--- a/src/main/java/com/knowledgepixels/nanodash/component/StatementItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/StatementItem.java
@@ -117,7 +117,7 @@ public class StatementItem extends Panel {
             if (isGrouped() && !first) {
                 viewElements.add(new HorizontalLine("statement"));
             }
-            viewElements.addAll(r.getStatementParts());
+            viewElements.addAll(r.getShownStatementParts());
             boolean isOnly = repetitionGroups.size() == 1;
             boolean isLast = repetitionGroups.get(repetitionGroups.size() - 1) == r;
             r.addRepetitionButton.setVisible(!context.isReadOnly() && isRepeatable() && isLast);
@@ -338,6 +338,9 @@ public class StatementItem extends Panel {
         private List<StatementPartItem> statementParts;
         private List<ValueItem> localItems = new ArrayList<>();
         private boolean filled = false;
+        // Optional group members that were left unassigned by a successful fill();
+        // read-only rendering hides these rows:
+        private Set<IRI> unmatchedParts = new HashSet<>();
 
         private List<ValueItem> items = new ArrayList<>();
 
@@ -386,6 +389,8 @@ public class StatementItem extends Panel {
 //                    optionalMark.setVisible(false);
 //                }
 
+                boolean isMemberOptional = isGrouped() && getTemplate().isOptionalStatement(s);
+
                 if (!context.isReadOnly() && isOptional && isLastLine) {
                     optionalMark = new Label("label", "(optional)");
                 } else {
@@ -393,6 +398,14 @@ public class StatementItem extends Panel {
                     optionalMark.setVisible(false);
                 }
                 statement.add(optionalMark);
+                // Member-level mark, rendered inline on the member's own line; unlike the
+                // group-level mark it holds per repetition, so it is never toggled off:
+                Label partOptionalMark = new Label("part-label", "(optional)");
+                partOptionalMark.setVisible(!context.isReadOnly() && isMemberOptional);
+                statement.add(partOptionalMark);
+                if (!context.isReadOnly() && isMemberOptional) {
+                    statement.add(new AttributeAppender("class", " nanopub-optional-part"));
+                }
                 if (isLastLine) {
                     addRepetitionButton = new Label("add-repetition", "+");
                     statement.add(addRepetitionButton);
@@ -454,6 +467,25 @@ public class StatementItem extends Panel {
          */
         public List<StatementPartItem> getStatementParts() {
             return statementParts;
+        }
+
+        /**
+         * Returns the statement parts to render: in read-only contexts, optional group
+         * members that were left unassigned by fill() are hidden; in editable contexts
+         * (fresh publish, derive, update) all parts are shown, with skipped members
+         * rendering as empty fields.
+         *
+         * @return a list of StatementPartItem objects to render
+         */
+        private List<StatementPartItem> getShownStatementParts() {
+            if (!context.isReadOnly() || unmatchedParts.isEmpty()) return statementParts;
+            List<StatementPartItem> shown = new ArrayList<>();
+            for (int i = 0; i < statementParts.size(); i++) {
+                if (!unmatchedParts.contains(statementPartIds.get(i))) {
+                    shown.add(statementParts.get(i));
+                }
+            }
+            return shown;
         }
 
         /**
@@ -563,6 +595,19 @@ public class StatementItem extends Panel {
             return false;
         }
 
+        /**
+         * Checks if the given member statement is effectively optional in this repetition group:
+         * either the whole group is optional or the member itself carries the optional flag.
+         * Unlike group-level optionality, the member-level flag holds per repetition, so it is
+         * not affected by the number of repetition groups.
+         *
+         * @param partId the IRI of the member statement to check
+         * @return true if the member statement is effectively optional, false otherwise
+         */
+        public boolean isOptionalPart(IRI partId) {
+            return isOptional() || getTemplate().isOptionalStatement(partId);
+        }
+
         private Value transform(Value value) {
             if (!(value instanceof IRI)) {
                 return value;
@@ -592,6 +637,11 @@ public class StatementItem extends Panel {
                 IRI subj = context.processIri((IRI) transform(t.getSubject(s)));
                 IRI pred = context.processIri((IRI) transform(t.getPredicate(s)));
                 Value obj = context.processValue(transform(t.getObject(s)));
+                if (isGrouped() && t.isOptionalStatement(s) && (subj == null || pred == null || obj == null)) {
+                    // Optional group member without all elements resolved: drop just this
+                    // triple; the rest of the group is still emitted.
+                    continue;
+                }
                 if (context.getType() == ContextType.ASSERTION) {
                     npCreator.addAssertionStatement(subj, pred, obj);
                 } else if (context.getType() == ContextType.PROVENANCE) {
@@ -618,6 +668,9 @@ public class StatementItem extends Panel {
 
         private boolean hasEmptyElements() {
             for (IRI s : statementPartIds) {
+                // Optional group members may stay empty; they are dropped at triple-creation
+                // time and must not block or drop the rest of the group:
+                if (isGrouped() && getTemplate().isOptionalStatement(s)) continue;
                 if (context.processIri((IRI) transform(getTemplate().getSubject(s))) == null) return true;
                 if (context.processIri((IRI) transform(getTemplate().getPredicate(s))) == null) return true;
                 if (context.processValue(transform(getTemplate().getObject(s))) == null) return true;
@@ -659,10 +712,17 @@ public class StatementItem extends Panel {
             // We do exactly that (with backtracking) but on a copy and then restore the models, so
             // matches() stays side-effect free.
             Map<IRI, Object> snapshot = snapshotModels();
+            Set<IRI> unmatchedBefore = new HashSet<>(unmatchedParts);
             try {
-                return assignParts(0, new ArrayList<>(statements));
+                List<Statement> copy = new ArrayList<>(statements);
+                // A match must consume at least one statement: with optional members, an
+                // assignment that skips every part would otherwise "match" without evidence,
+                // which would also keep the repetition loop in fill() spinning forever.
+                return assignParts(0, copy) && copy.size() < statements.size();
             } finally {
                 restoreModels(snapshot);
+                unmatchedParts.clear();
+                unmatchedParts.addAll(unmatchedBefore);
             }
         }
 
@@ -678,7 +738,9 @@ public class StatementItem extends Panel {
             // that blocks a later part even though a consistent assignment exists. assignParts tries
             // alternatives and rolls back the model bindings between attempts. On success the matched
             // statements are removed from the list and the winning bindings are kept.
-            if (!assignParts(0, statements)) {
+            unmatchedParts.clear();
+            int sizeBefore = statements.size();
+            if (!assignParts(0, statements) || statements.size() == sizeBefore) {
                 throw new UnificationException("Unification seemed to work but then didn't");
             }
             filled = true;
@@ -709,6 +771,15 @@ public class StatementItem extends Panel {
                     available.add(i, s);
                 }
                 restoreModels(snapshot);
+            }
+            IRI partId = statementPartIds.get(partIndex);
+            if (isGrouped() && getTemplate().isOptionalStatement(partId)) {
+                // Optional group member with no consistent candidate: leave it unassigned and
+                // move on. Trying all candidates first (above) keeps fills maximal — a member
+                // is only skipped when no consistent assignment exists.
+                unmatchedParts.add(partId);
+                if (assignParts(partIndex + 1, available)) return true;
+                unmatchedParts.remove(partId);
             }
             return false;
         }

--- a/src/main/java/com/knowledgepixels/nanodash/component/StatementPartItem.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/StatementPartItem.html
@@ -13,6 +13,7 @@
 <span class="valueitem pred" wicket:id="pred">pred</span>
 <span class="valueitem obj" wicket:id="obj">obj</span>
 <span class="fullstop">.</span>
+<span class="optional-label optional-part-label" wicket:id="part-label">label</span>
 <span class="nanopub-statement-float">
 <span wicket:id="add-repetition" class="smallbutton">+</span>
 <span wicket:id="remove-repetition" class="smallbutton">-</span>

--- a/src/main/java/com/knowledgepixels/nanodash/component/ValueItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/ValueItem.java
@@ -50,11 +50,11 @@ public class ValueItem extends AbstractContextComponent {
                     component = new IriItem("value", id, iri, id.equals("obj"), statementPartId, rg);
                 }
             } else if (template.isRestrictedChoicePlaceholder(iri)) {
-                component = new RestrictedChoiceItem("value", id, iri, rg.isOptional(), this.context);
+                component = new RestrictedChoiceItem("value", id, iri, rg.isOptionalPart(statementPartId), this.context);
             } else if (template.isAgentPlaceholder(iri)) {
-                component = new AgentChoiceItem("value", id, iri, rg.isOptional(), this.context);
+                component = new AgentChoiceItem("value", id, iri, rg.isOptionalPart(statementPartId), this.context);
             } else if (template.isGuidedChoicePlaceholder(iri)) {
-                component = new GuidedChoiceItem("value", id, iri, rg.isOptional(), this.context);
+                component = new GuidedChoiceItem("value", id, iri, rg.isOptionalPart(statementPartId), this.context);
             } else if (template.isIntroducedResource(iri) && (this.context.getFillMode() == FillMode.SUPERSEDE || this.context.getFillMode() == FillMode.OVERRIDE)
                     && introducesAnything(this.context.getFillSource())) {
                 // An introduced resource keeps its IRI across versions, so it is pinned
@@ -64,20 +64,20 @@ public class ValueItem extends AbstractContextComponent {
                 // yet) the field must stay fillable (issue #549).
                 component = new ReadonlyItem("value", id, iri, statementPartId, rg);
             } else if (template.isUriPlaceholder(iri)) {
-                component = new IriTextfieldItem("value", id, iri, rg.isOptional(), this.context);
+                component = new IriTextfieldItem("value", id, iri, rg.isOptionalPart(statementPartId), this.context);
             } else if (template.isLongLiteralPlaceholder(iri)) {
-                component = new LiteralTextareaItem("value", iri, rg.isOptional(), this.context);
+                component = new LiteralTextareaItem("value", iri, rg.isOptionalPart(statementPartId), this.context);
             } else if (template.isLiteralPlaceholder(iri)) {
                 // TODO add all date time types
                 if (XSD.DATE.equals(template.getDatatype(iri))) {
-                    component = new LiteralDateItem("value", iri, rg.isOptional(), this.context);
+                    component = new LiteralDateItem("value", iri, rg.isOptionalPart(statementPartId), this.context);
                 } else if (XSD.DATETIME.equals(template.getDatatype(iri))) {
-                    component = new LiteralDateTimeItem("value", iri, rg.isOptional(), this.context);
+                    component = new LiteralDateTimeItem("value", iri, rg.isOptionalPart(statementPartId), this.context);
                 } else {
-                    component = new LiteralTextfieldItem("value", iri, rg.isOptional(), this.context);
+                    component = new LiteralTextfieldItem("value", iri, rg.isOptionalPart(statementPartId), this.context);
                 }
             } else if (template.isPlaceholder(iri)) {
-                component = new ValueTextfieldItem("value", id, iri, rg.isOptional(), this.context);
+                component = new ValueTextfieldItem("value", id, iri, rg.isOptionalPart(statementPartId), this.context);
             } else {
                 component = new IriItem("value", id, iri, id.equals("obj"), statementPartId, rg);
             }

--- a/src/main/java/com/knowledgepixels/nanodash/template/Template.java
+++ b/src/main/java/com/knowledgepixels/nanodash/template/Template.java
@@ -898,13 +898,49 @@ public class Template implements Serializable {
 //				!assertionTypes.contains(NTEMPLATE.PROVENANCE_TEMPLATE) && !assertionTypes.contains(PUBINFO_TEMPLATE))) {
 //			throw new MalformedTemplateException("Unknown template type");
 //		}
-        // Grouped IRI are added via group, so direct link from template is redundant:
+        List<IRI> groupIris = new ArrayList<>();
         for (IRI iri : typeMap.keySet()) {
-            if (!typeMap.get(iri).contains(NTEMPLATE.GROUPED_STATEMENT)) continue;
+            if (typeMap.get(iri).contains(NTEMPLATE.GROUPED_STATEMENT)) groupIris.add(iri);
+        }
+        // Nested groups and repeatable members are out of scope (the group is the unit of
+        // repetition); ignore such member flags with a warning instead of half-rendering:
+        for (IRI iri : groupIris) {
+            if (!isGroupedStatement(iri)) continue;
             List<IRI> memberIris = getStatementIris(iri);
             if (memberIris == null) {
                 throw new MalformedTemplateException("Grouped statement has no member statements: " + iri);
             }
+            for (IRI member : memberIris) {
+                List<IRI> memberTypes = typeMap.get(member);
+                if (memberTypes == null) continue;
+                if (memberTypes.remove(NTEMPLATE.GROUPED_STATEMENT)) {
+                    logger.warn("Ignoring nested nt:GroupedStatement flag on member {} of group {}", member, iri);
+                }
+                if (memberTypes.remove(NTEMPLATE.REPEATABLE_STATEMENT)) {
+                    logger.warn("Ignoring nt:RepeatableStatement flag on member {} of group {}", member, iri);
+                }
+            }
+        }
+        for (IRI iri : groupIris) {
+            if (!isGroupedStatement(iri)) continue;
+            List<IRI> memberIris = getStatementIris(iri);
+            // A group needs at least one required member: an all-optional group would match zero
+            // statements, making its presence meaningless and repetition detection non-terminating.
+            // Degrade to group-level optionality (today's semantics) instead of rejecting:
+            boolean hasRequiredMember = false;
+            for (IRI member : memberIris) {
+                if (!isOptionalStatement(member)) hasRequiredMember = true;
+            }
+            if (!hasRequiredMember) {
+                logger.warn("All members of group {} are optional; treating the group itself as optional instead", iri);
+                if (!isOptionalStatement(iri)) {
+                    addType(iri, NTEMPLATE.OPTIONAL_STATEMENT);
+                }
+                for (IRI member : memberIris) {
+                    typeMap.get(member).remove(NTEMPLATE.OPTIONAL_STATEMENT);
+                }
+            }
+            // Grouped IRI are added via group, so direct link from template is redundant:
             for (IRI groupedIri : memberIris) {
                 statementMap.get(templateIri).remove(groupedIri);
             }

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -1803,6 +1803,14 @@ a[href=""] {
   display: none;
 }
 
+/* Mark of an optional member statement inside a (required) group: rendered inline
+   at the end of that member's line, unlike the group-level mark, which is
+   absolutely positioned on the group box. */
+.optional-part-label {
+  position: static;
+  margin-left: 6px;
+}
+
 .separate-statement {
   border-top: 1px solid rgba(0, 0, 0, 0.3);
   padding-top: 10px;

--- a/src/test/java/com/knowledgepixels/nanodash/template/OptionalGroupMemberFillTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/template/OptionalGroupMemberFillTest.java
@@ -1,0 +1,214 @@
+package com.knowledgepixels.nanodash.template;
+
+import com.knowledgepixels.nanodash.WicketApplication;
+import com.knowledgepixels.nanodash.component.StatementItem;
+import org.apache.wicket.util.tester.WicketTester;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.mockito.MockedStatic;
+import org.nanopub.Nanopub;
+import org.nanopub.NanopubCreator;
+import org.nanopub.vocabulary.NTEMPLATE;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+/**
+ * Fill/unification tests for member-level optionality inside grouped statements
+ * (docs/optional-statements-in-groups.md): a group matches a nanopub that omits
+ * an optional member's triple, the skipped member is tracked for row hiding,
+ * repetitions handle the optional member independently, and matching stays
+ * terminating and evidence-based (at least one statement consumed).
+ */
+public class OptionalGroupMemberFillTest {
+
+    private static final ValueFactory vf = SimpleValueFactory.getInstance();
+
+    private static final String NP_URI = "https://w3id.org/np/RAAbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_AbCdE";
+    private static final IRI GROUP = vf.createIRI(NP_URI + "/group");
+    private static final IRI ST1 = vf.createIRI(NP_URI + "/st1");
+    private static final IRI ST2 = vf.createIRI(NP_URI + "/st2");
+    private static final IRI THING = vf.createIRI(NP_URI + "/thing");
+    private static final IRI NAME = vf.createIRI(NP_URI + "/name");
+    private static final IRI SOME_CLASS = vf.createIRI("http://example.com/SomeClass");
+
+    private static final IRI THING1 = vf.createIRI("http://example.com/thing1");
+    private static final IRI THING2 = vf.createIRI("http://example.com/thing2");
+
+    private MockedStatic<TemplateData> templateDataMockedStatic;
+
+    @BeforeEach
+    void setUp() {
+        new WicketTester(new WicketApplication());
+        templateDataMockedStatic = mockStatic(TemplateData.class);
+    }
+
+    @AfterEach
+    void tearDown() {
+        templateDataMockedStatic.close();
+    }
+
+    /**
+     * Builds the mixed-group template — st1 (required: thing a SomeClass), st2
+     * (optional: thing rdfs:label name) — optionally repeatable, and registers it
+     * with the mocked TemplateData.
+     */
+    private void mockTemplate(boolean repeatable) throws Exception {
+        NanopubCreator creator = new NanopubCreator(NP_URI);
+        creator.addProvenanceStatement(vf.createStatement(creator.getAssertionUri(), RDFS.SEEALSO, creator.getAssertionUri()));
+        creator.addPubinfoStatement(vf.createStatement(creator.getNanopubUri(), RDFS.SEEALSO, creator.getNanopubUri()));
+        IRI templateNode = creator.getAssertionUri();
+        creator.addAssertionStatement(templateNode, RDF.TYPE, NTEMPLATE.ASSERTION_TEMPLATE);
+        creator.addAssertionStatement(templateNode, RDFS.LABEL, vf.createLiteral("Group test template"));
+        creator.addAssertionStatement(templateNode, NTEMPLATE.HAS_STATEMENT, GROUP);
+        creator.addAssertionStatement(GROUP, RDF.TYPE, NTEMPLATE.GROUPED_STATEMENT);
+        if (repeatable) {
+            creator.addAssertionStatement(GROUP, RDF.TYPE, NTEMPLATE.REPEATABLE_STATEMENT);
+        }
+        creator.addAssertionStatement(GROUP, NTEMPLATE.HAS_STATEMENT, ST1);
+        creator.addAssertionStatement(GROUP, NTEMPLATE.HAS_STATEMENT, ST2);
+        creator.addAssertionStatement(ST1, RDF.SUBJECT, THING);
+        creator.addAssertionStatement(ST1, RDF.PREDICATE, RDF.TYPE);
+        creator.addAssertionStatement(ST1, RDF.OBJECT, SOME_CLASS);
+        creator.addAssertionStatement(ST2, RDF.TYPE, NTEMPLATE.OPTIONAL_STATEMENT);
+        creator.addAssertionStatement(ST2, RDF.SUBJECT, THING);
+        creator.addAssertionStatement(ST2, RDF.PREDICATE, RDFS.LABEL);
+        creator.addAssertionStatement(ST2, RDF.OBJECT, NAME);
+        creator.addAssertionStatement(THING, RDF.TYPE, NTEMPLATE.URI_PLACEHOLDER);
+        creator.addAssertionStatement(THING, RDFS.LABEL, vf.createLiteral("thing"));
+        creator.addAssertionStatement(NAME, RDF.TYPE, NTEMPLATE.LITERAL_PLACEHOLDER);
+        creator.addAssertionStatement(NAME, RDFS.LABEL, vf.createLiteral("name"));
+        Template template = new Template(creator.finalizeNanopub());
+
+        TemplateData templateDataMock = mock(TemplateData.class);
+        templateDataMockedStatic.when(TemplateData::get).thenReturn(templateDataMock);
+        when(templateDataMock.getTemplate(NP_URI)).thenReturn(template);
+    }
+
+    /**
+     * Builds a data nanopub with the given assertion statements.
+     */
+    private static Nanopub dataNanopub(Statement... assertionStatements) throws Exception {
+        NanopubCreator creator = new NanopubCreator("http://purl.org/nanopub/temp/data/");
+        for (Statement st : assertionStatements) {
+            creator.addAssertionStatement(st);
+        }
+        creator.addProvenanceStatement(vf.createStatement(creator.getAssertionUri(), RDFS.SEEALSO, creator.getAssertionUri()));
+        creator.addPubinfoStatement(vf.createStatement(creator.getNanopubUri(), RDFS.SEEALSO, creator.getNanopubUri()));
+        return creator.finalizeNanopub();
+    }
+
+    /**
+     * Mirrors the viewer flow (NanopubItem.populateStatementItemList): read-only
+     * context built from the template, fed the data nanopub's assertion triples.
+     */
+    private TemplateContext fill(Nanopub dataNp, ValueFiller filler) {
+        TemplateContext context = new TemplateContext(ContextType.ASSERTION, NP_URI, "statement", dataNp);
+        context.initStatements();
+        filler.fill(context);
+        return context;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Set<IRI> getUnmatchedParts(StatementItem si) throws Exception {
+        Field rgsField = StatementItem.class.getDeclaredField("repetitionGroups");
+        rgsField.setAccessible(true);
+        Object rg = ((List<Object>) rgsField.get(si)).get(0);
+        Field upField = rg.getClass().getDeclaredField("unmatchedParts");
+        upField.setAccessible(true);
+        return (Set<IRI>) upField.get(rg);
+    }
+
+    @Test
+    void nanopubOmittingOptionalTripleMatches() throws Exception {
+        mockTemplate(false);
+        Nanopub dataNp = dataNanopub(vf.createStatement(THING1, RDF.TYPE, SOME_CLASS));
+        ValueFiller filler = new ValueFiller(dataNp, ContextType.ASSERTION, false);
+        TemplateContext context = fill(dataNp, filler);
+
+        StatementItem si = context.getStatementItems().get(0);
+        assertTrue(si.isMatched(), "group must match despite the missing optional triple");
+        assertTrue(filler.getUnusedStatements().isEmpty(),
+                "all statements must be consumed, but these stayed unused:\n" + filler.getUnusedStatements());
+        assertEquals(Set.of(ST2), getUnmatchedParts(si), "the skipped optional member must be tracked for row hiding");
+    }
+
+    @Test
+    void nanopubWithOptionalTripleMatchesFully() throws Exception {
+        mockTemplate(false);
+        Nanopub dataNp = dataNanopub(
+                vf.createStatement(THING1, RDF.TYPE, SOME_CLASS),
+                vf.createStatement(THING1, RDFS.LABEL, vf.createLiteral("thing one")));
+        ValueFiller filler = new ValueFiller(dataNp, ContextType.ASSERTION, false);
+        TemplateContext context = fill(dataNp, filler);
+
+        StatementItem si = context.getStatementItems().get(0);
+        assertTrue(si.isMatched());
+        assertTrue(filler.getUnusedStatements().isEmpty(),
+                "all statements must be consumed, but these stayed unused:\n" + filler.getUnusedStatements());
+        assertTrue(getUnmatchedParts(si).isEmpty(), "nothing was skipped, so no row may be hidden");
+    }
+
+    @Test
+    void optionalTripleAloneDoesNotMatchGroup() throws Exception {
+        mockTemplate(false);
+        Nanopub dataNp = dataNanopub(vf.createStatement(THING1, RDFS.LABEL, vf.createLiteral("thing one")));
+        ValueFiller filler = new ValueFiller(dataNp, ContextType.ASSERTION, false);
+        TemplateContext context = fill(dataNp, filler);
+
+        StatementItem si = context.getStatementItems().get(0);
+        assertFalse(si.isMatched(), "required member has no candidate, so the group must not match");
+        assertEquals(1, filler.getUnusedStatements().size(), "the label triple must stay unused");
+    }
+
+    @Test
+    @Timeout(10)
+    void repeatableGroupHandlesOptionalMemberPerRepetition() throws Exception {
+        mockTemplate(true);
+        Nanopub dataNp = dataNanopub(
+                vf.createStatement(THING1, RDF.TYPE, SOME_CLASS),
+                vf.createStatement(THING1, RDFS.LABEL, vf.createLiteral("thing one")),
+                vf.createStatement(THING2, RDF.TYPE, SOME_CLASS));
+        ValueFiller filler = new ValueFiller(dataNp, ContextType.ASSERTION, false);
+        TemplateContext context = fill(dataNp, filler);
+
+        StatementItem si = context.getStatementItems().get(0);
+        assertTrue(si.isMatched());
+        assertEquals(2, si.getRepetitionCount(),
+                "one repetition with the optional triple, one without");
+        assertTrue(filler.getUnusedStatements().isEmpty(),
+                "all statements must be consumed, but these stayed unused:\n" + filler.getUnusedStatements());
+    }
+
+    @Test
+    @Timeout(10)
+    void repeatableGroupTerminatesWhenNothingIsLeft() throws Exception {
+        mockTemplate(true);
+        Nanopub dataNp = dataNanopub(vf.createStatement(THING1, RDF.TYPE, SOME_CLASS));
+        ValueFiller filler = new ValueFiller(dataNp, ContextType.ASSERTION, false);
+        TemplateContext context = fill(dataNp, filler);
+
+        StatementItem si = context.getStatementItems().get(0);
+        assertTrue(si.isMatched());
+        // The all-consumed statement list must not allow further vacuous "matches"
+        // (every member skipped): the repetition loop has to stop.
+        assertTrue(filler.getUnusedStatements().isEmpty());
+    }
+
+}

--- a/src/test/java/com/knowledgepixels/nanodash/template/OptionalGroupMemberPublishTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/template/OptionalGroupMemberPublishTest.java
@@ -1,0 +1,154 @@
+package com.knowledgepixels.nanodash.template;
+
+import com.knowledgepixels.nanodash.WicketApplication;
+import org.apache.wicket.util.tester.WicketTester;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.nanopub.MalformedNanopubException;
+import org.nanopub.Nanopub;
+import org.nanopub.NanopubCreator;
+import org.nanopub.vocabulary.NTEMPLATE;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+/**
+ * Publish-path tests for member-level optionality inside grouped statements
+ * (docs/optional-statements-in-groups.md): an empty optional member is dropped
+ * from the created nanopub while the rest of the group is emitted; empty
+ * required members still fail.
+ */
+public class OptionalGroupMemberPublishTest {
+
+    private static final ValueFactory vf = SimpleValueFactory.getInstance();
+
+    private static final String NP_URI = "https://w3id.org/np/RAAbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_AbCdE";
+    private static final IRI GROUP = vf.createIRI(NP_URI + "/group");
+    private static final IRI ST1 = vf.createIRI(NP_URI + "/st1");
+    private static final IRI ST2 = vf.createIRI(NP_URI + "/st2");
+    private static final IRI THING = vf.createIRI(NP_URI + "/thing");
+    private static final IRI NAME = vf.createIRI(NP_URI + "/name");
+    private static final IRI SOME_CLASS = vf.createIRI("http://example.com/SomeClass");
+
+    private MockedStatic<TemplateData> templateDataMockedStatic;
+
+    @BeforeEach
+    void setUp() {
+        new WicketTester(new WicketApplication());
+        templateDataMockedStatic = mockStatic(TemplateData.class);
+    }
+
+    @AfterEach
+    void tearDown() {
+        templateDataMockedStatic.close();
+    }
+
+    /**
+     * Builds a template with one group: st1 (required: thing a SomeClass) and st2
+     * (optional: thing rdfs:label name), and registers it with the mocked
+     * TemplateData under its nanopub URI.
+     */
+    private TemplateContext mixedGroupContext() throws Exception {
+        NanopubCreator creator = new NanopubCreator(NP_URI);
+        creator.addProvenanceStatement(vf.createStatement(creator.getAssertionUri(), RDFS.SEEALSO, creator.getAssertionUri()));
+        creator.addPubinfoStatement(vf.createStatement(creator.getNanopubUri(), RDFS.SEEALSO, creator.getNanopubUri()));
+        IRI templateNode = creator.getAssertionUri();
+        creator.addAssertionStatement(templateNode, RDF.TYPE, NTEMPLATE.ASSERTION_TEMPLATE);
+        creator.addAssertionStatement(templateNode, RDFS.LABEL, vf.createLiteral("Group test template"));
+        creator.addAssertionStatement(templateNode, NTEMPLATE.HAS_STATEMENT, GROUP);
+        creator.addAssertionStatement(GROUP, RDF.TYPE, NTEMPLATE.GROUPED_STATEMENT);
+        creator.addAssertionStatement(GROUP, NTEMPLATE.HAS_STATEMENT, ST1);
+        creator.addAssertionStatement(GROUP, NTEMPLATE.HAS_STATEMENT, ST2);
+        creator.addAssertionStatement(ST1, RDF.SUBJECT, THING);
+        creator.addAssertionStatement(ST1, RDF.PREDICATE, RDF.TYPE);
+        creator.addAssertionStatement(ST1, RDF.OBJECT, SOME_CLASS);
+        creator.addAssertionStatement(ST2, RDF.TYPE, NTEMPLATE.OPTIONAL_STATEMENT);
+        creator.addAssertionStatement(ST2, RDF.SUBJECT, THING);
+        creator.addAssertionStatement(ST2, RDF.PREDICATE, RDFS.LABEL);
+        creator.addAssertionStatement(ST2, RDF.OBJECT, NAME);
+        creator.addAssertionStatement(THING, RDF.TYPE, NTEMPLATE.URI_PLACEHOLDER);
+        creator.addAssertionStatement(THING, RDFS.LABEL, vf.createLiteral("thing"));
+        creator.addAssertionStatement(NAME, RDF.TYPE, NTEMPLATE.LITERAL_PLACEHOLDER);
+        creator.addAssertionStatement(NAME, RDFS.LABEL, vf.createLiteral("name"));
+        Template template = new Template(creator.finalizeNanopub());
+
+        TemplateData templateDataMock = mock(TemplateData.class);
+        templateDataMockedStatic.when(TemplateData::get).thenReturn(templateDataMock);
+        when(templateDataMock.getTemplate(NP_URI)).thenReturn(template);
+
+        TemplateContext context = new TemplateContext(ContextType.ASSERTION, NP_URI, "statement", (String) null);
+        context.initStatements();
+        return context;
+    }
+
+    @SuppressWarnings("unchecked")
+    private void setModel(TemplateContext context, IRI placeholder, String value) {
+        ((org.apache.wicket.model.IModel<Object>) context.getComponentModels().get(placeholder)).setObject(value);
+    }
+
+    private Nanopub publish(TemplateContext context) throws Exception {
+        NanopubCreator creator = new NanopubCreator("http://purl.org/nanopub/temp/result/");
+        context.propagateStatements(creator);
+        creator.addProvenanceStatement(vf.createStatement(creator.getAssertionUri(), RDFS.SEEALSO, creator.getAssertionUri()));
+        creator.addPubinfoStatement(vf.createStatement(creator.getNanopubUri(), RDFS.SEEALSO, creator.getNanopubUri()));
+        return creator.finalizeNanopub();
+    }
+
+    private static boolean hasAssertionTriple(Nanopub np, Value subj, Value pred, Value obj) {
+        for (Statement st : np.getAssertion()) {
+            if (st.getSubject().equals(subj) && st.getPredicate().equals(pred) && st.getObject().equals(obj)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean hasAssertionTripleWithPredicate(Nanopub np, Value pred) {
+        for (Statement st : np.getAssertion()) {
+            if (st.getPredicate().equals(pred)) return true;
+        }
+        return false;
+    }
+
+    @Test
+    void emptyOptionalMemberIsDropped() throws Exception {
+        TemplateContext context = mixedGroupContext();
+        setModel(context, THING, "http://example.com/thing1");
+        // NAME stays empty
+        Nanopub np = publish(context);
+        assertTrue(hasAssertionTriple(np, vf.createIRI("http://example.com/thing1"), RDF.TYPE, SOME_CLASS));
+        assertFalse(hasAssertionTripleWithPredicate(np, RDFS.LABEL), "empty optional member must not be emitted");
+    }
+
+    @Test
+    void filledOptionalMemberIsEmitted() throws Exception {
+        TemplateContext context = mixedGroupContext();
+        setModel(context, THING, "http://example.com/thing1");
+        setModel(context, NAME, "some label");
+        Nanopub np = publish(context);
+        assertTrue(hasAssertionTriple(np, vf.createIRI("http://example.com/thing1"), RDF.TYPE, SOME_CLASS));
+        assertTrue(hasAssertionTriple(np, vf.createIRI("http://example.com/thing1"), RDFS.LABEL, vf.createLiteral("some label")));
+    }
+
+    @Test
+    void emptyRequiredMemberStillFails() throws Exception {
+        TemplateContext context = mixedGroupContext();
+        // THING stays empty, so the required member st1 cannot be resolved
+        setModel(context, NAME, "some label");
+        assertThrows(MalformedNanopubException.class, () -> publish(context));
+    }
+
+}

--- a/src/test/java/com/knowledgepixels/nanodash/template/OptionalGroupMemberTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/template/OptionalGroupMemberTest.java
@@ -1,0 +1,143 @@
+package com.knowledgepixels.nanodash.template;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.junit.jupiter.api.Test;
+import org.nanopub.Nanopub;
+import org.nanopub.NanopubCreator;
+import org.nanopub.vocabulary.NTEMPLATE;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for member-level optionality inside grouped statements
+ * (docs/optional-statements-in-groups.md): the member flags survive parsing, an
+ * all-optional group is normalized to a group-level optional, and out-of-scope
+ * member flags (repeatable, nested group) are ignored.
+ */
+public class OptionalGroupMemberTest {
+
+    private static final ValueFactory vf = SimpleValueFactory.getInstance();
+
+    private static final String NP_URI = "https://w3id.org/np/RAAbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_AbCdE";
+    private static final IRI GROUP = vf.createIRI(NP_URI + "/group");
+    private static final IRI ST1 = vf.createIRI(NP_URI + "/st1");
+    private static final IRI ST2 = vf.createIRI(NP_URI + "/st2");
+
+    /**
+     * Builds a template whose assertion is a group with two members: st1 (class
+     * assignment) and st2 (label). Callers add optionality/other flags on top.
+     */
+    private static NanopubCreator groupTemplateCreator() throws Exception {
+        NanopubCreator creator = new NanopubCreator(NP_URI);
+        creator.addProvenanceStatement(vf.createStatement(creator.getAssertionUri(), RDFS.SEEALSO, creator.getAssertionUri()));
+        creator.addPubinfoStatement(vf.createStatement(creator.getNanopubUri(), RDFS.SEEALSO, creator.getNanopubUri()));
+        IRI templateNode = creator.getAssertionUri();
+        IRI thing = vf.createIRI(NP_URI + "/thing");
+        IRI name = vf.createIRI(NP_URI + "/name");
+        creator.addAssertionStatement(templateNode, RDF.TYPE, NTEMPLATE.ASSERTION_TEMPLATE);
+        creator.addAssertionStatement(templateNode, RDFS.LABEL, vf.createLiteral("Group test template"));
+        creator.addAssertionStatement(templateNode, NTEMPLATE.HAS_STATEMENT, GROUP);
+        // Real templates also link the members directly from the template node (the
+        // redundant links the group post-processing removes again):
+        creator.addAssertionStatement(templateNode, NTEMPLATE.HAS_STATEMENT, ST1);
+        creator.addAssertionStatement(templateNode, NTEMPLATE.HAS_STATEMENT, ST2);
+        creator.addAssertionStatement(GROUP, RDF.TYPE, NTEMPLATE.GROUPED_STATEMENT);
+        creator.addAssertionStatement(GROUP, NTEMPLATE.HAS_STATEMENT, ST1);
+        creator.addAssertionStatement(GROUP, NTEMPLATE.HAS_STATEMENT, ST2);
+        creator.addAssertionStatement(ST1, RDF.SUBJECT, thing);
+        creator.addAssertionStatement(ST1, RDF.PREDICATE, RDF.TYPE);
+        creator.addAssertionStatement(ST1, RDF.OBJECT, vf.createIRI("http://example.com/SomeClass"));
+        creator.addAssertionStatement(ST2, RDF.SUBJECT, thing);
+        creator.addAssertionStatement(ST2, RDF.PREDICATE, RDFS.LABEL);
+        creator.addAssertionStatement(ST2, RDF.OBJECT, name);
+        creator.addAssertionStatement(thing, RDF.TYPE, NTEMPLATE.URI_PLACEHOLDER);
+        creator.addAssertionStatement(thing, RDFS.LABEL, vf.createLiteral("thing"));
+        creator.addAssertionStatement(name, RDF.TYPE, NTEMPLATE.LITERAL_PLACEHOLDER);
+        creator.addAssertionStatement(name, RDFS.LABEL, vf.createLiteral("name"));
+        return creator;
+    }
+
+    @Test
+    void mixedGroupKeepsMemberOptionality() throws Exception {
+        NanopubCreator creator = groupTemplateCreator();
+        creator.addAssertionStatement(ST2, RDF.TYPE, NTEMPLATE.OPTIONAL_STATEMENT);
+        Template t = new Template(creator.finalizeNanopub());
+        assertFalse(t.isOptionalStatement(GROUP), "group with a required member must not become optional");
+        assertFalse(t.isOptionalStatement(ST1));
+        assertTrue(t.isOptionalStatement(ST2), "member-level optional flag must survive parsing");
+        assertTrue(t.getStatementIris().contains(GROUP));
+        assertFalse(t.getStatementIris().contains(ST1), "members must be detached from the top level");
+        assertFalse(t.getStatementIris().contains(ST2), "members must be detached from the top level");
+    }
+
+    @Test
+    void allOptionalGroupNormalizedToOptionalGroup() throws Exception {
+        NanopubCreator creator = groupTemplateCreator();
+        creator.addAssertionStatement(ST1, RDF.TYPE, NTEMPLATE.OPTIONAL_STATEMENT);
+        creator.addAssertionStatement(ST2, RDF.TYPE, NTEMPLATE.OPTIONAL_STATEMENT);
+        Template t = new Template(creator.finalizeNanopub());
+        assertTrue(t.isOptionalStatement(GROUP), "all-optional group must be normalized to a group-level optional");
+        assertFalse(t.isOptionalStatement(ST1), "member flags must be stripped by the normalization");
+        assertFalse(t.isOptionalStatement(ST2), "member flags must be stripped by the normalization");
+    }
+
+    @Test
+    void allOptionalMembersInAlreadyOptionalGroupAreStripped() throws Exception {
+        NanopubCreator creator = groupTemplateCreator();
+        creator.addAssertionStatement(GROUP, RDF.TYPE, NTEMPLATE.OPTIONAL_STATEMENT);
+        creator.addAssertionStatement(ST1, RDF.TYPE, NTEMPLATE.OPTIONAL_STATEMENT);
+        creator.addAssertionStatement(ST2, RDF.TYPE, NTEMPLATE.OPTIONAL_STATEMENT);
+        Template t = new Template(creator.finalizeNanopub());
+        assertTrue(t.isOptionalStatement(GROUP));
+        assertFalse(t.isOptionalStatement(ST1));
+        assertFalse(t.isOptionalStatement(ST2));
+    }
+
+    @Test
+    void optionalGroupWithRequiredMembersIsUnchanged() throws Exception {
+        NanopubCreator creator = groupTemplateCreator();
+        creator.addAssertionStatement(GROUP, RDF.TYPE, NTEMPLATE.OPTIONAL_STATEMENT);
+        Template t = new Template(creator.finalizeNanopub());
+        assertTrue(t.isOptionalStatement(GROUP));
+        assertFalse(t.isOptionalStatement(ST1));
+        assertFalse(t.isOptionalStatement(ST2));
+    }
+
+    @Test
+    void repeatableMemberFlagIsIgnored() throws Exception {
+        NanopubCreator creator = groupTemplateCreator();
+        creator.addAssertionStatement(ST2, RDF.TYPE, NTEMPLATE.REPEATABLE_STATEMENT);
+        Template t = new Template(creator.finalizeNanopub());
+        assertFalse(t.isRepeatableStatement(ST2), "repeatable flag on a group member is out of scope and must be dropped");
+    }
+
+    @Test
+    void nestedGroupFlagIsIgnored() throws Exception {
+        NanopubCreator creator = groupTemplateCreator();
+        creator.addAssertionStatement(ST2, RDF.TYPE, NTEMPLATE.GROUPED_STATEMENT);
+        creator.addAssertionStatement(ST2, NTEMPLATE.HAS_STATEMENT, ST1);
+        Template t = new Template(creator.finalizeNanopub());
+        assertFalse(t.isGroupedStatement(ST2), "nested group flag on a group member is out of scope and must be dropped");
+    }
+
+    @Test
+    void memberlessGroupStillThrows() throws Exception {
+        NanopubCreator creator = new NanopubCreator(NP_URI);
+        creator.addProvenanceStatement(vf.createStatement(creator.getAssertionUri(), RDFS.SEEALSO, creator.getAssertionUri()));
+        creator.addPubinfoStatement(vf.createStatement(creator.getNanopubUri(), RDFS.SEEALSO, creator.getNanopubUri()));
+        IRI templateNode = creator.getAssertionUri();
+        creator.addAssertionStatement(templateNode, RDF.TYPE, NTEMPLATE.ASSERTION_TEMPLATE);
+        creator.addAssertionStatement(templateNode, RDFS.LABEL, vf.createLiteral("Broken template"));
+        creator.addAssertionStatement(templateNode, NTEMPLATE.HAS_STATEMENT, GROUP);
+        creator.addAssertionStatement(GROUP, RDF.TYPE, NTEMPLATE.GROUPED_STATEMENT);
+        Nanopub np = creator.finalizeNanopub();
+        assertThrows(MalformedTemplateException.class, () -> new Template(np));
+    }
+
+}


### PR DESCRIPTION
Implements member-level optionality inside statement groups per the design doc `docs/optional-statements-in-groups.md` (merged in #553's sibling d227dbc3): a member of a `nt:GroupedStatement` marked `nt:OptionalStatement` may stay empty — its triple is then dropped — while the group's other members keep their own requirements. Repeatable members and nested groups remain out of scope (the group is the unit of repetition) and are now explicitly ignored with a warning.

## Changes

- **Template parsing** (`Template`): an all-optional group is normalized to a group-level optional with a warning — a group needs ≥1 required member, otherwise matching would be vacuous and repetition detection would not terminate. Out-of-scope member flags (`nt:RepeatableStatement`, nested `nt:GroupedStatement`) are stripped with a warning.
- **Publish path** (`StatementItem`): `hasEmptyElements`/`addTriplesTo` skip empty optional members instead of blocking (required statement) or silently dropping the whole group (optional statement). Both gated on `isGrouped()` so top-level optional statements behave exactly as before.
- **Form UI** (`ValueItem`, `StatementPartItem.html`, `style.css`): member-optional fields are non-required (per repetition — unlike group-level optionality, which turns off when repeated); a per-line "(optional)" mark renders inline after the statement via a new `part-label` slot, leaving the group-level mark and its repetition toggling untouched.
- **Fill/unification** (`StatementItem`): `assignParts` gets a skip branch for optional members, tried only after all candidate statements fail, so fills stay maximal (match-over-skip). `matches()` additionally requires at least one consumed statement, guarding the trial-repetition loop against vacuous matches. Skipped members are tracked in `unmatchedParts`; their rows are hidden in read-only rendering and shown as empty editable fields in derive/update contexts.

## Backwards compatibility

Existing templates parse and behave identically (the new paths only activate on the member-level flag, which nothing honored before). Old parsers treat member-optional statements as required — stricter but never invalid; fill of a nanopub legitimately omitting the optional triple falls back to the generic statement display there. All 196 live templates in `AllAssertionTemplatesLoadingTest` still load.

## Tests

- `OptionalGroupMemberTest`: parsing, all-optional normalization, out-of-scope flag stripping, memberless-group regression.
- `OptionalGroupMemberPublishTest`: empty optional member dropped, filled member emitted, empty required member still fails.
- `OptionalGroupMemberFillTest`: group matches a nanopub omitting the optional triple (skipped member tracked for row hiding), full match, required-member-missing non-match, repeatable group with per-repetition optionality, termination guard (`@Timeout`).

All test fixtures are built programmatically (no new network dependencies). Full suite: 771 tests, 0 failures.

Verified additionally against the live "Annotation as a discourse contribution" template (`…RADVnxF4…`): its selector group publishes correctly with `oa:prefix`/`oa:suffix` omitted. (That template independently needs republishing with `nt:LocalResource` declarations for `statement`/`selector`/`anchor` — unrelated to this PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)