### PR TITLE
feat: language-tag picker for literal placeholders

### DIFF
--- a/docs/language-tag-picker.md
+++ b/docs/language-tag-picker.md
@@ -160,7 +160,7 @@ under `…#comment__2__lang`). Properties this inherits for free:
 - **Per-repetition tags:** each repetition group has its own derived key, so
   repetition 1 can be `@de` and repetition 2 `@fr`.
 - **URL-parameter prefill:** the same postfix-named parameter convention gives
-  `?comment=Haus&comment__lang=de` with no extra code beyond the usual
+  `?param_comment=Haus&param_comment__lang=de` with no extra code beyond the usual
   `hasParam`/`getParam` lookup in the component constructor.
 - **No collisions with the repetition machinery:** `finalizeStatements` probes only
   numeric suffixes (`postfix + "__" + i`, `TemplateContext.java:120-128`), and
@@ -279,7 +279,7 @@ Each step compiles and is testable on its own:
 2. **Form UI + publish path:** dropdown component with model/param wiring,
    validation, `processValue` change. Manual check in the dev jetty: enter text, pick
    tag, publish; verify `@tag` in the published TriG; repetition with two languages;
-   `?comment__lang=de` prefill.
+   `?param_comment__lang=de` prefill.
 3. **Fill/unification:** relaxation in `LiteralTextfieldItem` and `ReadonlyItem`.
    Tests: view a nanopub with `@fr` under an unrestricted picker (unifies, tag
    shown); under a restricted set excluding `fr` (falls back to generic display);

--- a/src/main/java/com/knowledgepixels/nanodash/component/LanguageTagChoiceProvider.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/LanguageTagChoiceProvider.java
@@ -1,0 +1,69 @@
+package com.knowledgepixels.nanodash.component;
+
+import org.wicketstuff.select2.ChoiceProvider;
+import org.wicketstuff.select2.Response;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Provides the language-tag choices for a language-tag-selectable literal
+ * placeholder: either the template's restricted set, or the full ISO 639-1
+ * list (with free entry of other BCP 47 tags handled by select2 tags mode).
+ */
+public class LanguageTagChoiceProvider extends ChoiceProvider<String> {
+
+    private static final List<String> ISO_LANGUAGES = Arrays.asList(Locale.getISOLanguages());
+
+    private final List<String> possibleTags;
+
+    /**
+     * Creates a provider offering the given tags, or the ISO 639-1 languages if null.
+     *
+     * @param possibleTags the allowed language tags, or null for the unrestricted list
+     */
+    public LanguageTagChoiceProvider(List<String> possibleTags) {
+        this.possibleTags = possibleTags;
+    }
+
+    @Override
+    public String getDisplayValue(String tag) {
+        if (tag == null || tag.isEmpty()) return "";
+        String name = Locale.forLanguageTag(tag).getDisplayName(Locale.ENGLISH);
+        if (name == null || name.isEmpty() || name.equals(tag)) return tag;
+        return tag + " — " + name;
+    }
+
+    @Override
+    public String getIdValue(String object) {
+        return object;
+    }
+
+    // Getting strange errors with Tomcat if this method is not overridden:
+    @Override
+    public void detach() {
+    }
+
+    @Override
+    public void query(String term, int page, Response<String> response) {
+        List<String> tags = (possibleTags == null) ? ISO_LANGUAGES : possibleTags;
+        if (term == null || term.isEmpty()) {
+            response.addAll(tags);
+            return;
+        }
+        String t = term.toLowerCase();
+        for (String tag : tags) {
+            if (tag.toLowerCase().contains(t) || getDisplayValue(tag).toLowerCase().contains(t)) {
+                response.add(tag);
+            }
+        }
+    }
+
+    @Override
+    public Collection<String> toChoices(Collection<String> ids) {
+        return ids;
+    }
+
+}

--- a/src/main/java/com/knowledgepixels/nanodash/component/LiteralTextareaItem.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/LiteralTextareaItem.html
@@ -8,6 +8,7 @@
 
 <wicket:panel>
 <span class="nowrap"><span class="quote">"</span><textarea class="nanopub-textfield" wicket:id="textarea" rows="4"></textarea><span class="quote">"</span></span>
+<select wicket:id="langchoice" class="langtag-select"></select>
 <span wicket:id="language" class="litlang">language</span>
 <span wicket:id="datatype" class="litdatatype">datatype</span>
 </wicket:panel>

--- a/src/main/java/com/knowledgepixels/nanodash/component/LiteralTextfieldItem.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/LiteralTextfieldItem.html
@@ -8,6 +8,7 @@
 
 <wicket:panel>
 <span class="nowrap"><span class="quote">"</span><input type="text" class="nanopub-textfield" wicket:id="textfield" /><span class="quote">"</span></span>
+<select wicket:id="langchoice" class="langtag-select"></select>
 <span wicket:id="language" class="litlang">language</span>
 <span wicket:id="datatype" class="litdatatype">datatype</span>
 </wicket:panel>

--- a/src/main/java/com/knowledgepixels/nanodash/component/LiteralTextfieldItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/LiteralTextfieldItem.java
@@ -8,11 +8,13 @@ import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.Component;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.form.OnChangeAjaxBehavior;
+import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.form.AbstractTextComponent;
 import org.apache.wicket.markup.html.form.TextField;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
+import org.apache.wicket.validation.IValidatable;
 import org.apache.wicket.validation.IValidator;
 import org.apache.wicket.validation.ValidationError;
 import org.eclipse.rdf4j.model.IRI;
@@ -22,6 +24,9 @@ import org.eclipse.rdf4j.model.util.Literals;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.wicketstuff.select2.Select2Choice;
+
+import java.util.List;
 
 /**
  * A component that represents a text field for entering literal values.
@@ -31,6 +36,8 @@ public class LiteralTextfieldItem extends AbstractContextComponent {
     private AbstractTextComponent<String> textfield;
     private Label languageComp, datatypeComp;
     private IModel<String> languageModel, datatypeModel;
+    private Select2Choice<String> langChoice;
+    private IModel<String> langModel;
     private final String regex;
     private final IRI iri;
     private final static Logger logger = LoggerFactory.getLogger(LiteralTextfieldItem.class);
@@ -94,18 +101,74 @@ public class LiteralTextfieldItem extends AbstractContextComponent {
         languageComp = new Label("language", languageModel);
         datatypeModel = Model.of("");
         datatypeComp = new Label("datatype", datatypeModel);
-        if (template.getLanguageTag(iri) != null) {
-            languageModel.setObject("(" + template.getLanguageTag(iri) + ")");
-            datatypeComp.setVisible(false);
-        } else if (template.getDatatype(iri) != null && !template.getDatatype(iri).equals(XSD.STRING)) {
-            datatypeModel.setObject("(" + template.getDatatype(iri).stringValue().replace(XSD.NAMESPACE, "xsd:") + ")");
+        if (template.isLanguageTagSelectable(iri)) {
             languageComp.setVisible(false);
+            datatypeComp.setVisible(false);
+            initLanguageChoice(optional);
         } else {
-            datatypeComp.setVisible(false);
-            languageComp.setVisible(false);
+            if (template.getLanguageTag(iri) != null) {
+                languageModel.setObject("(" + template.getLanguageTag(iri) + ")");
+                datatypeComp.setVisible(false);
+            } else if (template.getDatatype(iri) != null && !template.getDatatype(iri).equals(XSD.STRING)) {
+                datatypeModel.setObject("(" + template.getDatatype(iri).stringValue().replace(XSD.NAMESPACE, "xsd:") + ")");
+                languageComp.setVisible(false);
+            } else {
+                datatypeComp.setVisible(false);
+                languageComp.setVisible(false);
+            }
+            add(new WebMarkupContainer("langchoice").setVisible(false));
         }
         add(languageComp);
         add(datatypeComp);
+    }
+
+    /**
+     * Sets up the language-tag dropdown for a language-tag-selectable placeholder.
+     */
+    @SuppressWarnings("unchecked")
+    private void initLanguageChoice(boolean optional) {
+        final Template template = context.getTemplate();
+        IRI langModelKey = TemplateContext.getLanguageModelKey(iri);
+        langModel = (IModel<String>) context.getComponentModels().get(langModelKey);
+        if (langModel == null) {
+            langModel = Model.of("");
+            context.getComponentModels().put(langModelKey, langModel);
+            String langParam = Utils.getUriPostfix(iri) + TemplateContext.LANGUAGE_SUFFIX;
+            if (context.hasParam(langParam)) {
+                langModel.setObject(context.getParam(langParam));
+            } else if (template.getLanguageTag(iri) != null) {
+                langModel.setObject(template.getLanguageTag(iri));
+            }
+        }
+        List<String> possibleTags = template.getPossibleLanguageTags(iri);
+        langChoice = new Select2Choice<String>("langchoice", langModel, new LanguageTagChoiceProvider(possibleTags)) {
+
+            // A tag is also required whenever the paired text field has input, even on
+            // optional fields, so a language-tagged literal is never published untagged.
+            // Reading the raw request parameter keeps this independent of processing order.
+            @Override
+            public boolean isRequired() {
+                if (super.isRequired()) return true;
+                String raw = getTextComponent().getInput();
+                return raw != null && !raw.isBlank();
+            }
+
+        };
+        if (!optional) langChoice.setRequired(true);
+        String label = template.getLabel(iri);
+        langChoice.setLabel(Model.of("language" + (label == null ? "" : " of '" + label + "'")));
+        langChoice.getSettings().setCloseOnSelect(true);
+        langChoice.getSettings().setPlaceholder("language");
+        langChoice.getSettings().setAllowClear(true);
+        langChoice.getSettings().setDropdownCssClass("langtag-dropdown");
+        langChoice.getSettings().setWidth("10em");
+        if (possibleTags == null) {
+            langChoice.getSettings().setTags(true);
+        }
+        langChoice.add(new ValueItem.KeepValueAfterRefreshBehavior());
+        langChoice.add(new LangTagValidator(possibleTags));
+        context.getComponents().add(langChoice);
+        add(langChoice);
     }
 
     /**
@@ -134,6 +197,38 @@ public class LiteralTextfieldItem extends AbstractContextComponent {
     @Override
     public void removeFromContext() {
         context.getComponents().remove(getTextComponent());
+        if (langChoice != null) {
+            context.getComponents().remove(langChoice);
+        }
+    }
+
+    /**
+     * Validator for user-chosen language tags.
+     */
+    protected class LangTagValidator extends InvalidityHighlighting implements IValidator<String> {
+
+        private final List<String> possibleTags;
+
+        /**
+         * Creates a validator against the given allowed tags, or any well-formed tag if null.
+         *
+         * @param possibleTags the allowed (normalized) language tags, or null for unrestricted
+         */
+        public LangTagValidator(List<String> possibleTags) {
+            this.possibleTags = possibleTags;
+        }
+
+        @Override
+        public void validate(IValidatable<String> s) {
+            String tag = s.getValue();
+            if (tag == null || tag.isEmpty()) return;
+            if (!tag.matches("[a-zA-Z]{2,8}(-[0-9a-zA-Z]{1,8})*")) {
+                s.error(new ValidationError("'" + tag + "' is not a valid language tag"));
+            } else if (possibleTags != null && !possibleTags.contains(Literals.normalizeLanguageTag(tag))) {
+                s.error(new ValidationError("Language '" + tag + "' is not among the allowed languages"));
+            }
+        }
+
     }
 
     /**
@@ -145,6 +240,24 @@ public class LiteralTextfieldItem extends AbstractContextComponent {
         if (v instanceof Literal vL) {
             if (regex != null && !vL.stringValue().matches(regex)) {
                 return false;
+            }
+            if (context.getTemplate().isLanguageTagSelectable(iri)) {
+                // The value must carry a tag from the allowed set (any tag if
+                // unrestricted); a declared nt:hasLanguageTag is only the picker's
+                // default, not a constraint. Tag checks come before the empty-text
+                // shortcut so out-of-set values never unify vacuously.
+                if (vL.getLanguage().isEmpty()) return false;
+                String vTag = Literals.normalizeLanguageTag(vL.getLanguage().get());
+                List<String> possibleTags = context.getTemplate().getPossibleLanguageTags(iri);
+                if (possibleTags != null && !possibleTags.contains(vTag)) return false;
+                if (getTextComponent().getModelObject() == null || getTextComponent().getModelObject().isEmpty()) {
+                    return true;
+                }
+                if (langModel.getObject() != null && !langModel.getObject().isEmpty()
+                        && !vTag.equals(Literals.normalizeLanguageTag(langModel.getObject()))) {
+                    return false;
+                }
+                return vL.stringValue().equals(getTextComponent().getModelObject());
             }
             if (getTextComponent().getModelObject() == null || getTextComponent().getModelObject().isEmpty()) {
                 return true;
@@ -174,15 +287,18 @@ public class LiteralTextfieldItem extends AbstractContextComponent {
         if (!isUnifiableWith(v)) throw new UnificationException(v.stringValue());
         Literal vL = (Literal) v;
         getTextComponent().setModelObject(vL.stringValue());
-        if (context.getTemplate().getLanguageTag(iri) == null && vL.getLanguage().isPresent()) {
+        if (context.getTemplate().isLanguageTagSelectable(iri)) {
+            // The dropdown shows the tag; the static "(tag)" label stays hidden.
+            if (vL.getLanguage().isPresent()) {
+                langModel.setObject(Literals.normalizeLanguageTag(vL.getLanguage().get()));
+            }
+        } else if (context.getTemplate().getLanguageTag(iri) == null && vL.getLanguage().isPresent()) {
             languageModel.setObject("(" + vL.getLanguage().get().toLowerCase() + ")");
             languageComp.setVisible(true);
         } else if (context.getTemplate().getDatatype(iri) == null && !vL.getDatatype().equals(XSD.STRING)) {
             datatypeModel.setObject("(" + vL.getDatatype().stringValue().replace(XSD.NAMESPACE, "xsd:") + ")");
             datatypeComp.setVisible(true);
         }
-
-        getTextComponent().setModelObject(v.stringValue());
     }
 
     /**

--- a/src/main/java/com/knowledgepixels/nanodash/component/ReadonlyItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/ReadonlyItem.java
@@ -44,6 +44,7 @@ import org.slf4j.LoggerFactory;
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -411,7 +412,17 @@ public class ReadonlyItem extends AbstractContextComponent {
             }
             String languagetag = template.getLanguageTag(iri);
             IRI datatype = template.getDatatype(iri);
-            if (languagetag != null) {
+            if (template.isLanguageTagSelectable(iri)) {
+                // Any tag from the allowed set unifies (any tag at all if unrestricted);
+                // a declared nt:hasLanguageTag is only the picker's default.
+                if (vL.getLanguage().isEmpty()) {
+                    return false;
+                }
+                List<String> possibleTags = template.getPossibleLanguageTags(iri);
+                if (possibleTags != null && !possibleTags.contains(Literals.normalizeLanguageTag(vL.getLanguage().get()))) {
+                    return false;
+                }
+            } else if (languagetag != null) {
                 if (vL.getLanguage().isEmpty() || !Literals.normalizeLanguageTag(vL.getLanguage().get()).equals(languagetag)) {
                     return false;
                 }

--- a/src/main/java/com/knowledgepixels/nanodash/component/StatementItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/StatementItem.java
@@ -528,22 +528,26 @@ public class StatementItem extends Panel {
         private void remove() {
             String thisSuffix = getRepeatSuffix();
             for (IRI iriBase : iriSet) {
-                IRI thisIri = vf.createIRI(iriBase + thisSuffix);
-                if (context.getComponentModels().containsKey(thisIri)) {
-                    IModel swapModel1 = (IModel) context.getComponentModels().get(thisIri);
-                    for (int i = getRepeatIndex() + 1; i < repetitionGroups.size(); i++) {
-                        IModel swapModel2 = (IModel) context.getComponentModels().get(vf.createIRI(iriBase + getRepeatSuffix(i)));
-                        if (swapModel1 != null && swapModel2 != null) {
-                            swapModel1.setObject(swapModel2.getObject());
+                // Shift the value model and any derived model (e.g. the language-tag
+                // model of a language-tag-selectable literal placeholder) alike.
+                for (String derived : new String[]{"", TemplateContext.LANGUAGE_SUFFIX}) {
+                    IRI thisIri = vf.createIRI(iriBase + thisSuffix + derived);
+                    if (context.getComponentModels().containsKey(thisIri)) {
+                        IModel swapModel1 = (IModel) context.getComponentModels().get(thisIri);
+                        for (int i = getRepeatIndex() + 1; i < repetitionGroups.size(); i++) {
+                            IModel swapModel2 = (IModel) context.getComponentModels().get(vf.createIRI(iriBase + getRepeatSuffix(i) + derived));
+                            if (swapModel1 != null && swapModel2 != null) {
+                                swapModel1.setObject(swapModel2.getObject());
+                            }
+                            // Drop any retained rawInput so the shifted model value is rendered
+                            // instead of the user's previous (post-validation-error) entry.
+                            clearInputForModel(swapModel1);
+                            swapModel1 = swapModel2;
                         }
-                        // Drop any retained rawInput so the shifted model value is rendered
-                        // instead of the user's previous (post-validation-error) entry.
-                        clearInputForModel(swapModel1);
-                        swapModel1 = swapModel2;
-                    }
-                    if (swapModel1 != null) {
-                        swapModel1.setObject(null);
-                        clearInputForModel(swapModel1);
+                        if (swapModel1 != null) {
+                            swapModel1.setObject(null);
+                            clearInputForModel(swapModel1);
+                        }
                     }
                 }
             }

--- a/src/main/java/com/knowledgepixels/nanodash/template/Template.java
+++ b/src/main/java/com/knowledgepixels/nanodash/template/Template.java
@@ -34,8 +34,18 @@ public class Template implements Serializable {
      */
     public static final String DEFAULT_TARGET_NAMESPACE = "https://w3id.org/np/";
 
-    // TODO Move this to the other ntemplate vocabulary terms in nanopub-java:
+    // TODO Move these to the other ntemplate vocabulary terms in nanopub-java:
     private static final IRI ADVANCED_STATEMENT = vf.createIRI("https://w3id.org/np/o/ntemplate/AdvancedStatement");
+
+    /**
+     * Type of a literal placeholder whose language tag is selected by the user at fill time.
+     */
+    public static final IRI LANGUAGE_TAGGED_LITERAL_PLACEHOLDER = vf.createIRI("https://w3id.org/np/o/ntemplate/LanguageTaggedLiteralPlaceholder");
+
+    /**
+     * Predicate restricting the language tags offered by a language-tag picker.
+     */
+    public static final IRI POSSIBLE_LANGUAGE_TAG = vf.createIRI("https://w3id.org/np/o/ntemplate/possibleLanguageTag");
 
     private final Nanopub nanopub;
     private String label;
@@ -53,6 +63,7 @@ public class Template implements Serializable {
     private Map<IRI, String> labelMap = new HashMap<>();
     private Map<IRI, IRI> datatypeMap = new HashMap<>();
     private Map<IRI, String> languageTagMap = new HashMap<>();
+    private Map<IRI, List<String>> possibleLanguageTagMap = new HashMap<>();
     private Map<IRI, String> prefixMap = new HashMap<>();
     private Map<IRI, String> prefixLabelMap = new HashMap<>();
     private Map<IRI, String> regexMap = new HashMap<>();
@@ -238,6 +249,17 @@ public class Template implements Serializable {
     public String getLanguageTag(IRI iri) {
         iri = transform(iri);
         return languageTagMap.get(iri);
+    }
+
+    /**
+     * Returns the language tags a language-tag-selectable placeholder is restricted to.
+     *
+     * @param iri the literal placeholder IRI.
+     * @return the normalized allowed language tags, or null if unrestricted.
+     */
+    public List<String> getPossibleLanguageTags(IRI iri) {
+        iri = transform(iri);
+        return possibleLanguageTagMap.get(iri);
     }
 
     /**
@@ -476,7 +498,19 @@ public class Template implements Serializable {
      */
     public boolean isLiteralPlaceholder(IRI iri) {
         iri = transform(iri);
-        return typeMap.containsKey(iri) && (typeMap.get(iri).contains(NTEMPLATE.LITERAL_PLACEHOLDER) || typeMap.get(iri).contains(NTEMPLATE.LONG_LITERAL_PLACEHOLDER));
+        return typeMap.containsKey(iri) && (typeMap.get(iri).contains(NTEMPLATE.LITERAL_PLACEHOLDER) || typeMap.get(iri).contains(NTEMPLATE.LONG_LITERAL_PLACEHOLDER)
+                || typeMap.get(iri).contains(LANGUAGE_TAGGED_LITERAL_PLACEHOLDER));
+    }
+
+    /**
+     * Checks if the given literal placeholder lets the user select the language tag at fill time.
+     *
+     * @param iri the IRI to check.
+     * @return true if the IRI is a language-tag-selectable literal placeholder, false otherwise.
+     */
+    public boolean isLanguageTagSelectable(IRI iri) {
+        iri = transform(iri);
+        return typeMap.containsKey(iri) && typeMap.get(iri).contains(LANGUAGE_TAGGED_LITERAL_PLACEHOLDER);
     }
 
     /**
@@ -565,6 +599,7 @@ public class Template implements Serializable {
             if (t.equals(NTEMPLATE.AGENT_PLACEHOLDER)) return true;
             if (t.equals(NTEMPLATE.LITERAL_PLACEHOLDER)) return true;
             if (t.equals(NTEMPLATE.LONG_LITERAL_PLACEHOLDER)) return true;
+            if (t.equals(LANGUAGE_TAGGED_LITERAL_PLACEHOLDER)) return true;
             if (t.equals(NTEMPLATE.SEQUENCE_ELEMENT_PLACEHOLDER)) return true;
             if (t.equals(NTEMPLATE.ROOT_NANOPUB_PLACEHOLDER)) return true;
         }
@@ -790,6 +825,18 @@ public class Template implements Serializable {
             processShaclTemplate(templateNp);
         }
         tagUntypedLocalIrisAsLocalResources(templateNp);
+        checkLanguageTagPlaceholders();
+    }
+
+    // A literal is either language-tagged or datatyped, never both; the language-tag
+    // picker wins so the placeholder keeps rendering as a text field.
+    private void checkLanguageTagPlaceholders() {
+        for (Map.Entry<IRI, List<IRI>> e : typeMap.entrySet()) {
+            if (e.getValue().contains(LANGUAGE_TAGGED_LITERAL_PLACEHOLDER) && datatypeMap.containsKey(e.getKey())) {
+                logger.warn("Ignoring datatype {} on language-tag-selectable placeholder {}", datatypeMap.get(e.getKey()), e.getKey());
+                datatypeMap.remove(e.getKey());
+            }
+        }
     }
 
     // Local IRIs in used statement positions that carry no identity type (no placeholder
@@ -911,6 +958,8 @@ public class Template implements Serializable {
                 datatypeMap.put(subj, objIri);
             } else if (pred.equals(NTEMPLATE.HAS_LANGUAGE_TAG) && obj instanceof Literal) {
                 languageTagMap.put(subj, Literals.normalizeLanguageTag(objS));
+            } else if (pred.equals(POSSIBLE_LANGUAGE_TAG) && obj instanceof Literal) {
+                possibleLanguageTagMap.computeIfAbsent(subj, k -> new ArrayList<>()).add(Literals.normalizeLanguageTag(objS));
             } else if (pred.equals(NTEMPLATE.HAS_PREFIX) && obj instanceof Literal) {
                 prefixMap.put(subj, objS);
             } else if (pred.equals(NTEMPLATE.HAS_PREFIX_LABEL) && obj instanceof Literal) {
@@ -1105,6 +1154,8 @@ public class Template implements Serializable {
                 datatypeMap.put(subj, objIri);
             } else if (pred.equals(NTEMPLATE.HAS_LANGUAGE_TAG) && obj instanceof Literal) {
                 languageTagMap.put(subj, Literals.normalizeLanguageTag(objS));
+            } else if (pred.equals(POSSIBLE_LANGUAGE_TAG) && obj instanceof Literal) {
+                possibleLanguageTagMap.computeIfAbsent(subj, k -> new ArrayList<>()).add(Literals.normalizeLanguageTag(objS));
             } else if (pred.equals(NTEMPLATE.HAS_PREFIX) && obj instanceof Literal) {
                 prefixMap.put(subj, objS);
             } else if (pred.equals(NTEMPLATE.HAS_PREFIX_LABEL) && obj instanceof Literal) {

--- a/src/main/java/com/knowledgepixels/nanodash/template/TemplateContext.java
+++ b/src/main/java/com/knowledgepixels/nanodash/template/TemplateContext.java
@@ -14,6 +14,7 @@ import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.util.Literals;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
 import org.nanopub.*;
@@ -259,6 +260,23 @@ public class TemplateContext implements Serializable {
     }
 
     /**
+     * Suffix under which the language-tag model of a language-tag-selectable literal
+     * placeholder is keyed in the component models (appended after any repetition suffix).
+     */
+    public static final String LANGUAGE_SUFFIX = "__lang";
+
+    /**
+     * Returns the component-model key for the language tag of the given literal
+     * placeholder IRI, which must already carry its repetition suffix if any.
+     *
+     * @param iri the (repetition-suffixed) literal placeholder IRI
+     * @return the derived key for the language-tag model
+     */
+    public static IRI getLanguageModelKey(IRI iri) {
+        return vf.createIRI(iri.stringValue() + LANGUAGE_SUFFIX);
+    }
+
+    /**
      * Returns the introduced IRIs in this context.
      *
      * @return a set of introduced IRIs
@@ -406,8 +424,14 @@ public class TemplateContext implements Serializable {
             } else {
                 String tfObject = (String) tfObjectGeneric;
                 if (tf != null && tfObject != null && !tfObject.isEmpty()) {
-                    if (datatype != null) {
-                        processedValue = vf.createLiteral(tfObject, datatype);
+                    if (template.isLanguageTagSelectable(iri)) {
+                        IModel<?> langModel = componentModels.get(getLanguageModelKey(iri));
+                        Object chosenTag = (langModel == null) ? null : langModel.getObject();
+                        if (chosenTag != null && !chosenTag.toString().isEmpty()) {
+                            processedValue = vf.createLiteral(tfObject, Literals.normalizeLanguageTag(chosenTag.toString()));
+                        }
+                        // No tag chosen: leave the value unresolved rather than emitting an
+                        // untagged literal; form validation blocks this case on submit.
                     } else if (languageTag != null) {
                         processedValue = vf.createLiteral(tfObject, languageTag);
                     } else {

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -892,6 +892,12 @@ a.actionlink {
   border-top: solid 1px #aaa;
 }
 
+/* Language-tag pickers get a compact dropdown (overrides the general min-width above
+   and the mobile override further down): */
+.select2-dropdown.select2-dropdown--below.langtag-dropdown {
+  min-width: 12em !important;
+}
+
 button.select2-selection__clear {
   color: #888;
 }

--- a/src/test/java/com/knowledgepixels/nanodash/component/LiteralTextfieldLangItemTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/component/LiteralTextfieldLangItemTest.java
@@ -1,0 +1,196 @@
+package com.knowledgepixels.nanodash.component;
+
+import com.knowledgepixels.nanodash.WicketApplication;
+import com.knowledgepixels.nanodash.template.ContextType;
+import com.knowledgepixels.nanodash.template.Template;
+import com.knowledgepixels.nanodash.template.TemplateContext;
+import com.knowledgepixels.nanodash.template.TemplateData;
+import com.knowledgepixels.nanodash.template.TemplateTestUtil;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.util.tester.WicketTester;
+import org.apache.wicket.validation.Validatable;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.nanopub.NanopubCreator;
+import org.nanopub.vocabulary.NTEMPLATE;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+/**
+ * Component-level tests for the language-tag dropdown of
+ * language-tag-selectable literal placeholders (LiteralTextfieldItem).
+ */
+public class LiteralTextfieldLangItemTest {
+
+    private static final ValueFactory vf = SimpleValueFactory.getInstance();
+
+    private static final String NP_URI = "https://w3id.org/np/RAAbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_AbCdE";
+    private static final IRI COMMENT = vf.createIRI(NP_URI + "/comment");
+
+    private MockedStatic<TemplateData> templateDataMockedStatic;
+
+    @BeforeEach
+    void setUp() {
+        new WicketTester(new WicketApplication());
+        templateDataMockedStatic = mockStatic(TemplateData.class);
+    }
+
+    @AfterEach
+    void tearDown() {
+        templateDataMockedStatic.close();
+    }
+
+    /**
+     * Builds a one-statement template (subject rdfs:comment [comment]) and returns
+     * an uninitialized context for it; call setParam before initStatements.
+     */
+    private TemplateContext contextFor(boolean selectable, String defaultTag, String... possibleTags) throws Exception {
+        NanopubCreator creator = new NanopubCreator(NP_URI);
+        creator.addProvenanceStatement(vf.createStatement(creator.getAssertionUri(), RDFS.SEEALSO, creator.getAssertionUri()));
+        creator.addPubinfoStatement(vf.createStatement(creator.getNanopubUri(), RDFS.SEEALSO, creator.getNanopubUri()));
+        IRI templateNode = creator.getAssertionUri();
+        IRI st1 = vf.createIRI(NP_URI + "/st1");
+        creator.addAssertionStatement(templateNode, RDF.TYPE, NTEMPLATE.ASSERTION_TEMPLATE);
+        creator.addAssertionStatement(templateNode, RDFS.LABEL, vf.createLiteral("Component test template"));
+        creator.addAssertionStatement(templateNode, NTEMPLATE.HAS_STATEMENT, st1);
+        creator.addAssertionStatement(st1, RDF.SUBJECT, vf.createIRI("http://example.com/subject"));
+        creator.addAssertionStatement(st1, RDF.PREDICATE, RDFS.COMMENT);
+        creator.addAssertionStatement(st1, RDF.OBJECT, COMMENT);
+        creator.addAssertionStatement(COMMENT, RDF.TYPE, NTEMPLATE.LITERAL_PLACEHOLDER);
+        if (selectable) {
+            creator.addAssertionStatement(COMMENT, RDF.TYPE, Template.LANGUAGE_TAGGED_LITERAL_PLACEHOLDER);
+        }
+        if (defaultTag != null) {
+            creator.addAssertionStatement(COMMENT, NTEMPLATE.HAS_LANGUAGE_TAG, vf.createLiteral(defaultTag));
+        }
+        for (String tag : possibleTags) {
+            creator.addAssertionStatement(COMMENT, Template.POSSIBLE_LANGUAGE_TAG, vf.createLiteral(tag));
+        }
+        creator.addAssertionStatement(COMMENT, RDFS.LABEL, vf.createLiteral("comment"));
+        Template template = TemplateTestUtil.parseTemplate(creator.finalizeNanopub());
+
+        TemplateData templateDataMock = mock(TemplateData.class);
+        templateDataMockedStatic.when(TemplateData::get).thenReturn(templateDataMock);
+        when(templateDataMock.getTemplate(NP_URI)).thenReturn(template);
+
+        return new TemplateContext(ContextType.ASSERTION, NP_URI, "statement", (String) null);
+    }
+
+    @SuppressWarnings("unchecked")
+    private IModel<String> langModel(TemplateContext context) {
+        return (IModel<String>) context.getComponentModels().get(TemplateContext.getLanguageModelKey(COMMENT));
+    }
+
+    @Test
+    void langModelCreatedAndChoiceRegistered() throws Exception {
+        TemplateContext context = contextFor(true, null);
+        context.initStatements();
+        assertTrue(context.getComponentModels().containsKey(TemplateContext.getLanguageModelKey(COMMENT)));
+        assertEquals(2, context.getComponents().size(), "text field and language choice must both be registered");
+    }
+
+    @Test
+    void plainPlaceholderGetsNoLangModel() throws Exception {
+        TemplateContext context = contextFor(false, null);
+        context.initStatements();
+        assertFalse(context.getComponentModels().containsKey(TemplateContext.getLanguageModelKey(COMMENT)));
+        assertEquals(1, context.getComponents().size());
+    }
+
+    @Test
+    void defaultTagPreselects() throws Exception {
+        TemplateContext context = contextFor(true, "en");
+        context.initStatements();
+        assertEquals("en", langModel(context).getObject());
+    }
+
+    @Test
+    void paramBeatsDefault() throws Exception {
+        TemplateContext context = contextFor(true, "en");
+        context.setParam("comment__lang", "fr");
+        context.initStatements();
+        assertEquals("fr", langModel(context).getObject());
+    }
+
+    @Test
+    void noDefaultLeavesEmpty() throws Exception {
+        TemplateContext context = contextFor(true, null);
+        context.initStatements();
+        assertEquals("", langModel(context).getObject());
+    }
+
+    @Test
+    void removeFromContextDeregistersBothComponents() throws Exception {
+        TemplateContext context = contextFor(true, null);
+        context.initStatements();
+        assertEquals(2, context.getComponents().size());
+        LiteralTextfieldItem extra = new LiteralTextfieldItem("value", COMMENT, true, context);
+        assertEquals(4, context.getComponents().size());
+        extra.removeFromContext();
+        assertEquals(2, context.getComponents().size());
+    }
+
+    @Test
+    void validatorAcceptsFreeWellFormedTags() throws Exception {
+        TemplateContext context = contextFor(true, null);
+        context.initStatements();
+        LiteralTextfieldItem item = new LiteralTextfieldItem("value", COMMENT, true, context);
+        LiteralTextfieldItem.LangTagValidator validator = item.new LangTagValidator(null);
+        for (String ok : new String[]{"en", "en-GB", "zh-Hant", "de"}) {
+            Validatable<String> v = new Validatable<>(ok);
+            validator.validate(v);
+            assertTrue(v.isValid(), ok + " must be accepted");
+        }
+        for (String bad : new String[]{"x", "x!", "en-", "-en", "12"}) {
+            Validatable<String> v = new Validatable<>(bad);
+            validator.validate(v);
+            assertFalse(v.isValid(), bad + " must be rejected");
+        }
+    }
+
+    @Test
+    void validatorEnforcesRestrictedSet() throws Exception {
+        TemplateContext context = contextFor(true, null, "en", "de");
+        context.initStatements();
+        LiteralTextfieldItem item = new LiteralTextfieldItem("value", COMMENT, true, context);
+        LiteralTextfieldItem.LangTagValidator validator = item.new LangTagValidator(List.of("en", "de"));
+        Validatable<String> ok = new Validatable<>("de");
+        validator.validate(ok);
+        assertTrue(ok.isValid());
+        Validatable<String> bad = new Validatable<>("fr");
+        validator.validate(bad);
+        assertFalse(bad.isValid());
+        // Tags are compared normalized:
+        Validatable<String> okNormalized = new Validatable<>("DE");
+        validator.validate(okNormalized);
+        assertTrue(okNormalized.isValid());
+    }
+
+    @Test
+    void emptyTagIsLeftToRequiredCheck() throws Exception {
+        TemplateContext context = contextFor(true, null);
+        context.initStatements();
+        LiteralTextfieldItem item = new LiteralTextfieldItem("value", COMMENT, true, context);
+        LiteralTextfieldItem.LangTagValidator validator = item.new LangTagValidator(null);
+        Validatable<String> v = new Validatable<>(null);
+        validator.validate(v);
+        assertTrue(v.isValid());
+        assertNull(v.getValue());
+    }
+
+}

--- a/src/test/java/com/knowledgepixels/nanodash/template/LanguageTagFillTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/template/LanguageTagFillTest.java
@@ -1,0 +1,209 @@
+package com.knowledgepixels.nanodash.template;
+
+import com.knowledgepixels.nanodash.WicketApplication;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.util.tester.WicketTester;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.nanopub.Nanopub;
+import org.nanopub.NanopubCreator;
+import org.nanopub.vocabulary.NTEMPLATE;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+/**
+ * Fill/unification tests for language-tag-selectable literal placeholders
+ * (docs/language-tag-picker.md): any tag from the allowed set unifies, the
+ * declared default is not a constraint, untagged literals never unify, and
+ * fixed-tag placeholders keep their strict behavior.
+ */
+public class LanguageTagFillTest {
+
+    private static final ValueFactory vf = SimpleValueFactory.getInstance();
+
+    private static final String NP_URI = "https://w3id.org/np/RAAbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_AbCdE";
+    private static final IRI ST1 = vf.createIRI(NP_URI + "/st1");
+    private static final IRI COMMENT = vf.createIRI(NP_URI + "/comment");
+    private static final IRI SUBJECT = vf.createIRI("http://example.com/subject");
+
+    private MockedStatic<TemplateData> templateDataMockedStatic;
+
+    @BeforeEach
+    void setUp() {
+        new WicketTester(new WicketApplication());
+        templateDataMockedStatic = mockStatic(TemplateData.class);
+    }
+
+    @AfterEach
+    void tearDown() {
+        templateDataMockedStatic.close();
+    }
+
+    /**
+     * Builds a one-statement template (subject rdfs:comment [comment]) and registers
+     * it with the mocked TemplateData.
+     */
+    private void mockTemplate(boolean selectable, String fixedOrDefaultTag, String... possibleTags) throws Exception {
+        NanopubCreator creator = new NanopubCreator(NP_URI);
+        creator.addProvenanceStatement(vf.createStatement(creator.getAssertionUri(), RDFS.SEEALSO, creator.getAssertionUri()));
+        creator.addPubinfoStatement(vf.createStatement(creator.getNanopubUri(), RDFS.SEEALSO, creator.getNanopubUri()));
+        IRI templateNode = creator.getAssertionUri();
+        creator.addAssertionStatement(templateNode, RDF.TYPE, NTEMPLATE.ASSERTION_TEMPLATE);
+        creator.addAssertionStatement(templateNode, RDFS.LABEL, vf.createLiteral("Fill test template"));
+        creator.addAssertionStatement(templateNode, NTEMPLATE.HAS_STATEMENT, ST1);
+        creator.addAssertionStatement(ST1, RDF.SUBJECT, SUBJECT);
+        creator.addAssertionStatement(ST1, RDF.PREDICATE, RDFS.COMMENT);
+        creator.addAssertionStatement(ST1, RDF.OBJECT, COMMENT);
+        creator.addAssertionStatement(COMMENT, RDF.TYPE, NTEMPLATE.LITERAL_PLACEHOLDER);
+        if (selectable) {
+            creator.addAssertionStatement(COMMENT, RDF.TYPE, Template.LANGUAGE_TAGGED_LITERAL_PLACEHOLDER);
+        }
+        if (fixedOrDefaultTag != null) {
+            creator.addAssertionStatement(COMMENT, NTEMPLATE.HAS_LANGUAGE_TAG, vf.createLiteral(fixedOrDefaultTag));
+        }
+        for (String tag : possibleTags) {
+            creator.addAssertionStatement(COMMENT, Template.POSSIBLE_LANGUAGE_TAG, vf.createLiteral(tag));
+        }
+        creator.addAssertionStatement(COMMENT, RDFS.LABEL, vf.createLiteral("comment"));
+        Template template = new Template(creator.finalizeNanopub());
+
+        TemplateData templateDataMock = mock(TemplateData.class);
+        templateDataMockedStatic.when(TemplateData::get).thenReturn(templateDataMock);
+        when(templateDataMock.getTemplate(NP_URI)).thenReturn(template);
+    }
+
+    private static Nanopub dataNanopub(Value comment) throws Exception {
+        NanopubCreator creator = new NanopubCreator("http://purl.org/nanopub/temp/data/");
+        creator.addAssertionStatement(vf.createStatement(SUBJECT, RDFS.COMMENT, comment));
+        creator.addProvenanceStatement(vf.createStatement(creator.getAssertionUri(), RDFS.SEEALSO, creator.getAssertionUri()));
+        creator.addPubinfoStatement(vf.createStatement(creator.getNanopubUri(), RDFS.SEEALSO, creator.getNanopubUri()));
+        return creator.finalizeNanopub();
+    }
+
+    /**
+     * Mirrors the viewer flow: read-only context (ReadonlyItem) filled from the data nanopub.
+     */
+    private TemplateContext fillReadOnly(Nanopub dataNp, ValueFiller filler) {
+        TemplateContext context = new TemplateContext(ContextType.ASSERTION, NP_URI, "statement", dataNp);
+        context.initStatements();
+        filler.fill(context);
+        return context;
+    }
+
+    /**
+     * Mirrors the form flow (derive/supersede): editable context (LiteralTextfieldItem).
+     */
+    private TemplateContext fillEditable(Nanopub dataNp) {
+        TemplateContext context = new TemplateContext(ContextType.ASSERTION, NP_URI, "statement", (String) null);
+        context.initStatements();
+        new ValueFiller(dataNp, ContextType.ASSERTION, true).fill(context);
+        return context;
+    }
+
+    @Test
+    void readOnlyUnifiesAnyTagWhenUnrestricted() throws Exception {
+        mockTemplate(true, null);
+        Nanopub dataNp = dataNanopub(vf.createLiteral("maison", "fr"));
+        ValueFiller filler = new ValueFiller(dataNp, ContextType.ASSERTION, false);
+        TemplateContext context = fillReadOnly(dataNp, filler);
+        assertTrue(context.getStatementItems().get(0).isMatched());
+        assertTrue(filler.getUnusedStatements().isEmpty());
+    }
+
+    @Test
+    void readOnlyRejectsTagOutsideRestrictedSet() throws Exception {
+        mockTemplate(true, null, "en", "de");
+        Nanopub dataNp = dataNanopub(vf.createLiteral("maison", "fr"));
+        ValueFiller filler = new ValueFiller(dataNp, ContextType.ASSERTION, false);
+        TemplateContext context = fillReadOnly(dataNp, filler);
+        assertFalse(context.getStatementItems().get(0).isMatched(),
+                "a tag outside the restricted set must not unify");
+        assertEquals(1, filler.getUnusedStatements().size());
+    }
+
+    @Test
+    void readOnlyAcceptsTagInsideRestrictedSet() throws Exception {
+        mockTemplate(true, null, "en", "de");
+        Nanopub dataNp = dataNanopub(vf.createLiteral("Haus", "de"));
+        ValueFiller filler = new ValueFiller(dataNp, ContextType.ASSERTION, false);
+        TemplateContext context = fillReadOnly(dataNp, filler);
+        assertTrue(context.getStatementItems().get(0).isMatched());
+        assertTrue(filler.getUnusedStatements().isEmpty());
+    }
+
+    @Test
+    void readOnlyRejectsUntaggedLiteral() throws Exception {
+        mockTemplate(true, null);
+        Nanopub dataNp = dataNanopub(vf.createLiteral("maison"));
+        ValueFiller filler = new ValueFiller(dataNp, ContextType.ASSERTION, false);
+        TemplateContext context = fillReadOnly(dataNp, filler);
+        assertFalse(context.getStatementItems().get(0).isMatched(),
+                "an untagged literal must not unify with a language-tagged placeholder");
+    }
+
+    @Test
+    void defaultTagIsNotAConstraint() throws Exception {
+        mockTemplate(true, "en");
+        Nanopub dataNp = dataNanopub(vf.createLiteral("maison", "fr"));
+        ValueFiller filler = new ValueFiller(dataNp, ContextType.ASSERTION, false);
+        TemplateContext context = fillReadOnly(dataNp, filler);
+        assertTrue(context.getStatementItems().get(0).isMatched(),
+                "the declared default must not block other tags");
+    }
+
+    @Test
+    void editableFillSetsBothModelsAndRoundTrips() throws Exception {
+        mockTemplate(true, null);
+        TemplateContext context = fillEditable(dataNanopub(vf.createLiteral("maison", "fr")));
+        assertEquals("maison", context.getComponentModels().get(COMMENT).getObject());
+        IModel<?> langModel = context.getComponentModels().get(TemplateContext.getLanguageModelKey(COMMENT));
+        assertEquals("fr", langModel.getObject(), "fill must set the language model");
+        Value processed = context.processValue(COMMENT);
+        assertTrue(processed instanceof Literal);
+        assertEquals("fr", ((Literal) processed).getLanguage().orElse(null),
+                "the filled tag must round-trip through processValue");
+    }
+
+    @Test
+    void editableFillPreselectedDefaultIsOverwritten() throws Exception {
+        mockTemplate(true, "en");
+        TemplateContext context = fillEditable(dataNanopub(vf.createLiteral("maison", "fr")));
+        IModel<?> langModel = context.getComponentModels().get(TemplateContext.getLanguageModelKey(COMMENT));
+        assertEquals("fr", langModel.getObject(),
+                "the value's tag must win over the pre-selected default");
+    }
+
+    @Test
+    void fixedTagPlaceholderStaysStrict() throws Exception {
+        mockTemplate(false, "en");
+        TemplateContext context = fillEditable(dataNanopub(vf.createLiteral("maison", "fr")));
+        // Pre-entered text simulates the situation where the fixed-tag check applies:
+        assertEquals("maison", context.getComponentModels().get(COMMENT).getObject());
+        Nanopub dataNp2 = dataNanopub(vf.createLiteral("house", "en"));
+        ValueFiller filler = new ValueFiller(dataNp2, ContextType.ASSERTION, false);
+        TemplateContext roContext = fillReadOnly(dataNp2, filler);
+        assertTrue(roContext.getStatementItems().get(0).isMatched(),
+                "matching fixed tag must still unify");
+        Nanopub dataNp3 = dataNanopub(vf.createLiteral("maison", "fr"));
+        ValueFiller filler3 = new ValueFiller(dataNp3, ContextType.ASSERTION, false);
+        TemplateContext roContext3 = fillReadOnly(dataNp3, filler3);
+        assertFalse(roContext3.getStatementItems().get(0).isMatched(),
+                "non-matching fixed tag must still be rejected in read-only display");
+    }
+
+}

--- a/src/test/java/com/knowledgepixels/nanodash/template/LanguageTagPublishTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/template/LanguageTagPublishTest.java
@@ -1,0 +1,202 @@
+package com.knowledgepixels.nanodash.template;
+
+import com.knowledgepixels.nanodash.WicketApplication;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.Model;
+import org.apache.wicket.util.tester.WicketTester;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.nanopub.Nanopub;
+import org.nanopub.NanopubCreator;
+import org.nanopub.vocabulary.NTEMPLATE;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+/**
+ * Publish-path tests for language-tag-selectable literal placeholders
+ * (docs/language-tag-picker.md): the tag chosen in the language model is
+ * attached (normalized) to the published literal; a missing tag never
+ * produces an untagged literal.
+ */
+public class LanguageTagPublishTest {
+
+    private static final ValueFactory vf = SimpleValueFactory.getInstance();
+
+    private static final String NP_URI = "https://w3id.org/np/RAAbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_AbCdE";
+    private static final IRI ST1 = vf.createIRI(NP_URI + "/st1");
+    private static final IRI COMMENT = vf.createIRI(NP_URI + "/comment");
+    private static final IRI SUBJECT = vf.createIRI("http://example.com/subject");
+
+    private MockedStatic<TemplateData> templateDataMockedStatic;
+
+    @BeforeEach
+    void setUp() {
+        new WicketTester(new WicketApplication());
+        templateDataMockedStatic = mockStatic(TemplateData.class);
+    }
+
+    @AfterEach
+    void tearDown() {
+        templateDataMockedStatic.close();
+    }
+
+    /**
+     * Builds a template with one optional statement (subject rdfs:comment [comment])
+     * where the comment placeholder carries the given types, and returns an
+     * initialized context for it.
+     */
+    private TemplateContext contextWith(boolean selectable, String fixedOrDefaultTag) throws Exception {
+        NanopubCreator creator = new NanopubCreator(NP_URI);
+        creator.addProvenanceStatement(vf.createStatement(creator.getAssertionUri(), RDFS.SEEALSO, creator.getAssertionUri()));
+        creator.addPubinfoStatement(vf.createStatement(creator.getNanopubUri(), RDFS.SEEALSO, creator.getNanopubUri()));
+        IRI templateNode = creator.getAssertionUri();
+        creator.addAssertionStatement(templateNode, RDF.TYPE, NTEMPLATE.ASSERTION_TEMPLATE);
+        creator.addAssertionStatement(templateNode, RDFS.LABEL, vf.createLiteral("Language tag test template"));
+        // Constant statement st0 keeps the assertion graph non-empty when the
+        // optional statement st1 is dropped:
+        IRI st0 = vf.createIRI(NP_URI + "/st0");
+        creator.addAssertionStatement(templateNode, NTEMPLATE.HAS_STATEMENT, st0);
+        creator.addAssertionStatement(st0, RDF.SUBJECT, SUBJECT);
+        creator.addAssertionStatement(st0, RDF.PREDICATE, RDF.TYPE);
+        creator.addAssertionStatement(st0, RDF.OBJECT, vf.createIRI("http://example.com/SomeClass"));
+        creator.addAssertionStatement(templateNode, NTEMPLATE.HAS_STATEMENT, ST1);
+        creator.addAssertionStatement(ST1, RDF.TYPE, NTEMPLATE.OPTIONAL_STATEMENT);
+        creator.addAssertionStatement(ST1, RDF.SUBJECT, SUBJECT);
+        creator.addAssertionStatement(ST1, RDF.PREDICATE, RDFS.COMMENT);
+        creator.addAssertionStatement(ST1, RDF.OBJECT, COMMENT);
+        creator.addAssertionStatement(COMMENT, RDF.TYPE, NTEMPLATE.LITERAL_PLACEHOLDER);
+        if (selectable) {
+            creator.addAssertionStatement(COMMENT, RDF.TYPE, Template.LANGUAGE_TAGGED_LITERAL_PLACEHOLDER);
+        }
+        if (fixedOrDefaultTag != null) {
+            creator.addAssertionStatement(COMMENT, NTEMPLATE.HAS_LANGUAGE_TAG, vf.createLiteral(fixedOrDefaultTag));
+        }
+        creator.addAssertionStatement(COMMENT, RDFS.LABEL, vf.createLiteral("comment"));
+        Template template = new Template(creator.finalizeNanopub());
+
+        TemplateData templateDataMock = mock(TemplateData.class);
+        templateDataMockedStatic.when(TemplateData::get).thenReturn(templateDataMock);
+        when(templateDataMock.getTemplate(NP_URI)).thenReturn(template);
+
+        TemplateContext context = new TemplateContext(ContextType.ASSERTION, NP_URI, "statement", (String) null);
+        context.initStatements();
+        return context;
+    }
+
+    @SuppressWarnings("unchecked")
+    private void setText(TemplateContext context, String value) {
+        ((IModel<Object>) context.getComponentModels().get(COMMENT)).setObject(value);
+    }
+
+    private void setLang(TemplateContext context, String tag) {
+        context.getComponentModels().put(TemplateContext.getLanguageModelKey(COMMENT), Model.of(tag));
+    }
+
+    private Nanopub publish(TemplateContext context) throws Exception {
+        NanopubCreator creator = new NanopubCreator("http://purl.org/nanopub/temp/result/");
+        context.propagateStatements(creator);
+        creator.addProvenanceStatement(vf.createStatement(creator.getAssertionUri(), RDFS.SEEALSO, creator.getAssertionUri()));
+        creator.addPubinfoStatement(vf.createStatement(creator.getNanopubUri(), RDFS.SEEALSO, creator.getNanopubUri()));
+        return creator.finalizeNanopub();
+    }
+
+    private static Literal commentLiteral(Nanopub np) {
+        for (Statement st : np.getAssertion()) {
+            if (st.getPredicate().equals(RDFS.COMMENT) && st.getObject() instanceof Literal l) {
+                return l;
+            }
+        }
+        return null;
+    }
+
+    @Test
+    void chosenTagIsPublished() throws Exception {
+        TemplateContext context = contextWith(true, null);
+        setText(context, "Haus");
+        setLang(context, "de");
+        Literal l = commentLiteral(publish(context));
+        assertNotNull(l);
+        assertEquals("Haus", l.stringValue());
+        assertEquals("de", l.getLanguage().orElse(null));
+    }
+
+    @Test
+    void chosenTagIsNormalized() throws Exception {
+        TemplateContext context = contextWith(true, null);
+        setText(context, "hello");
+        setLang(context, "EN-gb");
+        Literal l = commentLiteral(publish(context));
+        assertNotNull(l);
+        assertEquals("en-GB", l.getLanguage().orElse(null));
+    }
+
+    @Test
+    void textWithoutTagIsNeverPublishedUntagged() throws Exception {
+        TemplateContext context = contextWith(true, null);
+        setText(context, "Haus");
+        // no language model at all
+        assertNull(commentLiteral(publish(context)), "optional statement with unresolved object must be dropped");
+    }
+
+    @Test
+    void emptyTagModelIsNeverPublishedUntagged() throws Exception {
+        TemplateContext context = contextWith(true, null);
+        setText(context, "Haus");
+        setLang(context, "");
+        assertNull(commentLiteral(publish(context)));
+    }
+
+    @Test
+    void tagWithoutTextPublishesNothing() throws Exception {
+        TemplateContext context = contextWith(true, null);
+        setLang(context, "de");
+        assertNull(commentLiteral(publish(context)));
+    }
+
+    @Test
+    void preselectedDefaultTagApplies() throws Exception {
+        // The default (nt:hasLanguageTag on a selectable placeholder) pre-fills the
+        // language model when the component is built, so an untouched dropdown
+        // publishes the default tag.
+        TemplateContext context = contextWith(true, "en");
+        setText(context, "Haus");
+        Literal l = commentLiteral(publish(context));
+        assertNotNull(l);
+        assertEquals("en", l.getLanguage().orElse(null));
+    }
+
+    @Test
+    void fixedTagPlaceholderIsUnchanged() throws Exception {
+        TemplateContext context = contextWith(false, "en");
+        setText(context, "house");
+        Literal l = commentLiteral(publish(context));
+        assertNotNull(l);
+        assertEquals("house", l.stringValue());
+        assertEquals("en", l.getLanguage().orElse(null));
+    }
+
+    @Test
+    void plainLiteralPlaceholderIsUnchanged() throws Exception {
+        TemplateContext context = contextWith(false, null);
+        setText(context, "house");
+        Literal l = commentLiteral(publish(context));
+        assertNotNull(l);
+        assertFalse(l.getLanguage().isPresent());
+    }
+
+}

--- a/src/test/java/com/knowledgepixels/nanodash/template/LanguageTagRepetitionTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/template/LanguageTagRepetitionTest.java
@@ -1,0 +1,138 @@
+package com.knowledgepixels.nanodash.template;
+
+import com.knowledgepixels.nanodash.WicketApplication;
+import com.knowledgepixels.nanodash.component.StatementItem;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.Model;
+import org.apache.wicket.util.tester.WicketTester;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.nanopub.NanopubCreator;
+import org.nanopub.vocabulary.NTEMPLATE;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests that removing a repetition group shifts the language-tag models of
+ * language-tag-selectable placeholders alongside the text models
+ * (StatementItem.RepetitionGroup.remove(), docs/language-tag-picker.md).
+ */
+public class LanguageTagRepetitionTest {
+
+    private static final ValueFactory vf = SimpleValueFactory.getInstance();
+
+    private static final String NP_URI = "https://w3id.org/np/RAAbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_AbCdE";
+    private static final IRI ST1 = vf.createIRI(NP_URI + "/st1");
+    private static final IRI COMMENT = vf.createIRI(NP_URI + "/comment");
+    private static final IRI COMMENT_REP1 = vf.createIRI(NP_URI + "/comment__1");
+
+    private MockedStatic<TemplateData> templateDataMockedStatic;
+
+    @BeforeEach
+    void setUp() {
+        new WicketTester(new WicketApplication());
+        templateDataMockedStatic = mockStatic(TemplateData.class);
+    }
+
+    @AfterEach
+    void tearDown() {
+        templateDataMockedStatic.close();
+    }
+
+    private TemplateContext repeatableContext() throws Exception {
+        NanopubCreator creator = new NanopubCreator(NP_URI);
+        creator.addProvenanceStatement(vf.createStatement(creator.getAssertionUri(), RDFS.SEEALSO, creator.getAssertionUri()));
+        creator.addPubinfoStatement(vf.createStatement(creator.getNanopubUri(), RDFS.SEEALSO, creator.getNanopubUri()));
+        IRI templateNode = creator.getAssertionUri();
+        creator.addAssertionStatement(templateNode, RDF.TYPE, NTEMPLATE.ASSERTION_TEMPLATE);
+        creator.addAssertionStatement(templateNode, RDFS.LABEL, vf.createLiteral("Repetition test template"));
+        creator.addAssertionStatement(templateNode, NTEMPLATE.HAS_STATEMENT, ST1);
+        creator.addAssertionStatement(ST1, RDF.TYPE, NTEMPLATE.REPEATABLE_STATEMENT);
+        creator.addAssertionStatement(ST1, RDF.SUBJECT, vf.createIRI("http://example.com/subject"));
+        creator.addAssertionStatement(ST1, RDF.PREDICATE, RDFS.COMMENT);
+        creator.addAssertionStatement(ST1, RDF.OBJECT, COMMENT);
+        creator.addAssertionStatement(COMMENT, RDF.TYPE, NTEMPLATE.LITERAL_PLACEHOLDER);
+        creator.addAssertionStatement(COMMENT, RDF.TYPE, Template.LANGUAGE_TAGGED_LITERAL_PLACEHOLDER);
+        creator.addAssertionStatement(COMMENT, RDFS.LABEL, vf.createLiteral("comment"));
+        Template template = new Template(creator.finalizeNanopub());
+
+        TemplateData templateDataMock = mock(TemplateData.class);
+        templateDataMockedStatic.when(TemplateData::get).thenReturn(templateDataMock);
+        when(templateDataMock.getTemplate(NP_URI)).thenReturn(template);
+
+        TemplateContext context = new TemplateContext(ContextType.ASSERTION, NP_URI, "statement", (String) null);
+        context.initStatements();
+        return context;
+    }
+
+    @SuppressWarnings("unchecked")
+    private IModel<Object> model(TemplateContext context, IRI key) {
+        return (IModel<Object>) context.getComponentModels().get(key);
+    }
+
+    private void removeRepetitionGroup(StatementItem si, int index) throws Exception {
+        Field rgsField = StatementItem.class.getDeclaredField("repetitionGroups");
+        rgsField.setAccessible(true);
+        List<?> rgs = (List<?>) rgsField.get(si);
+        Object rg = rgs.get(index);
+        Method removeMethod = rg.getClass().getDeclaredMethod("remove");
+        removeMethod.setAccessible(true);
+        removeMethod.invoke(rg);
+    }
+
+    @Test
+    void removingRepetitionShiftsTextAndLanguageModels() throws Exception {
+        TemplateContext context = repeatableContext();
+        StatementItem si = context.getStatementItems().get(0);
+        si.addRepetitionGroup();
+        assertEquals(2, si.getRepetitionCount());
+
+        model(context, COMMENT).setObject("Haus");
+        context.getComponentModels().put(TemplateContext.getLanguageModelKey(COMMENT), Model.of("de"));
+        model(context, COMMENT_REP1).setObject("maison");
+        context.getComponentModels().put(TemplateContext.getLanguageModelKey(COMMENT_REP1), Model.of("fr"));
+
+        removeRepetitionGroup(si, 0);
+
+        assertEquals("maison", model(context, COMMENT).getObject());
+        assertEquals("fr", model(context, TemplateContext.getLanguageModelKey(COMMENT)).getObject(),
+                "language model must shift together with the text model");
+        assertNull(model(context, COMMENT_REP1).getObject());
+        assertNull(model(context, TemplateContext.getLanguageModelKey(COMMENT_REP1)).getObject());
+    }
+
+    @Test
+    void removingLastRepetitionClearsBothModels() throws Exception {
+        TemplateContext context = repeatableContext();
+        StatementItem si = context.getStatementItems().get(0);
+        si.addRepetitionGroup();
+
+        model(context, COMMENT).setObject("Haus");
+        context.getComponentModels().put(TemplateContext.getLanguageModelKey(COMMENT), Model.of("de"));
+        model(context, COMMENT_REP1).setObject("maison");
+        context.getComponentModels().put(TemplateContext.getLanguageModelKey(COMMENT_REP1), Model.of("fr"));
+
+        removeRepetitionGroup(si, 1);
+
+        assertEquals("Haus", model(context, COMMENT).getObject());
+        assertEquals("de", model(context, TemplateContext.getLanguageModelKey(COMMENT)).getObject());
+        assertNull(model(context, COMMENT_REP1).getObject());
+        assertNull(model(context, TemplateContext.getLanguageModelKey(COMMENT_REP1)).getObject());
+    }
+
+}

--- a/src/test/java/com/knowledgepixels/nanodash/template/LanguageTagTemplateTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/template/LanguageTagTemplateTest.java
@@ -1,0 +1,130 @@
+package com.knowledgepixels.nanodash.template;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.eclipse.rdf4j.model.vocabulary.XSD;
+import org.junit.jupiter.api.Test;
+import org.nanopub.NanopubCreator;
+import org.nanopub.vocabulary.NTEMPLATE;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for parsing language-tag-selectable literal placeholders
+ * (nt:LanguageTaggedLiteralPlaceholder, nt:possibleLanguageTag).
+ */
+public class LanguageTagTemplateTest {
+
+    private static final ValueFactory vf = SimpleValueFactory.getInstance();
+
+    private static final String NP_URI = "https://w3id.org/np/RAAbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_AbCdE";
+    private static final IRI COMMENT_PLACEHOLDER = vf.createIRI(NP_URI + "/comment");
+
+    /**
+     * Builds a template nanopub with one statement whose object is the comment
+     * placeholder, typed with the given placeholder types. The returned creator
+     * can take further statements before finalizing.
+     */
+    private static NanopubCreator newCreator(IRI... placeholderTypes) throws Exception {
+        NanopubCreator creator = new NanopubCreator(NP_URI);
+        creator.addProvenanceStatement(vf.createStatement(creator.getAssertionUri(), RDFS.SEEALSO, creator.getAssertionUri()));
+        creator.addPubinfoStatement(vf.createStatement(creator.getNanopubUri(), RDFS.SEEALSO, creator.getNanopubUri()));
+        IRI templateNode = creator.getAssertionUri();
+        IRI st1 = vf.createIRI(NP_URI + "/st1");
+        creator.addAssertionStatement(templateNode, RDF.TYPE, NTEMPLATE.ASSERTION_TEMPLATE);
+        creator.addAssertionStatement(templateNode, RDFS.LABEL, vf.createLiteral("Test template"));
+        creator.addAssertionStatement(templateNode, NTEMPLATE.HAS_STATEMENT, st1);
+        creator.addAssertionStatement(st1, RDF.SUBJECT, vf.createIRI("http://example.com/subject"));
+        creator.addAssertionStatement(st1, RDF.PREDICATE, RDFS.COMMENT);
+        creator.addAssertionStatement(st1, RDF.OBJECT, COMMENT_PLACEHOLDER);
+        for (IRI type : placeholderTypes) {
+            creator.addAssertionStatement(COMMENT_PLACEHOLDER, RDF.TYPE, type);
+        }
+        creator.addAssertionStatement(COMMENT_PLACEHOLDER, RDFS.LABEL, vf.createLiteral("comment"));
+        return creator;
+    }
+
+    @Test
+    void selectablePlaceholderParses() throws Exception {
+        NanopubCreator creator = newCreator(NTEMPLATE.LITERAL_PLACEHOLDER, Template.LANGUAGE_TAGGED_LITERAL_PLACEHOLDER);
+        Template t = new Template(creator.finalizeNanopub());
+        assertTrue(t.isLanguageTagSelectable(COMMENT_PLACEHOLDER));
+        assertTrue(t.isLiteralPlaceholder(COMMENT_PLACEHOLDER));
+        assertNull(t.getPossibleLanguageTags(COMMENT_PLACEHOLDER));
+        assertNull(t.getLanguageTag(COMMENT_PLACEHOLDER));
+    }
+
+    @Test
+    void possibleLanguageTagsAreNormalized() throws Exception {
+        NanopubCreator creator = newCreator(NTEMPLATE.LITERAL_PLACEHOLDER, Template.LANGUAGE_TAGGED_LITERAL_PLACEHOLDER);
+        creator.addAssertionStatement(COMMENT_PLACEHOLDER, Template.POSSIBLE_LANGUAGE_TAG, vf.createLiteral("en"));
+        creator.addAssertionStatement(COMMENT_PLACEHOLDER, Template.POSSIBLE_LANGUAGE_TAG, vf.createLiteral("DE-de"));
+        Template t = new Template(creator.finalizeNanopub());
+        List<String> tags = t.getPossibleLanguageTags(COMMENT_PLACEHOLDER);
+        assertEquals(2, tags.size());
+        assertTrue(tags.contains("en"));
+        assertTrue(tags.contains("de-DE"));
+    }
+
+    @Test
+    void defaultLanguageTagParses() throws Exception {
+        NanopubCreator creator = newCreator(NTEMPLATE.LITERAL_PLACEHOLDER, Template.LANGUAGE_TAGGED_LITERAL_PLACEHOLDER);
+        creator.addAssertionStatement(COMMENT_PLACEHOLDER, NTEMPLATE.HAS_LANGUAGE_TAG, vf.createLiteral("en"));
+        Template t = new Template(creator.finalizeNanopub());
+        assertEquals("en", t.getLanguageTag(COMMENT_PLACEHOLDER));
+        assertTrue(t.isLanguageTagSelectable(COMMENT_PLACEHOLDER));
+    }
+
+    @Test
+    void plainLiteralPlaceholderIsNotSelectable() throws Exception {
+        NanopubCreator creator = newCreator(NTEMPLATE.LITERAL_PLACEHOLDER);
+        creator.addAssertionStatement(COMMENT_PLACEHOLDER, NTEMPLATE.HAS_LANGUAGE_TAG, vf.createLiteral("en"));
+        Template t = new Template(creator.finalizeNanopub());
+        assertFalse(t.isLanguageTagSelectable(COMMENT_PLACEHOLDER));
+        assertEquals("en", t.getLanguageTag(COMMENT_PLACEHOLDER));
+    }
+
+    @Test
+    void selectableTypeAloneIsLiteralPlaceholder() throws Exception {
+        NanopubCreator creator = newCreator(Template.LANGUAGE_TAGGED_LITERAL_PLACEHOLDER);
+        Template t = new Template(creator.finalizeNanopub());
+        assertTrue(t.isLiteralPlaceholder(COMMENT_PLACEHOLDER));
+        assertTrue(t.isPlaceholder(COMMENT_PLACEHOLDER));
+        assertTrue(t.isLanguageTagSelectable(COMMENT_PLACEHOLDER));
+    }
+
+    @Test
+    void conflictingDatatypeIsDropped() throws Exception {
+        NanopubCreator creator = newCreator(NTEMPLATE.LITERAL_PLACEHOLDER, Template.LANGUAGE_TAGGED_LITERAL_PLACEHOLDER);
+        creator.addAssertionStatement(COMMENT_PLACEHOLDER, NTEMPLATE.HAS_DATATYPE, XSD.DATE);
+        Template t = new Template(creator.finalizeNanopub());
+        assertNull(t.getDatatype(COMMENT_PLACEHOLDER));
+    }
+
+    @Test
+    void datatypeIsKeptOnPlainPlaceholder() throws Exception {
+        NanopubCreator creator = newCreator(NTEMPLATE.LITERAL_PLACEHOLDER);
+        creator.addAssertionStatement(COMMENT_PLACEHOLDER, NTEMPLATE.HAS_DATATYPE, XSD.DATE);
+        Template t = new Template(creator.finalizeNanopub());
+        assertEquals(XSD.DATE, t.getDatatype(COMMENT_PLACEHOLDER));
+    }
+
+    @Test
+    void repetitionSuffixedLookupWorks() throws Exception {
+        NanopubCreator creator = newCreator(NTEMPLATE.LITERAL_PLACEHOLDER, Template.LANGUAGE_TAGGED_LITERAL_PLACEHOLDER);
+        creator.addAssertionStatement(COMMENT_PLACEHOLDER, Template.POSSIBLE_LANGUAGE_TAG, vf.createLiteral("en"));
+        Template t = new Template(creator.finalizeNanopub());
+        IRI suffixed = vf.createIRI(COMMENT_PLACEHOLDER.stringValue() + "__1");
+        assertTrue(t.isLanguageTagSelectable(suffixed));
+        assertEquals(List.of("en"), t.getPossibleLanguageTags(suffixed));
+    }
+
+}

--- a/src/test/java/com/knowledgepixels/nanodash/template/TemplateTestUtil.java
+++ b/src/test/java/com/knowledgepixels/nanodash/template/TemplateTestUtil.java
@@ -1,0 +1,24 @@
+package com.knowledgepixels.nanodash.template;
+
+import org.nanopub.Nanopub;
+
+/**
+ * Gives tests outside this package access to the package-private Template constructor.
+ */
+public class TemplateTestUtil {
+
+    private TemplateTestUtil() {
+    }
+
+    /**
+     * Parses a template from the given nanopub.
+     *
+     * @param np the template nanopub
+     * @return the parsed template
+     * @throws MalformedTemplateException if the template is malformed
+     */
+    public static Template parseTemplate(Nanopub np) throws MalformedTemplateException {
+        return new Template(np);
+    }
+
+}


### PR DESCRIPTION
Implements the design in [docs/language-tag-picker.md](https://github.com/knowledgepixels/nanodash/blob/master/docs/language-tag-picker.md): the user filling a template can pick the language tag of a literal at fill time, instead of the tag being fixed per placeholder by the template author.

## Vocabulary (minted locally, TODO upstream to nanopub-java)
- `nt:LanguageTaggedLiteralPlaceholder` — typed alongside `nt:LiteralPlaceholder`/`nt:LongLiteralPlaceholder`; renders a language dropdown and always publishes `rdf:langString`
- `nt:possibleLanguageTag` (0..n) — restricts the dropdown choices; absent = full ISO 639-1 list + free BCP 47 entry
- `nt:hasLanguageTag` on a picker placeholder = the pre-selected **default** (old clients degrade to today's fixed-tag field — the backward-compat hinge)

## Implementation
- Chosen tag lives in a second component model keyed `<iri>__lang` (derived after `__N` repetition suffixing) → per-repetition tags and `param_<name>__lang` URL prefill for free
- `RepetitionGroup.remove()` shifts the derived language models alongside text models
- Dropdown requiredness is dynamic: a tag is required whenever the paired text field has input, so a language-tagged literal is never published untagged (no PublishForm changes needed)
- Unification relaxed for pickers (any tag from the allowed set; default is not a constraint) in `LiteralTextfieldItem` and `ReadonlyItem`; fixed-tag placeholders stay strict

## Testing
- 31 new tests across 5 classes (parsing, publish path, repetition shifting, component wiring/validation, fill/unification); full suite green
- Verified end-to-end in the browser on an isolated jetty (form rendering, restricted/unrestricted pickers, default pre-selection, required-validation, free `en-GB` entry, signed preview carrying `@de`/`@en-GB`, URL prefill)

🤖 Generated with [Claude Code](https://claude.com/claude-code)