### PR TITLE
Report and block templates with literals in subject/predicate position

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/component/MissingValueItem.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/MissingValueItem.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html xmlns:wicket="http://wicket.apache.org">
+
+<head>
+<link rel="stylesheet" href="../../../../../webapp/style.css?for-local-testing-only" type="text/css" media="screen" title="Stylesheet" />
+</head>
+<body>
+
+<wicket:panel>
+<span class="negative">(missing)</span>
+</wicket:panel>
+
+</body>
+
+</html>

--- a/src/main/java/com/knowledgepixels/nanodash/component/MissingValueItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/MissingValueItem.java
@@ -1,0 +1,70 @@
+package com.knowledgepixels.nanodash.component;
+
+import com.knowledgepixels.nanodash.template.UnificationException;
+import org.apache.wicket.markup.html.panel.Panel;
+import org.eclipse.rdf4j.model.Value;
+
+/**
+ * A component that stands in for a statement part the template doesn't define, such as a
+ * statement without an {@code rdf:subject}. It never unifies, so statements containing it
+ * cannot be matched or published.
+ */
+public class MissingValueItem extends Panel implements ContextComponent {
+
+    /**
+     * Constructor for creating a MissingValueItem.
+     *
+     * @param id the Wicket component ID
+     */
+    public MissingValueItem(String id) {
+        super(id);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void removeFromContext() {
+        // Nothing to be done here.
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isUnifiableWith(Value v) {
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void unifyWith(Value v) throws UnificationException {
+        throw new UnificationException(v == null ? "null" : v.stringValue());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void fillFinished() {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void finalizeValues() {
+    }
+
+    /**
+     * Returns a string representation of the MissingValueItem.
+     *
+     * @return a string describing the missing value item
+     */
+    public String toString() {
+        return "[Missing value item]";
+    }
+
+}

--- a/src/main/java/com/knowledgepixels/nanodash/component/PublishForm.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/PublishForm.html
@@ -14,6 +14,12 @@
 
 <p><span wicket:id="newversion" class="negative">information about new versions of templates will be put here:</span> <a wicket:id="newversionlink">switch to latest version</a></p>
 
+<p><span wicket:id="template-error-intro" class="negative">template error intro will be put here</span></p>
+
+<ul>
+<li wicket:id="template-errors"><span wicket:id="template-error-part" class="negative">Assertion: </span><span wicket:id="template-error" class="negative">template error message</span></li>
+</ul>
+
 <p><span wicket:id="warnings" class="negative">warning messages will be put here</span></p>
 
 <ul>
@@ -126,17 +132,19 @@
 </button>
 </p>
 
-<p>
+<p wicket:id="consent-section">
 <input type="checkbox" wicket:id="consentcheck" id="consentcheck"/>
 <label for="consentcheck">
 I understand that published data cannot be fully removed (only retracted or superseded by new versions), and is publicly connected to my personal identifier.
 </label>
 </p>
 
-<p class="center">
+<p wicket:id="button-section" class="center">
 <input type="submit" class="button" value="Publish" onclick="this.value='Publishing\u2026'; this.disabled=true; this.form.submit();" />
 <button wicket:id="preview-button" type="submit" class="button light">Preview</button>
 </p>
+
+<p wicket:id="publishing-disabled" class="center negative">reason why publishing is disabled will be put here</p>
 
 </form>
 

--- a/src/main/java/com/knowledgepixels/nanodash/component/PublishForm.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/PublishForm.java
@@ -59,6 +59,7 @@ import org.wicketstuff.select2.ChoiceProvider;
 import org.wicketstuff.select2.Response;
 import org.wicketstuff.select2.Select2Choice;
 
+import java.io.Serializable;
 import java.lang.reflect.InvocationTargetException;
 import java.util.*;
 
@@ -78,6 +79,8 @@ public class PublishForm extends Panel {
     private static final String derivesFromPubInfoTemplateId = "https://w3id.org/np/RARW4MsFkHuwjycNElvEVtuMjpf4yWDL10-0C5l2MqqRQ";
 
     private static final String[] fixedPubInfoTemplates = new String[]{CREATOR_PUB_INFO_TEMPLATE, LICENSE_PUB_INFO_TEMPLATE};
+
+    private static final String INVALID_TEMPLATE_MESSAGE = "This form is based on an invalid template and cannot be published.";
 
     /**
      * Fill modes for the nanopublication to be created.
@@ -101,6 +104,16 @@ public class PublishForm extends Panel {
          * source nanopub's introduced resource IRIs and its root definition nanopub.
          */
         OVERRIDE
+    }
+
+    /**
+     * A problem reported by {@link Template#getStatementErrors()}, together with the part of the
+     * nanopublication ("Assertion", "Provenance", "Publication info") whose template has it.
+     *
+     * @param part    the nanopublication part the offending template defines
+     * @param message the description of the problem
+     */
+    public record TemplateError(String part, String message) implements Serializable {
     }
 
     protected Form<?> form;
@@ -431,6 +444,30 @@ public class PublishForm extends Panel {
 
         });
 
+        // Statements of the involved templates that cannot produce valid RDF, e.g. a literal
+        // placeholder in subject position. Such a template silently publishes something other
+        // than what it describes, so the problem is spelled out above the form:
+        List<TemplateError> templateErrors = new ArrayList<>();
+        collectTemplateErrors("Assertion", assertionContext, templateErrors);
+        collectTemplateErrors("Provenance", provenanceContext, templateErrors);
+        for (TemplateContext c : pubInfoContexts) {
+            collectTemplateErrors("Publication info", c, templateErrors);
+        }
+        if (!templateErrors.isEmpty()) {
+            add(new Label("template-error-intro", "This form is based on an invalid template and will not produce the nanopublication it describes:"));
+        } else {
+            add(new Label("template-error-intro", "").setVisible(false));
+        }
+        add(new ListView<TemplateError>("template-errors", templateErrors) {
+
+            @Override
+            protected void populateItem(ListItem<TemplateError> item) {
+                item.add(new Label("template-error-part", item.getModelObject().part() + ": "));
+                item.add(new Label("template-error", item.getModelObject().message()));
+            }
+
+        });
+
         // Finalize statements, which picks up parameter values in repetitions:
         assertionContext.finalizeStatements();
         provenanceContext.finalizeStatements();
@@ -451,6 +488,12 @@ public class PublishForm extends Panel {
             }
 
             protected void onSubmit() {
+                // The publish button is hidden in this case, but the form can still be
+                // submitted by pressing Enter in one of its fields:
+                if (!templateErrors.isEmpty()) {
+                    feedbackPanel.error(INVALID_TEMPLATE_MESSAGE);
+                    return;
+                }
                 if (!Boolean.TRUE.equals(consentCheck.getModelObject())) {
                     feedbackPanel.error("You need to check the checkbox that you understand the consequences.");
                     return;
@@ -787,11 +830,29 @@ public class PublishForm extends Panel {
         form.add(piTemplateChoice);
         refreshPubInfo(null);
 
-        form.add(consentCheck);
+        // An invalid template cannot produce the nanopublication it describes, so there is
+        // nothing to consent to, publish or preview; the reasons are listed above the form.
+        boolean publishingDisabled = !templateErrors.isEmpty();
 
-        form.add(new Button("preview-button") {
+        WebMarkupContainer consentSection = new WebMarkupContainer("consent-section");
+        consentSection.add(consentCheck);
+        consentSection.setVisible(!publishingDisabled);
+        form.add(consentSection);
+
+        WebMarkupContainer buttonSection = new WebMarkupContainer("button-section");
+        buttonSection.setVisible(!publishingDisabled);
+        form.add(buttonSection);
+
+        form.add(new Label("publishing-disabled", "Publishing is disabled because of the template errors listed above.")
+                .setVisible(publishingDisabled));
+
+        buttonSection.add(new Button("preview-button") {
             @Override
             public void onSubmit() {
+                if (!templateErrors.isEmpty()) {
+                    feedbackPanel.error(INVALID_TEMPLATE_MESSAGE);
+                    return;
+                }
                 try {
                     Nanopub np = createNanopub();
                     TransformContext tc = new TransformContext(SignatureAlgorithm.RSA, NanodashSession.get().getKeyPair(), NanodashSession.get().getUserIri(), false, false, false);
@@ -897,6 +958,13 @@ public class PublishForm extends Panel {
             pubInfoContexts.add(c);
         }
         return c;
+    }
+
+    private static void collectTemplateErrors(String part, TemplateContext context, List<TemplateError> errors) {
+        if (context == null || context.getTemplate() == null) return;
+        for (String error : context.getTemplate().getStatementErrors()) {
+            errors.add(new TemplateError(part, error));
+        }
     }
 
     private synchronized Nanopub createNanopub() throws MalformedNanopubException, NanopubAlreadyFinalizedException {

--- a/src/main/java/com/knowledgepixels/nanodash/component/StatementItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/StatementItem.java
@@ -352,9 +352,12 @@ public class StatementItem extends Panel {
         public RepetitionGroup() {
             statementParts = new ArrayList<>();
             for (IRI s : statementPartIds) {
+                // Declared subject/predicate: a template can (invalidly) put a literal there,
+                // and rendering it shows the user what is wrong; Template.getStatementErrors()
+                // spells it out.
                 StatementPartItem statement = new StatementPartItem("statement",
-                        makeValueItem("subj", getTemplate().getSubject(s), s),
-                        makeValueItem("pred", getTemplate().getPredicate(s), s),
+                        makeValueItem("subj", getTemplate().getDeclaredSubject(s), s),
+                        makeValueItem("pred", getTemplate().getDeclaredPredicate(s), s),
                         makeValueItem("obj", getTemplate().getObject(s), s)
                 );
                 statementParts.add(statement);

--- a/src/main/java/com/knowledgepixels/nanodash/component/TemplateFormPreview.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/TemplateFormPreview.html
@@ -12,6 +12,13 @@
 
 <h4>Template Form Preview</h4>
 
+<div wicket:id="errors" class="message negative">
+<p><strong>This template is invalid and will not produce the nanopublications it describes:</strong></p>
+<ul>
+<li wicket:id="error"><span wicket:id="errormessage">error message</span></li>
+</ul>
+</div>
+
 <p>The form defined by this template nanopublication will look like this:</p>
 
 <form wicket:id="form">

--- a/src/main/java/com/knowledgepixels/nanodash/component/TemplateFormPreview.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/TemplateFormPreview.java
@@ -6,6 +6,7 @@ import com.knowledgepixels.nanodash.template.ContextType;
 import com.knowledgepixels.nanodash.template.Template;
 import com.knowledgepixels.nanodash.template.TemplateContext;
 import com.knowledgepixels.nanodash.template.TemplateData;
+import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.markup.html.list.ListItem;
@@ -86,6 +87,18 @@ public class TemplateFormPreview extends Panel {
             c.initStatements();
             c.finalizeStatements();
         }
+
+        // Statements that cannot produce valid RDF (e.g. a literal in subject position) are
+        // listed above the form, which still renders so the problem can be located in it.
+        List<String> statementErrors = template.getStatementErrors();
+        WebMarkupContainer errorSection = new WebMarkupContainer("errors");
+        errorSection.add(new ListView<String>("error", statementErrors) {
+            protected void populateItem(ListItem<String> item) {
+                item.add(new Label("errormessage", item.getModelObject()));
+            }
+        });
+        errorSection.setVisible(!statementErrors.isEmpty());
+        add(errorSection);
 
         // Build the form (needed for Wicket form components to render, but no submit action)
         Form<?> form = new Form<Void>("form");

--- a/src/main/java/com/knowledgepixels/nanodash/component/ValueItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/ValueItem.java
@@ -81,8 +81,13 @@ public class ValueItem extends AbstractContextComponent {
             } else {
                 component = new IriItem("value", id, iri, id.equals("obj"), statementPartId, rg);
             }
+        } else if (value instanceof Literal literal) {
+            component = new LiteralItem("value", id, literal, rg);
         } else {
-            component = new LiteralItem("value", id, (Literal) value, rg);
+            // The template declares no value at all for this position (e.g. a statement
+            // without rdf:subject). Render a marker rather than failing to render the whole
+            // form; Template.getStatementErrors() reports what is missing.
+            component = new MissingValueItem("value");
         }
         add((Component) component);
     }

--- a/src/main/java/com/knowledgepixels/nanodash/template/Template.java
+++ b/src/main/java/com/knowledgepixels/nanodash/template/Template.java
@@ -71,6 +71,11 @@ public class Template implements Serializable {
     private Map<IRI, IRI> statementSubjects = new HashMap<>();
     private Map<IRI, IRI> statementPredicates = new HashMap<>();
     private Map<IRI, Value> statementObjects = new HashMap<>();
+    // Subject/predicate values that are not IRIs (i.e. literals), which is invalid RDF but
+    // does occur in published templates. Kept apart from the maps above so the rest of the
+    // code keeps seeing IRIs, and reported by getStatementErrors().
+    private Map<IRI, Value> nonIriStatementSubjects = new HashMap<>();
+    private Map<IRI, Value> nonIriStatementPredicates = new HashMap<>();
     private Map<IRI, Integer> statementOrder = new HashMap<>();
     private IRI defaultProvenance;
     private List<IRI> requiredPubInfoElements = new ArrayList<>();
@@ -365,6 +370,94 @@ public class Template implements Serializable {
      */
     public Value getObject(IRI statementIri) {
         return statementObjects.get(statementIri);
+    }
+
+    /**
+     * Returns the subject of a statement as the template declares it, which may be a literal
+     * and therefore invalid in that position (in which case {@link #getSubject(IRI)} is null).
+     * Use this for rendering, so that an invalid subject is shown to the user instead of
+     * silently disappearing; see {@link #getStatementErrors()}.
+     *
+     * @param statementIri the IRI of the statement to retrieve.
+     * @return the declared subject of the statement, or null if the statement declares none.
+     */
+    public Value getDeclaredSubject(IRI statementIri) {
+        IRI subj = statementSubjects.get(statementIri);
+        if (subj != null) return subj;
+        return nonIriStatementSubjects.get(statementIri);
+    }
+
+    /**
+     * Returns the predicate of a statement as the template declares it, which may be a literal
+     * and therefore invalid in that position (in which case {@link #getPredicate(IRI)} is null).
+     * See {@link #getDeclaredSubject(IRI)}.
+     *
+     * @param statementIri the IRI of the statement to retrieve.
+     * @return the declared predicate of the statement, or null if the statement declares none.
+     */
+    public Value getDeclaredPredicate(IRI statementIri) {
+        IRI pred = statementPredicates.get(statementIri);
+        if (pred != null) return pred;
+        return nonIriStatementPredicates.get(statementIri);
+    }
+
+    /**
+     * Returns human-readable descriptions of the statements of this template that cannot
+     * produce valid RDF, because their subject or predicate is a literal, is a placeholder
+     * that can only be filled with a literal, or is missing altogether. Only URIs are allowed
+     * in subject and predicate position.
+     *
+     * @return the error descriptions, empty if all statements are well-formed.
+     */
+    public List<String> getStatementErrors() {
+        List<String> errors = new ArrayList<>();
+        List<IRI> topIris = getStatementIris();
+        if (topIris == null) return errors;
+        int i = 0;
+        for (IRI top : topIris) {
+            i++;
+            List<IRI> memberIris = getStatementIris(top);
+            if (memberIris == null) {
+                collectStatementErrors(top, "Statement " + i, errors);
+            } else {
+                int j = 0;
+                for (IRI member : memberIris) {
+                    j++;
+                    collectStatementErrors(member, "Statement " + i + "." + j, errors);
+                }
+            }
+        }
+        return errors;
+    }
+
+    private void collectStatementErrors(IRI statementIri, String statementNumber, List<String> errors) {
+        String statementName = statementNumber + " (" + getLocalName(statementIri) + ")";
+        collectPositionError(getDeclaredSubject(statementIri), "subject", statementName, errors);
+        collectPositionError(getDeclaredPredicate(statementIri), "predicate", statementName, errors);
+    }
+
+    private void collectPositionError(Value value, String position, String statementName, List<String> errors) {
+        if (value == null) {
+            errors.add(statementName + ": no " + position + " is defined.");
+        } else if (value instanceof Literal) {
+            errors.add(statementName + ": the literal " + describeValue(value) + " is used in " + position +
+                    " position, but only URIs are allowed there.");
+        } else if (isLiteralPlaceholder((IRI) value)) {
+            errors.add(statementName + ": the literal placeholder " + describeValue(value) + " is used in " + position +
+                    " position, but only URIs are allowed there.");
+        }
+    }
+
+    private String describeValue(Value value) {
+        if (value instanceof Literal) return "\"" + value.stringValue() + "\"";
+        String label = getLabel((IRI) value);
+        String localName = getLocalName(value);
+        if (label == null) return localName;
+        return "\"" + label + "\" (" + localName + ")";
+    }
+
+    private String getLocalName(Value value) {
+        return value.stringValue().replaceFirst("^.*[/#]", "");
     }
 
     /**
@@ -966,10 +1059,18 @@ public class Template implements Serializable {
                 prefixLabelMap.put(subj, objS);
             } else if (pred.equals(NTEMPLATE.HAS_REGEX) && obj instanceof Literal) {
                 regexMap.put(subj, objS);
-            } else if (pred.equals(RDF.SUBJECT) && obj instanceof IRI objIri) {
-                statementSubjects.put(subj, objIri);
-            } else if (pred.equals(RDF.PREDICATE) && obj instanceof IRI objIri) {
-                statementPredicates.put(subj, objIri);
+            } else if (pred.equals(RDF.SUBJECT)) {
+                if (obj instanceof IRI objIri) {
+                    statementSubjects.put(subj, objIri);
+                } else {
+                    nonIriStatementSubjects.put(subj, obj);
+                }
+            } else if (pred.equals(RDF.PREDICATE)) {
+                if (obj instanceof IRI objIri) {
+                    statementPredicates.put(subj, objIri);
+                } else {
+                    nonIriStatementPredicates.put(subj, obj);
+                }
             } else if (pred.equals(RDF.OBJECT)) {
                 statementObjects.put(subj, obj);
             } else if (pred.equals(NTEMPLATE.HAS_DEFAULT_VALUE)) {
@@ -1231,6 +1332,10 @@ public class Template implements Serializable {
     }
 
     private IRI transform(IRI iri) {
+        // A template can leave a statement part undefined (see getStatementErrors()), in which
+        // case the null propagates here through getSubject()/getPredicate(). Let the type and
+        // label lookups below answer "no" for it instead of failing to render the whole form.
+        if (iri == null) return null;
         String s = iri.stringValue();
         // Map a rendered IRI back to its template form for map lookups (label, type,
         // datatype, …). RepetitionGroup.transform expands the template's "~~ARTIFACTCODE~~"

--- a/src/test/java/com/knowledgepixels/nanodash/component/PublishFormTemplateErrorTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/component/PublishFormTemplateErrorTest.java
@@ -1,0 +1,106 @@
+package com.knowledgepixels.nanodash.component;
+
+import com.knowledgepixels.nanodash.WicketApplication;
+import com.knowledgepixels.nanodash.page.PublishPage;
+import com.knowledgepixels.nanodash.template.TemplateData;
+import org.apache.wicket.request.mapper.parameter.PageParameters;
+import org.apache.wicket.util.tester.WicketTester;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.nanopub.Nanopub;
+import org.nanopub.NanopubCreator;
+import org.nanopub.vocabulary.NTEMPLATE;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests that the publish form itself reports templates that cannot produce valid RDF, such as a
+ * literal placeholder in subject position. Without this, filling in such a template silently
+ * publishes something other than what the template describes.
+ */
+class PublishFormTemplateErrorTest {
+
+    private static final ValueFactory vf = SimpleValueFactory.getInstance();
+
+    private WicketTester tester;
+
+    @BeforeEach
+    void setUp() {
+        tester = new WicketTester(new WicketApplication());
+    }
+
+    /**
+     * Builds and registers a minimal assertion template with one statement, whose subject is
+     * either the URI placeholder ("the thing") or the literal placeholder ("the name"). Each
+     * template gets its own nanopub URI, because templates are cached by URI.
+     */
+    private static String registerTemplate(String npUri, boolean literalSubject) throws Exception {
+        IRI st1 = vf.createIRI(npUri + "/st1");
+        IRI thing = vf.createIRI(npUri + "/thing");
+        IRI name = vf.createIRI(npUri + "/name");
+        NanopubCreator creator = new NanopubCreator(npUri);
+        creator.addProvenanceStatement(vf.createStatement(creator.getAssertionUri(), RDFS.SEEALSO, creator.getAssertionUri()));
+        creator.addPubinfoStatement(vf.createStatement(creator.getNanopubUri(), RDFS.SEEALSO, creator.getNanopubUri()));
+        IRI templateNode = creator.getAssertionUri();
+        creator.addAssertionStatement(templateNode, RDF.TYPE, NTEMPLATE.ASSERTION_TEMPLATE);
+        creator.addAssertionStatement(templateNode, RDFS.LABEL, vf.createLiteral("Publish form test template"));
+        creator.addAssertionStatement(templateNode, NTEMPLATE.HAS_STATEMENT, st1);
+        creator.addAssertionStatement(st1, RDF.SUBJECT, literalSubject ? name : thing);
+        creator.addAssertionStatement(st1, RDF.PREDICATE, RDFS.LABEL);
+        creator.addAssertionStatement(st1, RDF.OBJECT, name);
+        creator.addAssertionStatement(thing, RDF.TYPE, NTEMPLATE.URI_PLACEHOLDER);
+        creator.addAssertionStatement(thing, RDFS.LABEL, vf.createLiteral("the thing"));
+        creator.addAssertionStatement(name, RDF.TYPE, NTEMPLATE.LITERAL_PLACEHOLDER);
+        creator.addAssertionStatement(name, RDFS.LABEL, vf.createLiteral("the name"));
+        Nanopub np = creator.finalizeNanopub();
+        TemplateData.get().registerTemplate(np);
+        return npUri;
+    }
+
+    private String renderPublishForm(String templateId) {
+        PageParameters params = new PageParameters().add("template", templateId);
+        tester.startComponentInPage(new PublishForm("panel", params, PublishPage.class, null));
+        return tester.getLastResponseAsString();
+    }
+
+    @Test
+    void literalPlaceholderInSubjectPositionIsShownAsError() throws Exception {
+        String id = registerTemplate("https://w3id.org/np/RAAbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_Pub01", true);
+        String html = renderPublishForm(id);
+        assertTrue(html.contains("based on an invalid template"), html);
+        assertTrue(html.contains("Assertion: "), html);
+        assertTrue(html.contains("subject position"), html);
+        assertTrue(html.contains("&quot;the name&quot; (name)"), html);
+    }
+
+    @Test
+    void invalidTemplateHidesConsentAndButtons() throws Exception {
+        String id = registerTemplate("https://w3id.org/np/RAAbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_Pub03", true);
+        String html = renderPublishForm(id);
+        assertFalse(html.contains("value=\"Publish\""), html);
+        assertFalse(html.contains(">Preview</button>"), html);
+        assertFalse(html.contains("I understand that published data"), html);
+        assertTrue(html.contains("Publishing is disabled"), html);
+    }
+
+    @Test
+    void wellFormedTemplateShowsNoError() throws Exception {
+        String id = registerTemplate("https://w3id.org/np/RAAbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_Pub02", false);
+        String html = renderPublishForm(id);
+        assertTrue(html.contains("Create Nanopublication"), html);
+        // The default provenance and publication-info templates are loaded too, so this also
+        // guards against the standard set of templates reporting errors:
+        assertFalse(html.contains("based on an invalid template"), html);
+        assertTrue(html.contains("value=\"Publish\""), html);
+        assertTrue(html.contains(">Preview</button>"), html);
+        assertTrue(html.contains("I understand that published data"), html);
+        assertFalse(html.contains("Publishing is disabled"), html);
+    }
+
+}

--- a/src/test/java/com/knowledgepixels/nanodash/component/TemplateFormPreviewTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/component/TemplateFormPreviewTest.java
@@ -1,0 +1,131 @@
+package com.knowledgepixels.nanodash.component;
+
+import com.knowledgepixels.nanodash.WicketApplication;
+import org.apache.wicket.util.tester.WicketTester;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.nanopub.Nanopub;
+import org.nanopub.NanopubCreator;
+import org.nanopub.vocabulary.NTEMPLATE;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests that the template form preview (shown when previewing or viewing a template
+ * nanopublication) reports statements that cannot produce valid RDF, such as a literal
+ * placeholder in subject position.
+ */
+class TemplateFormPreviewTest {
+
+    private static final ValueFactory vf = SimpleValueFactory.getInstance();
+
+    private WicketTester tester;
+
+    @BeforeEach
+    void setUp() {
+        tester = new WicketTester(new WicketApplication());
+    }
+
+    /**
+     * Builds a minimal assertion template with one statement, whose subject is either the URI
+     * placeholder ("the thing") or the literal placeholder ("the name"). Each template gets its
+     * own nanopub URI, because templates are cached by URI in the global template registry.
+     */
+    private static Nanopub templateWithLiteralSubject(String npUri, boolean literalSubject) throws Exception {
+        IRI st1 = vf.createIRI(npUri + "/st1");
+        IRI thing = vf.createIRI(npUri + "/thing");
+        IRI name = vf.createIRI(npUri + "/name");
+        NanopubCreator creator = new NanopubCreator(npUri);
+        creator.addProvenanceStatement(vf.createStatement(creator.getAssertionUri(), RDFS.SEEALSO, creator.getAssertionUri()));
+        creator.addPubinfoStatement(vf.createStatement(creator.getNanopubUri(), RDFS.SEEALSO, creator.getNanopubUri()));
+        IRI templateNode = creator.getAssertionUri();
+        creator.addAssertionStatement(templateNode, RDF.TYPE, NTEMPLATE.ASSERTION_TEMPLATE);
+        creator.addAssertionStatement(templateNode, RDFS.LABEL, vf.createLiteral("Preview test template"));
+        creator.addAssertionStatement(templateNode, NTEMPLATE.HAS_STATEMENT, st1);
+        creator.addAssertionStatement(st1, RDF.SUBJECT, literalSubject ? name : thing);
+        creator.addAssertionStatement(st1, RDF.PREDICATE, RDFS.LABEL);
+        creator.addAssertionStatement(st1, RDF.OBJECT, name);
+        creator.addAssertionStatement(thing, RDF.TYPE, NTEMPLATE.URI_PLACEHOLDER);
+        creator.addAssertionStatement(thing, RDFS.LABEL, vf.createLiteral("the thing"));
+        creator.addAssertionStatement(name, RDF.TYPE, NTEMPLATE.LITERAL_PLACEHOLDER);
+        creator.addAssertionStatement(name, RDFS.LABEL, vf.createLiteral("the name"));
+        return creator.finalizeNanopub();
+    }
+
+    @Test
+    void literalPlaceholderInSubjectPositionIsShownAsError() throws Exception {
+        Nanopub np = templateWithLiteralSubject("https://w3id.org/np/RAAbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_Bad01", true);
+        tester.startComponentInPage(new TemplateFormPreview("panel", np));
+        String html = tester.getLastResponseAsString();
+        assertTrue(html.contains("This template is invalid"), html);
+        assertTrue(html.contains("subject position"), html);
+        assertTrue(html.contains("&quot;the name&quot; (name)"), html);
+    }
+
+    @Test
+    void wellFormedTemplateShowsNoError() throws Exception {
+        Nanopub np = templateWithLiteralSubject("https://w3id.org/np/RAAbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_Ok001", false);
+        tester.startComponentInPage(new TemplateFormPreview("panel", np));
+        String html = tester.getLastResponseAsString();
+        assertFalse(html.contains("This template is invalid"), html);
+        assertTrue(html.contains("Template Form Preview"), html);
+    }
+
+    /**
+     * A plain literal (rather than a placeholder) in subject position used to be dropped at
+     * parse time and then fail the whole preview with a NullPointerException.
+     */
+    @Test
+    void literalInSubjectPositionIsShownAsErrorAndRendered() throws Exception {
+        String npUri = "https://w3id.org/np/RAAbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_Bad02";
+        IRI st1 = vf.createIRI(npUri + "/st1");
+        NanopubCreator creator = templateCreator(npUri);
+        creator.addAssertionStatement(st1, RDF.SUBJECT, vf.createLiteral("not a URI"));
+        creator.addAssertionStatement(st1, RDF.PREDICATE, RDFS.LABEL);
+        creator.addAssertionStatement(st1, RDF.OBJECT, vf.createIRI(npUri + "/name"));
+        tester.startComponentInPage(new TemplateFormPreview("panel", creator.finalizeNanopub()));
+        String html = tester.getLastResponseAsString();
+        assertTrue(html.contains("This template is invalid"), html);
+        assertTrue(html.contains("subject position"), html);
+        assertTrue(html.contains("not a URI"), html);
+    }
+
+    /**
+     * A statement listed with nt:hasStatement but never defined used to fail the whole preview
+     * with a NullPointerException; it now renders as "(missing)" plus an error message.
+     */
+    @Test
+    void undefinedStatementIsShownAsErrorAndRendered() throws Exception {
+        String npUri = "https://w3id.org/np/RAAbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_Bad03";
+        tester.startComponentInPage(new TemplateFormPreview("panel", templateCreator(npUri).finalizeNanopub()));
+        String html = tester.getLastResponseAsString();
+        assertTrue(html.contains("This template is invalid"), html);
+        assertTrue(html.contains("no subject is defined"), html);
+        assertTrue(html.contains("(missing)"), html);
+    }
+
+    /**
+     * Template with a single statement st1 that the caller still has to define.
+     */
+    private static NanopubCreator templateCreator(String npUri) throws Exception {
+        IRI st1 = vf.createIRI(npUri + "/st1");
+        IRI name = vf.createIRI(npUri + "/name");
+        NanopubCreator creator = new NanopubCreator(npUri);
+        creator.addProvenanceStatement(vf.createStatement(creator.getAssertionUri(), RDFS.SEEALSO, creator.getAssertionUri()));
+        creator.addPubinfoStatement(vf.createStatement(creator.getNanopubUri(), RDFS.SEEALSO, creator.getNanopubUri()));
+        IRI templateNode = creator.getAssertionUri();
+        creator.addAssertionStatement(templateNode, RDF.TYPE, NTEMPLATE.ASSERTION_TEMPLATE);
+        creator.addAssertionStatement(templateNode, RDFS.LABEL, vf.createLiteral("Preview test template"));
+        creator.addAssertionStatement(templateNode, NTEMPLATE.HAS_STATEMENT, st1);
+        creator.addAssertionStatement(name, RDF.TYPE, NTEMPLATE.LITERAL_PLACEHOLDER);
+        creator.addAssertionStatement(name, RDFS.LABEL, vf.createLiteral("the name"));
+        return creator;
+    }
+
+}

--- a/src/test/java/com/knowledgepixels/nanodash/template/StatementErrorTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/template/StatementErrorTest.java
@@ -1,0 +1,152 @@
+package com.knowledgepixels.nanodash.template;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.junit.jupiter.api.Test;
+import org.nanopub.NanopubCreator;
+import org.nanopub.vocabulary.NTEMPLATE;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link Template#getStatementErrors()}: statements whose subject or predicate is a
+ * literal, is a placeholder that can only be filled with a literal, or is missing altogether
+ * cannot produce valid RDF and must be reported (see the "literals in subject/predicate
+ * position" issue).
+ */
+class StatementErrorTest {
+
+    private static final ValueFactory vf = SimpleValueFactory.getInstance();
+
+    private static final String NP_URI = "https://w3id.org/np/RAAbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_AbCdE";
+    private static final IRI ST1 = vf.createIRI(NP_URI + "/st1");
+    private static final IRI THING = vf.createIRI(NP_URI + "/thing");
+    private static final IRI NAME = vf.createIRI(NP_URI + "/name");
+
+    /**
+     * Builds a template with a single statement "thing rdfs:label name", where thing is a URI
+     * placeholder and name a literal placeholder. Callers override statement parts on top.
+     */
+    private static NanopubCreator singleStatementCreator() throws Exception {
+        NanopubCreator creator = new NanopubCreator(NP_URI);
+        creator.addProvenanceStatement(vf.createStatement(creator.getAssertionUri(), RDFS.SEEALSO, creator.getAssertionUri()));
+        creator.addPubinfoStatement(vf.createStatement(creator.getNanopubUri(), RDFS.SEEALSO, creator.getNanopubUri()));
+        IRI templateNode = creator.getAssertionUri();
+        creator.addAssertionStatement(templateNode, RDF.TYPE, NTEMPLATE.ASSERTION_TEMPLATE);
+        creator.addAssertionStatement(templateNode, RDFS.LABEL, vf.createLiteral("Statement error test template"));
+        creator.addAssertionStatement(templateNode, NTEMPLATE.HAS_STATEMENT, ST1);
+        creator.addAssertionStatement(THING, RDF.TYPE, NTEMPLATE.URI_PLACEHOLDER);
+        creator.addAssertionStatement(THING, RDFS.LABEL, vf.createLiteral("the thing"));
+        creator.addAssertionStatement(NAME, RDF.TYPE, NTEMPLATE.LITERAL_PLACEHOLDER);
+        creator.addAssertionStatement(NAME, RDFS.LABEL, vf.createLiteral("the name"));
+        return creator;
+    }
+
+    private static NanopubCreator wellFormedCreator() throws Exception {
+        NanopubCreator creator = singleStatementCreator();
+        creator.addAssertionStatement(ST1, RDF.SUBJECT, THING);
+        creator.addAssertionStatement(ST1, RDF.PREDICATE, RDFS.LABEL);
+        creator.addAssertionStatement(ST1, RDF.OBJECT, NAME);
+        return creator;
+    }
+
+    @Test
+    void wellFormedStatementHasNoErrors() throws Exception {
+        Template t = new Template(wellFormedCreator().finalizeNanopub());
+        assertEquals(List.of(), t.getStatementErrors());
+    }
+
+    @Test
+    void literalPlaceholderInSubjectPositionIsReported() throws Exception {
+        NanopubCreator creator = singleStatementCreator();
+        creator.addAssertionStatement(ST1, RDF.SUBJECT, NAME);
+        creator.addAssertionStatement(ST1, RDF.PREDICATE, RDFS.LABEL);
+        creator.addAssertionStatement(ST1, RDF.OBJECT, THING);
+        List<String> errors = new Template(creator.finalizeNanopub()).getStatementErrors();
+        assertEquals(1, errors.size(), errors.toString());
+        assertTrue(errors.get(0).contains("\"the name\" (name)"), errors.get(0));
+        assertTrue(errors.get(0).contains("subject position"), errors.get(0));
+    }
+
+    @Test
+    void literalPlaceholderInPredicatePositionIsReported() throws Exception {
+        NanopubCreator creator = singleStatementCreator();
+        creator.addAssertionStatement(ST1, RDF.SUBJECT, THING);
+        creator.addAssertionStatement(ST1, RDF.PREDICATE, NAME);
+        creator.addAssertionStatement(ST1, RDF.OBJECT, THING);
+        List<String> errors = new Template(creator.finalizeNanopub()).getStatementErrors();
+        assertEquals(1, errors.size(), errors.toString());
+        assertTrue(errors.get(0).contains("predicate position"), errors.get(0));
+    }
+
+    @Test
+    void literalPlaceholderInObjectPositionIsFine() throws Exception {
+        Template t = new Template(wellFormedCreator().finalizeNanopub());
+        assertEquals(List.of(), t.getStatementErrors());
+    }
+
+    @Test
+    void literalInSubjectPositionIsReportedAndKeptForRendering() throws Exception {
+        NanopubCreator creator = singleStatementCreator();
+        creator.addAssertionStatement(ST1, RDF.SUBJECT, vf.createLiteral("not a URI"));
+        creator.addAssertionStatement(ST1, RDF.PREDICATE, RDFS.LABEL);
+        creator.addAssertionStatement(ST1, RDF.OBJECT, NAME);
+        Template t = new Template(creator.finalizeNanopub());
+        List<String> errors = t.getStatementErrors();
+        assertEquals(1, errors.size(), errors.toString());
+        assertTrue(errors.get(0).contains("\"not a URI\""), errors.get(0));
+        assertTrue(errors.get(0).contains("subject position"), errors.get(0));
+        // The literal is not a valid subject, so the IRI-typed accessor stays empty, but the
+        // declared value is kept so the form can show the user what is wrong:
+        assertNull(t.getSubject(ST1));
+        assertEquals(vf.createLiteral("not a URI"), t.getDeclaredSubject(ST1));
+    }
+
+    @Test
+    void undefinedStatementIsReported() throws Exception {
+        // Statement referenced by nt:hasStatement but never given a subject/predicate/object:
+        Template t = new Template(singleStatementCreator().finalizeNanopub());
+        List<String> errors = t.getStatementErrors();
+        assertEquals(2, errors.size(), errors.toString());
+        assertTrue(errors.get(0).contains("no subject is defined"), errors.get(0));
+        assertTrue(errors.get(1).contains("no predicate is defined"), errors.get(1));
+    }
+
+    @Test
+    void errorNamesStatementByNumberAndLocalName() throws Exception {
+        NanopubCreator creator = singleStatementCreator();
+        creator.addAssertionStatement(ST1, RDF.SUBJECT, NAME);
+        creator.addAssertionStatement(ST1, RDF.PREDICATE, RDFS.LABEL);
+        creator.addAssertionStatement(ST1, RDF.OBJECT, THING);
+        List<String> errors = new Template(creator.finalizeNanopub()).getStatementErrors();
+        assertTrue(errors.get(0).startsWith("Statement 1 (st1):"), errors.get(0));
+    }
+
+    @Test
+    void groupMemberErrorIsNumberedWithinItsGroup() throws Exception {
+        IRI group = vf.createIRI(NP_URI + "/group");
+        IRI st2 = vf.createIRI(NP_URI + "/st2");
+        NanopubCreator creator = singleStatementCreator();
+        creator.addAssertionStatement(creator.getAssertionUri(), NTEMPLATE.HAS_STATEMENT, group);
+        creator.addAssertionStatement(group, RDF.TYPE, NTEMPLATE.GROUPED_STATEMENT);
+        creator.addAssertionStatement(group, NTEMPLATE.HAS_STATEMENT, ST1);
+        creator.addAssertionStatement(group, NTEMPLATE.HAS_STATEMENT, st2);
+        creator.addAssertionStatement(ST1, RDF.SUBJECT, THING);
+        creator.addAssertionStatement(ST1, RDF.PREDICATE, RDFS.LABEL);
+        creator.addAssertionStatement(ST1, RDF.OBJECT, NAME);
+        creator.addAssertionStatement(st2, RDF.SUBJECT, NAME);
+        creator.addAssertionStatement(st2, RDF.PREDICATE, RDFS.LABEL);
+        creator.addAssertionStatement(st2, RDF.OBJECT, THING);
+        List<String> errors = new Template(creator.finalizeNanopub()).getStatementErrors();
+        assertEquals(1, errors.size(), errors.toString());
+        assertTrue(errors.get(0).startsWith("Statement 1.2 (st2):"), errors.get(0));
+    }
+
+}


### PR DESCRIPTION
Closes the issue that a template statement can put a literal in subject or predicate position, e.g. [RA-Meh2D…](https://w3id.org/np/RA-Meh2D4oWxwU_3hkOzETTJ01TW9WliWVONq4oCnIthM), whose `st71` uses the `nt:LiteralPlaceholder` `sub:abundance` as its subject.

## The problem

Such a template rendered like any other and gave no indication of a problem. On publish, `TemplateContext.processIri` fell back to returning the placeholder's own IRI, so the nanopublication carried a meaningless URI (`…/abundance`) as subject rather than the literal the user entered — silently wrong data.

Two related cases failed even harder, with a bare `NullPointerException` that killed the whole form: a *plain literal* in `rdf:subject`/`rdf:predicate` was dropped at parse time by the `obj instanceof IRI` guard, and a statement referenced by `nt:hasStatement` but never defined left the position empty. The latter is not hypothetical — both published versions of the Rosetta Statement template (`RA8c438Y…`, `RAQL814V…`) reference `st16`–`st20` without defining them.

## The change

`Template.getStatementErrors()` returns human-readable descriptions of statements that cannot produce valid RDF — a literal, a literal placeholder, or nothing at all in subject or predicate position:

> Statement 10 (st71): the literal placeholder "species abundance" (abundance) is used in subject position, but only URIs are allowed there.

These are surfaced in two places:

- **Template form preview** (`TemplateFormPreview`, used by both `PreviewPage` and `ViewPage`) lists them in a red box above the form. The form still renders below it, so the offending row can be found.
- **Publish form** (`PublishForm`) lists them above the form, tagged with which of the three templates they came from (Assertion / Provenance / Publication info), and removes the consent checkbox together with the Publish and Preview buttons, replacing them with a short reason.

Hiding the buttons alone would not be enough — a Wicket form still submits on Enter in a text field — so `Form.onSubmit` and the preview button's `onSubmit` both refuse to proceed as well. That is the actual enforcement.

To make the two crashing cases renderable, literals in subject/predicate are now kept during parsing (in separate maps, so `getSubject`/`getPredicate` stay `IRI`-typed as the rest of the code expects) and exposed through new `getDeclaredSubject`/`getDeclaredPredicate`, which `StatementItem` uses for rendering. `ValueItem` renders a new `MissingValueItem` (`(missing)`) instead of dereferencing null, and `Template.transform` tolerates null so the `is*Placeholder` lookups answer "no" rather than throwing.

## Testing

- `StatementErrorTest` — the detection rules, including group-member numbering and that a literal in object position stays fine.
- `TemplateFormPreviewTest` — renders the panel for the literal-placeholder, literal-constant and undefined-statement cases, plus a clean template.
- `PublishFormTemplateErrorTest` — renders the publish form and checks the errors appear, the consent and buttons disappear, and that a well-formed template keeps all of them. That last case also loads the default provenance and pubinfo templates, so it guards against the standard set ever tripping the check and disabling publishing for everyone.

I also ran the new check over all 195 published assertion templates from `AllAssertionTemplatesLoadingTest`: no false positives, only the two genuinely broken Rosetta templates above. Those forms were already unpublishable (`addTriplesTo` threw "Field of statement not set." on submit), so nothing that used to work stops working — their users now see a clear reason up front instead of an error after clicking Publish.

Not addressed here: prevention at template *creation* time, which the issue expected to be difficult. An author who previews before publishing does now see the error, but is not stopped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)