### PR TITLE
feat: allow artifact-code wildcard IRIs in local-resource choice dropdowns

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/RestrictedChoice.java
+++ b/src/main/java/com/knowledgepixels/nanodash/RestrictedChoice.java
@@ -68,7 +68,9 @@ public class RestrictedChoice implements Serializable {
         List<String> possibleValuesList = new ArrayList<>();
         for (String s : possibleValues) {
             if (context.getTemplate().isLocalResource(placeholderIri)) {
-                if (s.matches("https?://.+")) continue;
+                // Full URIs are not local, except artifact-code wildcard IRIs, which mint
+                // a new resource per publication just like local short IDs do.
+                if (s.matches("https?://.+") && !s.contains("~~ARTIFACTCODE~~")) continue;
             }
             possibleValuesList.add(s);
         }

--- a/src/test/java/com/knowledgepixels/nanodash/RestrictedChoiceTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/RestrictedChoiceTest.java
@@ -2,11 +2,14 @@ package com.knowledgepixels.nanodash;
 
 import com.knowledgepixels.nanodash.template.Template;
 import com.knowledgepixels.nanodash.template.TemplateContext;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.Model;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Value;
 import org.junit.jupiter.api.Test;
 import org.nanopub.vocabulary.NTEMPLATE;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -45,6 +48,28 @@ class RestrictedChoiceTest {
         List<String> possibleValues = restrictedChoice.getPossibleValues();
 
         assertEquals(List.of("\"value1\"", "\"value2\""), possibleValues);
+    }
+
+    @Test
+    void getPossibleValuesKeepsArtifactCodeWildcardIrisForLocalResources() {
+        TemplateContext mockContext = mock(TemplateContext.class);
+        Template mockTemplate = mock(Template.class);
+        when(mockContext.getTemplate()).thenReturn(mockTemplate);
+        IRI placeholderIri = vf.createIRI("https://knowledgepixels.com/placeholder");
+        IRI refIri = vf.createIRI("https://knowledgepixels.com/ref");
+        when(mockTemplate.getPossibleValues(placeholderIri)).thenReturn(List.of(refIri));
+        when(mockTemplate.isPlaceholder(refIri)).thenReturn(true);
+        when(mockTemplate.isLocalResource(placeholderIri)).thenReturn(true);
+        Map<IRI, IModel<?>> componentModels = new HashMap<>();
+        componentModels.put(refIri, Model.of("https://w3id.org/peh/biochementities/~~ARTIFACTCODE~~"));
+        componentModels.put(vf.createIRI(refIri + "__1"), Model.of("https://w3id.org/peh/terms/BioChemEntity"));
+        componentModels.put(vf.createIRI(refIri + "__2"), Model.of("shortid"));
+        when(mockContext.getComponentModels()).thenReturn((Map) componentModels);
+
+        RestrictedChoice restrictedChoice = new RestrictedChoice(placeholderIri, mockContext);
+
+        assertEquals(List.of("https://w3id.org/peh/biochementities/~~ARTIFACTCODE~~", "shortid"),
+                restrictedChoice.getPossibleValues());
     }
 
     @Test


### PR DESCRIPTION
## Summary

Local-resource restricted-choice dropdowns (e.g. the template-creation meta-template's "placeholder is-a type" subject) filter out all full URIs from their options, offering only local short IDs. This made it impossible to select a fixed IRI like `https://w3id.org/peh/biochementities/~~ARTIFACTCODE~~` — for instance to mark it as an introduced resource — even though such artifact-code wildcard IRIs mint a new resource per publication, just like local short IDs do.

This exempts values containing `~~ARTIFACTCODE~~` from the URL filter in `RestrictedChoice.getPossibleValues()`.

Notes:
- Existing triples of this shape already round-tripped through supersede fill (the filler pre-selects out-of-list values); this change makes them *newly selectable* in the form as well.
- The publish machinery already handles fixed wildcard IRIs typed `nt:IntroducedResource` (`TemplateContext.processValue` emits `npx:introduces` for fixed IRIs too), so no further changes are needed.

## Test plan

- New unit test `getPossibleValuesKeepsArtifactCodeWildcardIrisForLocalResources` covering: wildcard URI kept, plain full URI still filtered, local short ID kept.
- Full suite green locally (835 tests, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)