### PR TITLE
feat: treat untyped local IRIs in template statements as local resources

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/template/Template.java
+++ b/src/main/java/com/knowledgepixels/nanodash/template/Template.java
@@ -789,6 +789,44 @@ public class Template implements Serializable {
             // Experimental SHACL-based template:
             processShaclTemplate(templateNp);
         }
+        tagUntypedLocalIrisAsLocalResources(templateNp);
+    }
+
+    // Local IRIs in used statement positions that carry no identity type (no placeholder
+    // type, not a Local/Introduced/Embedded Resource) are automatically treated as Local
+    // Resources, so every produced nanopub mints them under its own namespace instead of
+    // copying the template-local IRI verbatim (see issue #551).
+    private void tagUntypedLocalIrisAsLocalResources(Nanopub templateNp) {
+        List<IRI> topIris = statementMap.get(templateIri);
+        if (topIris == null) return;
+        String npUri = templateNp.getUri().stringValue();
+        List<IRI> statementIris = new ArrayList<>();
+        for (IRI iri : topIris) {
+            if (statementMap.containsKey(iri)) {
+                // grouped statement
+                statementIris.addAll(statementMap.get(iri));
+            } else {
+                statementIris.add(iri);
+            }
+        }
+        for (IRI st : statementIris) {
+            tagIfUntypedLocal(statementSubjects.get(st), npUri);
+            tagIfUntypedLocal(statementPredicates.get(st), npUri);
+            tagIfUntypedLocal(statementObjects.get(st), npUri);
+        }
+    }
+
+    private void tagIfUntypedLocal(Value value, String npUri) {
+        if (!(value instanceof IRI iri)) return;
+        String s = iri.stringValue();
+        // Only sub-IRIs of the template nanopub are local; the nanopub URI itself is a
+        // global reference to the template and stays verbatim:
+        if (!s.startsWith(npUri) || s.length() == npUri.length()) return;
+        if (iri.equals(templateIri)) return;
+        // Statement/group identifiers referenced as values stay untouched:
+        if (statementMap.containsKey(iri) || statementSubjects.containsKey(iri)) return;
+        if (isPlaceholder(iri) || isLocalResource(iri) || isIntroducedResource(iri) || isEmbeddedResource(iri)) return;
+        addType(iri, NTEMPLATE.LOCAL_RESOURCE);
     }
 
     private void processNpTemplate(Nanopub templateNp) throws MalformedTemplateException {

--- a/src/test/java/com/knowledgepixels/nanodash/template/AutoLocalResourceTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/template/AutoLocalResourceTest.java
@@ -1,0 +1,130 @@
+package com.knowledgepixels.nanodash.template;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.junit.jupiter.api.Test;
+import org.nanopub.NanopubCreator;
+import org.nanopub.vocabulary.NTEMPLATE;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for the automatic Local Resource treatment of template-local IRIs (issue
+ * #551): a local IRI used in a statement position without any identity type is
+ * treated as if it were tagged nt:LocalResource, so produced nanopubs mint it
+ * under their own namespace instead of copying it verbatim.
+ */
+public class AutoLocalResourceTest {
+
+    private static final ValueFactory vf = SimpleValueFactory.getInstance();
+
+    private static final String NP_URI = "https://w3id.org/np/RAAbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_AbCdE";
+    private static final IRI ST1 = vf.createIRI(NP_URI + "/st1");
+    private static final IRI LOCAL_SUBJ = vf.createIRI(NP_URI + "/localthing");
+    private static final IRI LOCAL_PRED = vf.createIRI(NP_URI + "/haslocalrelation");
+    private static final IRI LOCAL_OBJ = vf.createIRI(NP_URI + "/localvalue");
+    private static final IRI EXTERNAL_OBJ = vf.createIRI("http://example.com/SomeClass");
+
+    private static NanopubCreator templateCreator() throws Exception {
+        NanopubCreator creator = new NanopubCreator(NP_URI);
+        creator.addProvenanceStatement(vf.createStatement(creator.getAssertionUri(), RDFS.SEEALSO, creator.getAssertionUri()));
+        creator.addPubinfoStatement(vf.createStatement(creator.getNanopubUri(), RDFS.SEEALSO, creator.getNanopubUri()));
+        IRI templateNode = creator.getAssertionUri();
+        creator.addAssertionStatement(templateNode, RDF.TYPE, NTEMPLATE.ASSERTION_TEMPLATE);
+        creator.addAssertionStatement(templateNode, RDFS.LABEL, vf.createLiteral("Auto local resource test template"));
+        creator.addAssertionStatement(templateNode, NTEMPLATE.HAS_STATEMENT, ST1);
+        creator.addAssertionStatement(ST1, RDF.SUBJECT, LOCAL_SUBJ);
+        creator.addAssertionStatement(ST1, RDF.PREDICATE, LOCAL_PRED);
+        creator.addAssertionStatement(ST1, RDF.OBJECT, LOCAL_OBJ);
+        return creator;
+    }
+
+    @Test
+    void untypedLocalIrisBecomeLocalResourcesInAllPositions() throws Exception {
+        Template t = new Template(templateCreator().finalizeNanopub());
+        assertTrue(t.isLocalResource(LOCAL_SUBJ), "untyped local subject must become a Local Resource");
+        assertTrue(t.isLocalResource(LOCAL_PRED), "untyped local predicate must become a Local Resource");
+        assertTrue(t.isLocalResource(LOCAL_OBJ), "untyped local object must become a Local Resource");
+    }
+
+    @Test
+    void externalIrisStayUntouched() throws Exception {
+        NanopubCreator creator = templateCreator();
+        creator.addAssertionStatement(ST1, RDF.OBJECT, EXTERNAL_OBJ);
+        Template t = new Template(creator.finalizeNanopub());
+        assertFalse(t.isLocalResource(EXTERNAL_OBJ));
+    }
+
+    @Test
+    void placeholdersStayUntouched() throws Exception {
+        NanopubCreator creator = templateCreator();
+        creator.addAssertionStatement(LOCAL_SUBJ, RDF.TYPE, NTEMPLATE.URI_PLACEHOLDER);
+        Template t = new Template(creator.finalizeNanopub());
+        assertFalse(t.isLocalResource(LOCAL_SUBJ), "a placeholder must not be auto-tagged as Local Resource");
+        assertTrue(t.isPlaceholder(LOCAL_SUBJ));
+    }
+
+    @Test
+    void introducedResourcesStayUntouched() throws Exception {
+        NanopubCreator creator = templateCreator();
+        creator.addAssertionStatement(LOCAL_SUBJ, RDF.TYPE, NTEMPLATE.INTRODUCED_RESOURCE);
+        Template t = new Template(creator.finalizeNanopub());
+        assertFalse(t.isLocalResource(LOCAL_SUBJ), "an introduced resource must not be auto-tagged as Local Resource");
+        assertTrue(t.isIntroducedResource(LOCAL_SUBJ));
+    }
+
+    @Test
+    void explicitLocalResourceTagStillWorks() throws Exception {
+        NanopubCreator creator = templateCreator();
+        creator.addAssertionStatement(LOCAL_SUBJ, RDF.TYPE, NTEMPLATE.LOCAL_RESOURCE);
+        Template t = new Template(creator.finalizeNanopub());
+        assertTrue(t.isLocalResource(LOCAL_SUBJ));
+    }
+
+    @Test
+    void localIrisInDeadStatementsStayUntouched() throws Exception {
+        // A statement definition not referenced via nt:hasStatement is dead; its
+        // local IRIs are never published and must not be tagged.
+        NanopubCreator creator = templateCreator();
+        IRI deadStatement = vf.createIRI(NP_URI + "/deadst");
+        IRI deadLocal = vf.createIRI(NP_URI + "/deadlocal");
+        creator.addAssertionStatement(deadStatement, RDF.SUBJECT, deadLocal);
+        creator.addAssertionStatement(deadStatement, RDF.PREDICATE, RDF.TYPE);
+        creator.addAssertionStatement(deadStatement, RDF.OBJECT, EXTERNAL_OBJ);
+        Template t = new Template(creator.finalizeNanopub());
+        assertFalse(t.isLocalResource(deadLocal), "local IRIs in unreferenced statement definitions must not be tagged");
+    }
+
+    @Test
+    void templateNanopubUriItselfStaysUntouched() throws Exception {
+        NanopubCreator creator = templateCreator();
+        creator.addAssertionStatement(ST1, RDF.OBJECT, vf.createIRI(NP_URI));
+        Template t = new Template(creator.finalizeNanopub());
+        assertFalse(t.isLocalResource(vf.createIRI(NP_URI)), "the template nanopub URI is a global reference, not a local IRI");
+    }
+
+    @Test
+    void groupMemberStatementsAreCovered() throws Exception {
+        NanopubCreator creator = new NanopubCreator(NP_URI);
+        creator.addProvenanceStatement(vf.createStatement(creator.getAssertionUri(), RDFS.SEEALSO, creator.getAssertionUri()));
+        creator.addPubinfoStatement(vf.createStatement(creator.getNanopubUri(), RDFS.SEEALSO, creator.getNanopubUri()));
+        IRI templateNode = creator.getAssertionUri();
+        IRI group = vf.createIRI(NP_URI + "/group");
+        creator.addAssertionStatement(templateNode, RDF.TYPE, NTEMPLATE.ASSERTION_TEMPLATE);
+        creator.addAssertionStatement(templateNode, RDFS.LABEL, vf.createLiteral("Group test template"));
+        creator.addAssertionStatement(templateNode, NTEMPLATE.HAS_STATEMENT, group);
+        creator.addAssertionStatement(templateNode, NTEMPLATE.HAS_STATEMENT, ST1);
+        creator.addAssertionStatement(group, RDF.TYPE, NTEMPLATE.GROUPED_STATEMENT);
+        creator.addAssertionStatement(group, NTEMPLATE.HAS_STATEMENT, ST1);
+        creator.addAssertionStatement(ST1, RDF.SUBJECT, LOCAL_SUBJ);
+        creator.addAssertionStatement(ST1, RDF.PREDICATE, RDF.TYPE);
+        creator.addAssertionStatement(ST1, RDF.OBJECT, EXTERNAL_OBJ);
+        Template t = new Template(creator.finalizeNanopub());
+        assertTrue(t.isLocalResource(LOCAL_SUBJ), "local IRIs inside grouped statements must be tagged too");
+    }
+
+}


### PR DESCRIPTION
Implements #551: local IRIs used in template statement positions without any identity type (no placeholder type, not a Local/Introduced/Embedded Resource) are now automatically treated as `nt:LocalResource`, so every produced nanopublication mints them under its own namespace instead of copying the template-local IRI verbatim.

## How

A single post-parse pass in `Template` (`tagUntypedLocalIrisAsLocalResources`, run after both the regular `nt:` and the SHACL parse paths) walks all used statements — top-level and group members, so dead statement definitions are naturally skipped — and adds `nt:LocalResource` to the type map of any subject/predicate/object IRI that:

- is a strict sub-IRI of the template nanopub URI (the nanopub URI itself stays a global reference),
- is not the template node or a statement/group identifier, and
- carries no identity type.

All downstream behavior (rendering, repetition suffixing, publish-time minting, unification) follows through the existing `isLocalResource` checks.

## Notes

- The rule applies uniformly to subject, predicate, and object positions. This intentionally drops the "copy this template-local IRI verbatim" behavior; per the survey on #551, only 2 published nanopubs network-wide relied on it (predicate position).
- The explicit `nt:LocalResource` tag keeps working and remains required for its second role: combined with a placeholder type it means "user input is a suffix minted under the target namespace", which cannot be inferred.

## Testing

- New `AutoLocalResourceTest` (8 cases: all three positions, external IRIs, placeholder/introduced exclusions, explicit tag, dead statements, nanopub URI itself, group members); full suite green (779 tests).
- Verified end-to-end on a local instance via the preview flow with "Commenting on something" (untyped `sub:local` subject): the previewed signed nanopub mints `<new-np>#local` in its own namespace, with no trace of the template's artifact code. Also checked that "Defining a new class" (explicit LocalResource+UriPlaceholder suffix field) renders unchanged and "SSSOM FAIR Mapping" (~30 untyped local object IRIs) loads without errors.

Closes #551

🤖 Generated with [Claude Code](https://claude.com/claude-code)