### PR TITLE
Update NanopubAction template URI for comment, approval and retraction

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/action/ApprovalAction.java
+++ b/src/main/java/com/knowledgepixels/nanodash/action/ApprovalAction.java
@@ -10,7 +10,7 @@ public class ApprovalAction extends NanopubAction {
     /**
      * The URI of the template for the approval action.
      */
-    public static final String TEMPLATE_URI = "http://purl.org/np/RAsmppaxXZ613z9olynInTqIo0oiCelsbONDi2c5jlEMg";
+    public static final String TEMPLATE_URI = "https://w3id.org/np/RAkhTlKa-i0miq_DN3V4HSv-btlDgwzg8qPUesrsJ0k9Q";
 
     /**
      * {@inheritDoc}

--- a/src/main/java/com/knowledgepixels/nanodash/action/CommentAction.java
+++ b/src/main/java/com/knowledgepixels/nanodash/action/CommentAction.java
@@ -10,7 +10,7 @@ public class CommentAction extends NanopubAction {
     /**
      * The URI of the template for the comment action.
      */
-    public static final String TEMPLATE_URI = "http://purl.org/np/RAqfUmjV05ruLK3Efq2kCODsHfY16LJGO3nAwDi5rmtv0";
+    public static final String TEMPLATE_URI = "https://w3id.org/np/RAaqrSEatLCNYWZb6VigZk_ttPrtNSyvhhFSgunSybPEs";
 
     /**
      * {@inheritDoc}

--- a/src/main/java/com/knowledgepixels/nanodash/action/RetractionAction.java
+++ b/src/main/java/com/knowledgepixels/nanodash/action/RetractionAction.java
@@ -10,7 +10,7 @@ public class RetractionAction extends NanopubAction {
     /**
      * The URI of the template used for retraction actions.
      */
-    public static final String TEMPLATE_URI = "http://purl.org/np/RAvySE8-JDPqaPnm_XShAa-aVuDZ2iW2z7Oc1Q9cfvxZE";
+    public static final String TEMPLATE_URI = "https://w3id.org/np/RAZl7bwTcLA5M5uLy5WCPuz8QEejBYEQnVNkL_d1lbj4Y";
 
     /**
      * {@inheritDoc}


### PR DESCRIPTION
This pull request updates the template URIs for several action classes to use newly defined templates.

Template URI updates:

* Updated the `TEMPLATE_URI` in `ApprovalAction` to use `https://w3id.org/np/RAkhTlKa-i0miq_DN3V4HSv-btlDgwzg8qPUesrsJ0k9Q`.
* Updated the `TEMPLATE_URI` in `CommentAction` to use `https://w3id.org/np/RAaqrSEatLCNYWZb6VigZk_ttPrtNSyvhhFSgunSybPEs`.
* Updated the `TEMPLATE_URI` in `RetractionAction` to use `https://w3id.org/np/RAZl7bwTcLA5M5uLy5WCPuz8QEejBYEQnVNkL_d1lbj4Y`.…retraction