### PR TITLE
feat: add a "nanopub not found" page (#270)

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/NanodashThreadPool.java
+++ b/src/main/java/com/knowledgepixels/nanodash/NanodashThreadPool.java
@@ -39,4 +39,17 @@ public class NanodashThreadPool {
         return POOL.submit(task);
     }
 
+    /**
+     * Submits a task that produces a result. Note that under the caller-runs policy a
+     * task may end up running in the calling thread when the pool is saturated, in which
+     * case waiting on the returned future with a timeout doesn't bound the wait.
+     *
+     * @param task the task to run
+     * @param <T>  the type of the task's result
+     * @return a future holding the task's result
+     */
+    public static <T> Future<T> submit(Callable<T> task) {
+        return POOL.submit(task);
+    }
+
 }

--- a/src/main/java/com/knowledgepixels/nanodash/NanopubLookup.java
+++ b/src/main/java/com/knowledgepixels/nanodash/NanopubLookup.java
@@ -1,6 +1,10 @@
 package com.knowledgepixels.nanodash;
 
+import net.trustyuri.ArtifactCode;
+import net.trustyuri.ModuleDirectory;
+import net.trustyuri.TrustyUriModule;
 import net.trustyuri.TrustyUriUtils;
+import net.trustyuri.rdf.RdfModule;
 import org.nanopub.Nanopub;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -10,7 +14,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
-import java.util.regex.Pattern;
 
 /**
  * The outcome of looking up a nanopublication by its identifier.
@@ -35,14 +38,6 @@ public class NanopubLookup {
      * from the cache if the user tries again.
      */
     public static final long DEFAULT_TIMEOUT_MS = 15_000;
-
-    /**
-     * A last path segment that is apparently an attempt at an RDF-module artifact code
-     * (starts with "RA", made up of artifact-code characters, roughly the right length)
-     * without being a valid one — typically a truncated or mistyped copy-paste. A valid
-     * code is "RA" followed by exactly 43 characters.
-     */
-    private static final Pattern APPARENT_ARTIFACT_CODE = Pattern.compile("^RA[A-Za-z0-9\\-_]{28,58}$");
 
     /**
      * Why a lookup did or didn't produce a nanopublication.
@@ -169,15 +164,14 @@ public class NanopubLookup {
 
     /**
      * Checks whether the given identifier could denote a nanopublication, i.e. whether it
-     * ends in a valid trusty URI artifact code. This says nothing about whether such a
-     * nanopublication exists.
+     * ends in a valid artifact code of the RDF module — the only kind a nanopublication
+     * carries. This says nothing about whether such a nanopublication exists.
      *
      * @param id the identifier to check
      * @return true if the identifier is a well-formed nanopublication identifier
      */
     public static boolean isPotentialNanopubId(String id) {
-        if (id == null || id.isBlank()) return false;
-        return TrustyUriUtils.isPotentialTrustyUri(id);
+        return nanopubArtifactCode(id) != null;
     }
 
     /**
@@ -190,9 +184,48 @@ public class NanopubLookup {
      * @return true if the identifier looks like a malformed nanopublication identifier
      */
     public static boolean looksLikeMalformedNanopubId(String id) {
-        if (id == null || id.isBlank() || isPotentialNanopubId(id)) return false;
-        String lastSegment = id.replaceFirst("^.*[/#]", "");
-        return APPARENT_ARTIFACT_CODE.matcher(lastSegment).matches();
+        // Claims our module, yet doesn't form a valid artifact code for it: a trusty URI
+        // that lost or gained characters on the way.
+        return moduleOf(id) instanceof RdfModule && nanopubArtifactCode(id) == null;
+    }
+
+    /**
+     * Returns the artifact code the given identifier ends in, as long as it is a valid one
+     * of the RDF module — the only kind a nanopublication carries. Anything else yields
+     * null: no artifact code at all, a malformed one, or one of another trusty URI module,
+     * which then denotes something other than a nanopublication.
+     *
+     * @param id the identifier to take apart
+     * @return the artifact code, or null if the identifier doesn't carry one of ours
+     */
+    private static ArtifactCode nanopubArtifactCode(String id) {
+        String artifactCode = trailingArtifactCode(id);
+        if (artifactCode == null || !TrustyUriUtils.isPotentialArtifactCode(artifactCode)) return null;
+        ArtifactCode code = ArtifactCode.of(artifactCode);
+        return code.getModule() instanceof RdfModule ? code : null;
+    }
+
+    /**
+     * Returns the trusty URI module the given identifier claims by the prefix of its
+     * trailing artifact code, whether or not that code is well-formed.
+     *
+     * @param id the identifier to take apart
+     * @return the module, or null if the identifier claims none
+     */
+    private static TrustyUriModule moduleOf(String id) {
+        String artifactCode = trailingArtifactCode(id);
+        return artifactCode == null ? null : ModuleDirectory.getModule(TrustyUriUtils.getModuleId(artifactCode));
+    }
+
+    /**
+     * Returns the artifact-code-shaped tail of the given identifier, valid or not.
+     *
+     * @param id the identifier to take apart
+     * @return the tail, or null if the identifier doesn't end in one
+     */
+    private static String trailingArtifactCode(String id) {
+        if (id == null || id.isBlank()) return null;
+        return TrustyUriUtils.getArtifactCode(id);
     }
 
     /**

--- a/src/main/java/com/knowledgepixels/nanodash/NanopubLookup.java
+++ b/src/main/java/com/knowledgepixels/nanodash/NanopubLookup.java
@@ -1,0 +1,243 @@
+package com.knowledgepixels.nanodash;
+
+import net.trustyuri.TrustyUriUtils;
+import org.nanopub.Nanopub;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
+import java.util.regex.Pattern;
+
+/**
+ * The outcome of looking up a nanopublication by its identifier.
+ * <p>
+ * Retrieving a nanopublication can fail in ways that mean very different things to the
+ * user, and that should therefore be shown differently: a mistyped or truncated
+ * identifier is a problem with the request, whereas a well-formed identifier that
+ * doesn't resolve simply means the nanopublication isn't (yet) on the network. The
+ * latter includes the case where the lookup takes too long: the network is queried
+ * registry by registry, so a lookup gets a time budget and is reported as unresolved
+ * once that is exceeded, rather than leaving the user waiting indefinitely.
+ *
+ * @see com.knowledgepixels.nanodash.page.NanopubNotFoundPage
+ */
+public class NanopubLookup {
+
+    private static final Logger logger = LoggerFactory.getLogger(NanopubLookup.class);
+
+    /**
+     * Time budget for a single lookup, in milliseconds. The retrieval itself keeps
+     * running in the background when this is exceeded, so its result is available
+     * from the cache if the user tries again.
+     */
+    public static final long DEFAULT_TIMEOUT_MS = 15_000;
+
+    /**
+     * A last path segment that is apparently an attempt at an RDF-module artifact code
+     * (starts with "RA", made up of artifact-code characters, roughly the right length)
+     * without being a valid one — typically a truncated or mistyped copy-paste. A valid
+     * code is "RA" followed by exactly 43 characters.
+     */
+    private static final Pattern APPARENT_ARTIFACT_CODE = Pattern.compile("^RA[A-Za-z0-9\\-_]{28,58}$");
+
+    /**
+     * Why a lookup did or didn't produce a nanopublication.
+     */
+    public enum Status {
+
+        /**
+         * The nanopublication was retrieved.
+         */
+        FOUND,
+
+        /**
+         * The given identifier is not a well-formed nanopublication (trusty) URI, so it
+         * cannot refer to any nanopublication at all.
+         */
+        INVALID_ID,
+
+        /**
+         * The identifier is well-formed, but no nanopublication with it was found on the
+         * network.
+         */
+        NOT_FOUND,
+
+        /**
+         * The identifier is well-formed, but the network didn't answer within the time
+         * budget. The nanopublication may or may not exist.
+         */
+        TIMEOUT
+
+    }
+
+    private final Status status;
+    private final Nanopub nanopub;
+    private final String id;
+    private final String errorMessage;
+
+    private NanopubLookup(Status status, Nanopub nanopub, String id, String errorMessage) {
+        this.status = status;
+        this.nanopub = nanopub;
+        this.id = id;
+        this.errorMessage = errorMessage;
+    }
+
+    /**
+     * Wraps an already-available nanopublication as a successful lookup, for callers that
+     * got hold of it by other means than a network lookup.
+     *
+     * @param nanopub the nanopublication
+     * @return a lookup with status {@link Status#FOUND}
+     */
+    public static NanopubLookup found(Nanopub nanopub) {
+        return new NanopubLookup(Status.FOUND, nanopub, nanopub.getUri().stringValue(), null);
+    }
+
+    /**
+     * Looks up the nanopublication with the given identifier, using the default time
+     * budget.
+     *
+     * @param id the nanopublication identifier (trusty URI or artifact code)
+     * @return the outcome of the lookup, never null
+     */
+    public static NanopubLookup lookUp(String id) {
+        return lookUp(id, DEFAULT_TIMEOUT_MS);
+    }
+
+    /**
+     * Looks up the nanopublication with the given identifier.
+     *
+     * @param id        the nanopublication identifier (trusty URI or artifact code)
+     * @param timeoutMs how long to wait for the network before giving up, in milliseconds
+     * @return the outcome of the lookup, never null
+     */
+    public static NanopubLookup lookUp(String id, long timeoutMs) {
+        return lookUp(id, timeoutMs, Utils::getNanopub);
+    }
+
+    /**
+     * Looks up the nanopublication with the given identifier, using the given retrieval
+     * function instead of the default one. For callers that fetch nanopublications in
+     * their own way, and for tests, which must not depend on the network.
+     *
+     * @param id        the nanopublication identifier (trusty URI or artifact code)
+     * @param timeoutMs how long to wait for the retrieval before giving up, in milliseconds
+     * @param retriever fetches the nanopublication for an identifier, returning null if
+     *                  there is none
+     * @return the outcome of the lookup, never null
+     */
+    public static NanopubLookup lookUp(String id, long timeoutMs, Function<String, Nanopub> retriever) {
+        if (id == null || id.isBlank()) {
+            return new NanopubLookup(Status.INVALID_ID, null, id, "No nanopublication identifier was given.");
+        }
+        if (!isPotentialNanopubId(id)) {
+            return new NanopubLookup(Status.INVALID_ID, null, id,
+                    "'" + id + "' is not a valid nanopublication identifier. Such an identifier ends in a trusty URI" +
+                            " artifact code, i.e. 'RA' followed by 43 letters, digits, hyphens or underscores.");
+        }
+        Future<Nanopub> retrieval = NanodashThreadPool.submit(() -> retriever.apply(id));
+        try {
+            Nanopub np = retrieval.get(timeoutMs, TimeUnit.MILLISECONDS);
+            if (np == null) {
+                return new NanopubLookup(Status.NOT_FOUND, null, id, null);
+            }
+            return new NanopubLookup(Status.FOUND, np, id, null);
+        } catch (TimeoutException ex) {
+            // Deliberately not cancelled: the retrieval fills the nanopub cache when it
+            // eventually completes, so a retry by the user can be answered right away.
+            logger.info("Retrieving nanopublication timed out after {} ms: {}", timeoutMs, id);
+            return new NanopubLookup(Status.TIMEOUT, null, id, null);
+        } catch (ExecutionException ex) {
+            Throwable cause = ex.getCause();
+            if (cause instanceof IllegalArgumentException) {
+                logger.info("Not a nanopublication identifier: {}", id, cause);
+                return new NanopubLookup(Status.INVALID_ID, null, id,
+                        "'" + id + "' is not a valid nanopublication identifier: " + cause.getMessage());
+            }
+            logger.error("Error while retrieving nanopublication: {}", id, cause);
+            return new NanopubLookup(Status.NOT_FOUND, null, id, null);
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            logger.warn("Interrupted while retrieving nanopublication: {}", id);
+            return new NanopubLookup(Status.TIMEOUT, null, id, null);
+        }
+    }
+
+    /**
+     * Checks whether the given identifier could denote a nanopublication, i.e. whether it
+     * ends in a valid trusty URI artifact code. This says nothing about whether such a
+     * nanopublication exists.
+     *
+     * @param id the identifier to check
+     * @return true if the identifier is a well-formed nanopublication identifier
+     */
+    public static boolean isPotentialNanopubId(String id) {
+        if (id == null || id.isBlank()) return false;
+        return TrustyUriUtils.isPotentialTrustyUri(id);
+    }
+
+    /**
+     * Checks whether the given identifier is apparently meant to be a nanopublication
+     * identifier without being a valid one, e.g. a trusty URI that lost characters on the
+     * way. Used to tell a broken nanopublication link apart from an ordinary (non-trusty)
+     * term URI, which is a perfectly valid thing to look up.
+     *
+     * @param id the identifier to check
+     * @return true if the identifier looks like a malformed nanopublication identifier
+     */
+    public static boolean looksLikeMalformedNanopubId(String id) {
+        if (id == null || id.isBlank() || isPotentialNanopubId(id)) return false;
+        String lastSegment = id.replaceFirst("^.*[/#]", "");
+        return APPARENT_ARTIFACT_CODE.matcher(lastSegment).matches();
+    }
+
+    /**
+     * Returns why the lookup did or didn't produce a nanopublication.
+     *
+     * @return the status, never null
+     */
+    public Status getStatus() {
+        return status;
+    }
+
+    /**
+     * Checks whether the nanopublication was found.
+     *
+     * @return true if the nanopublication was retrieved
+     */
+    public boolean isFound() {
+        return status == Status.FOUND;
+    }
+
+    /**
+     * Returns the retrieved nanopublication.
+     *
+     * @return the nanopublication, or null if it wasn't found
+     */
+    public Nanopub getNanopub() {
+        return nanopub;
+    }
+
+    /**
+     * Returns the identifier this lookup was made for.
+     *
+     * @return the identifier, as given by the caller
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Returns a message explaining what is wrong with the identifier.
+     *
+     * @return the message, or null if the identifier itself is fine
+     */
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+}

--- a/src/main/java/com/knowledgepixels/nanodash/Utils.java
+++ b/src/main/java/com/knowledgepixels/nanodash/Utils.java
@@ -49,6 +49,7 @@ import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -114,7 +115,8 @@ public class Utils {
         return TrustyUriUtils.getArtifactCode(npId.toString()).substring(0, 10);
     }
 
-    private static Map<String, Nanopub> nanopubs = new HashMap<>();
+    // Concurrent, as retrieval also happens on background threads (see NanopubLookup):
+    private static Map<String, Nanopub> nanopubs = new ConcurrentHashMap<>();
 
     /**
      * Adds a nanopublication to the local cache so it can be retrieved immediately

--- a/src/main/java/com/knowledgepixels/nanodash/WicketApplication.java
+++ b/src/main/java/com/knowledgepixels/nanodash/WicketApplication.java
@@ -147,6 +147,7 @@ public class WicketApplication extends WebApplication implements NanopubPublishe
         mountPage(ErrorPage.MOUNT_PATH, ErrorPage.class);
         mountPage("/error/404", ErrorPage.class);
         mountPage("/error/500", ErrorPage.class);
+        mountPage(NanopubNotFoundPage.MOUNT_PATH, NanopubNotFoundPage.class);
 
         mountPage(UserPage.MOUNT_PATH, UserPage.class);
         mountPage(ChannelPage.MOUNT_PATH, ChannelPage.class);

--- a/src/main/java/com/knowledgepixels/nanodash/page/ErrorPage.html
+++ b/src/main/java/com/knowledgepixels/nanodash/page/ErrorPage.html
@@ -13,6 +13,7 @@
   <div class="row-section">
     <div class="col-12">
       <h2>An error has happened... :(</h2>
+      <div wicket:id="message" class="message"></div>
     </div>
   </div>
 </wicket:extend>

--- a/src/main/java/com/knowledgepixels/nanodash/page/ErrorPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/ErrorPage.java
@@ -1,6 +1,7 @@
 package com.knowledgepixels.nanodash.page;
 
 import com.knowledgepixels.nanodash.component.TitleBar;
+import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.request.http.WebResponse;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
 
@@ -13,6 +14,13 @@ public class ErrorPage extends NanodashPage {
      * The mount path for the error page.
      */
     public static final String MOUNT_PATH = "/error";
+
+    /**
+     * Page parameter holding an optional message with details about what went wrong. It
+     * is shown to the user, so it should explain the problem in plain words rather than
+     * expose internals.
+     */
+    public static final String MESSAGE_PARAM = "message";
 
     /**
      * {@inheritDoc}
@@ -31,6 +39,8 @@ public class ErrorPage extends NanodashPage {
     public ErrorPage(final PageParameters parameters) {
         super(parameters);
         add(new TitleBar("titlebar", this, null));
+        String message = parameters.get(MESSAGE_PARAM).toString("");
+        add(new Label("message", message).setVisible(!message.isBlank()));
     }
 
     /**

--- a/src/main/java/com/knowledgepixels/nanodash/page/ExplorePage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/ExplorePage.java
@@ -164,7 +164,7 @@ public class ExplorePage extends NanodashPage {
 
         Map<String, String> nanopubParams = new HashMap<>();
         nanopubParams.put("ref", tempRef);
-        Nanopub np = Utils.getAsNanopub(tempRef);
+        Nanopub np = resolveNanopub(tempRef);
         boolean isNanopubId = (np != null);
         if (isNanopubId) {
             tempRef = np.getUri().stringValue();
@@ -392,6 +392,33 @@ public class ExplorePage extends NanodashPage {
         nanopubSection.setVisible(contentTab && hasNanopub);
         infoSection.setVisible(publishedNanopub == null && contentTab && !hasNanopub);
         referencesSection.setVisible(!contentTab);
+    }
+
+    /**
+     * Resolves the explored reference to the nanopublication it denotes, if it denotes
+     * one. Plain term IRIs resolve to null and are then shown as things rather than as
+     * nanopublications. A reference that is meant to denote a nanopublication but doesn't
+     * resolve leaves nothing to show, so it is sent to the "not found" page instead —
+     * or, when the identifier itself is broken, to the error page telling the user what
+     * is wrong with it.
+     *
+     * @param ref the explored reference
+     * @return the nanopublication, or null if the reference doesn't denote one
+     */
+    private Nanopub resolveNanopub(String ref) {
+        // A nanopublication published a moment ago is at hand already, and isn't
+        // necessarily retrievable from the network yet:
+        if (publishedNanopub != null) return publishedNanopub;
+        if (NanopubLookup.isPotentialNanopubId(ref)) {
+            NanopubLookup lookup = NanopubLookup.lookUp(ref);
+            if (lookup.isFound()) return lookup.getNanopub();
+            NanopubNotFoundPage.forwardFor(lookup);
+        } else if (NanopubLookup.looksLikeMalformedNanopubId(ref)) {
+            // Apparently a nanopublication link that got mangled on the way; the lookup
+            // reports what is wrong with it without going to the network.
+            NanopubNotFoundPage.forwardFor(NanopubLookup.lookUp(ref));
+        }
+        return null;
     }
 
     /**

--- a/src/main/java/com/knowledgepixels/nanodash/page/NanopubNotFoundPage.html
+++ b/src/main/java/com/knowledgepixels/nanodash/page/NanopubNotFoundPage.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html xmlns:wicket="http://wicket.apache.org">
+<head>
+  <wicket:remove>
+    <link rel="stylesheet" href="../../../../../webapp/style.css?for-local-testing-only" type="text/css" media="screen" title="Stylesheet" />
+  </wicket:remove>
+  <wicket:head>
+    <title>Nanopublication not found | nanodash</title>
+  </wicket:head>
+</head>
+<body>
+<wicket:extend>
+
+  <div class="row-section">
+    <div class="col-12">
+      <h2>🔍 Nanopublication not found</h2>
+      <div class="message">
+        <p>The nanopublication you are looking for couldn't be found on the network.</p>
+        <p wicket:id="explanation"></p>
+        <p><code wicket:id="nanopub-id"></code></p>
+      </div>
+      <p>
+        <a class="button" href="." wicket:id="retry-link">try again</a>
+        <a class="button" href="." wicket:id="home-link">to the homepage</a>
+      </p>
+    </div>
+  </div>
+
+</wicket:extend>
+</body>
+</html>

--- a/src/main/java/com/knowledgepixels/nanodash/page/NanopubNotFoundPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/NanopubNotFoundPage.java
@@ -1,0 +1,129 @@
+package com.knowledgepixels.nanodash.page;
+
+import com.knowledgepixels.nanodash.NanopubLookup;
+import com.knowledgepixels.nanodash.component.TitleBar;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.wicket.RestartResponseException;
+import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.link.BookmarkablePageLink;
+import org.apache.wicket.request.http.WebResponse;
+import org.apache.wicket.request.mapper.parameter.PageParameters;
+
+/**
+ * The page shown when a nanopublication that was asked for couldn't be retrieved, even
+ * though the identifier itself is well-formed. This is a normal outcome rather than a
+ * malfunction — the nanopublication may never have been published, may have been
+ * published to a network this instance doesn't reach, or may not have propagated to the
+ * registries yet — so it gets its own page instead of the generic error page. A
+ * malformed identifier is a different matter and goes to {@link ErrorPage} with the
+ * details of what is wrong with it.
+ *
+ * @see NanopubLookup
+ */
+public class NanopubNotFoundPage extends NanodashPage {
+
+    /**
+     * The mount path for this page.
+     */
+    public static final String MOUNT_PATH = "/nanopub-not-found";
+
+    /**
+     * Page parameter holding the identifier that couldn't be resolved.
+     */
+    public static final String ID_PARAM = "id";
+
+    /**
+     * Page parameter set when the lookup ran out of time instead of coming back empty.
+     */
+    public static final String TIMEOUT_PARAM = "timeout";
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getMountPath() {
+        return MOUNT_PATH;
+    }
+
+    private final boolean timedOut;
+
+    /**
+     * Shows the outcome of a failed nanopublication lookup on the page it belongs on, by
+     * aborting the current request: this page when the identifier is well-formed but
+     * doesn't resolve, the generic error page (with details) when it is malformed.
+     *
+     * @param lookup the failed lookup
+     * @throws RestartResponseException always, to render the other page instead
+     * @throws IllegalArgumentException if the lookup did find a nanopublication
+     */
+    public static void forwardFor(NanopubLookup lookup) {
+        switch (lookup.getStatus()) {
+            case FOUND -> throw new IllegalArgumentException("Nanopublication was found, nothing to forward to");
+            case INVALID_ID -> throw new RestartResponseException(ErrorPage.class,
+                    new PageParameters().set(ErrorPage.MESSAGE_PARAM, lookup.getErrorMessage()));
+            default -> {
+                PageParameters params = new PageParameters().set(ID_PARAM, lookup.getId());
+                if (lookup.getStatus() == NanopubLookup.Status.TIMEOUT) {
+                    params.set(TIMEOUT_PARAM, "true");
+                }
+                throw new RestartResponseException(NanopubNotFoundPage.class, params);
+            }
+        }
+    }
+
+    /**
+     * Constructor for NanopubNotFoundPage.
+     *
+     * @param parameters Page parameters containing the identifier that couldn't be
+     *                   resolved, and optionally whether the lookup timed out.
+     */
+    public NanopubNotFoundPage(final PageParameters parameters) {
+        super(parameters);
+        add(new TitleBar("titlebar", this, null));
+
+        String id = parameters.get(ID_PARAM).toString("");
+        timedOut = parameters.get(TIMEOUT_PARAM).toBoolean(false);
+
+        add(new Label("explanation", timedOut
+                ? "Looking it up took too long, so it couldn't be shown here. It may well be out there: the network" +
+                  " is slow to answer right now, or the nanopublication sits on a registry that is taking its time." +
+                  " Trying again in a moment is likely to help."
+                : "It may never have been published or it may have been published in a registry not connected to this instance and not propagated to others yet."));
+        add(new Label("nanopub-id", id).setVisible(!id.isEmpty()));
+
+        // Retrying is worth offering: a lookup that timed out here keeps running in the
+        // background, so the nanopublication may well be in the cache by now.
+        add(new BookmarkablePageLink<Void>("retry-link", ExplorePage.class, new PageParameters().set("id", id))
+                .setVisible(!id.isEmpty()));
+        add(new BookmarkablePageLink<Void>("home-link", HomePage.class));
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Answers with the HTTP status that matches the reason the nanopublication couldn't
+     * be shown, so that clients other than browsers can tell the two apart too.
+     */
+    @Override
+    protected void configureResponse(WebResponse response) {
+        super.configureResponse(response);
+        response.setStatus(timedOut ? HttpServletResponse.SC_GATEWAY_TIMEOUT : HttpServletResponse.SC_NOT_FOUND);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isVersioned() {
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isErrorPage() {
+        return true;
+    }
+
+}

--- a/src/main/java/com/knowledgepixels/nanodash/page/ViewPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/ViewPage.java
@@ -4,6 +4,7 @@ import java.io.ByteArrayInputStream;
 import java.util.Base64;
 
 import com.knowledgepixels.nanodash.NanopubElement;
+import com.knowledgepixels.nanodash.NanopubLookup;
 import com.knowledgepixels.nanodash.Utils;
 import com.knowledgepixels.nanodash.component.NanopubItem;
 import com.knowledgepixels.nanodash.component.TemplateFormPreview;
@@ -62,8 +63,13 @@ public class ViewPage extends NanodashPage {
                 throw new RuntimeException("Failed to parse nanopub from '_nanopub_trig' parameter", ex);
             }
         } else {
-            String ref = parameters.get("id").toString();
-            np = Utils.getAsNanopub(ref);
+            // Nothing to show without the nanopub itself, so a failed lookup goes to the
+            // not-found page (or, for a malformed id, the error page explaining why).
+            NanopubLookup lookup = NanopubLookup.lookUp(parameters.get("id").toString());
+            if (!lookup.isFound()) {
+                NanopubNotFoundPage.forwardFor(lookup);
+            }
+            np = lookup.getNanopub();
         }
         boolean showHeader = "on".equals(parameters.get("show-header").toOptionalString());
         boolean showFooter = "on".equals(parameters.get("show-footer").toOptionalString());

--- a/src/test/java/com/knowledgepixels/nanodash/NanopubLookupTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/NanopubLookupTest.java
@@ -31,6 +31,24 @@ class NanopubLookupTest {
     }
 
     @Test
+    void idOfAnyWrongLengthIsRecognizedAsMalformedNanopubId() {
+        for (String wrongLength : new String[]{VALID_ID.substring(0, VALID_ID.length() - 18), VALID_ID + "abc"}) {
+            assertFalse(NanopubLookup.isPotentialNanopubId(wrongLength), wrongLength);
+            assertTrue(NanopubLookup.looksLikeMalformedNanopubId(wrongLength), wrongLength);
+        }
+    }
+
+    // Artifact codes of other trusty URI modules (files, for one) denote things that are
+    // not nanopublications, whole or broken, so neither predicate claims them.
+    @Test
+    void artifactCodeOfAnotherModuleIsNoNanopubId() {
+        String fileModuleId = VALID_ID.replaceFirst("/RA", "/FA");
+        assertFalse(NanopubLookup.isPotentialNanopubId(fileModuleId));
+        assertFalse(NanopubLookup.looksLikeMalformedNanopubId(fileModuleId));
+        assertFalse(NanopubLookup.looksLikeMalformedNanopubId(TRUNCATED_ID.replaceFirst("/RA", "/FA")));
+    }
+
+    @Test
     void plainTermIriIsNeitherValidNorMalformedNanopubId() {
         for (String termIri : new String[]{"http://example.com/my-term", "https://w3id.org/np/RAFl3dEa/term", "https://orcid.org/0000-0000-0000-0000"}) {
             assertFalse(NanopubLookup.isPotentialNanopubId(termIri), termIri);

--- a/src/test/java/com/knowledgepixels/nanodash/NanopubLookupTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/NanopubLookupTest.java
@@ -1,0 +1,131 @@
+package com.knowledgepixels.nanodash;
+
+import com.knowledgepixels.nanodash.utils.TestUtils;
+import org.junit.jupiter.api.Test;
+import org.nanopub.MalformedNanopubException;
+import org.nanopub.Nanopub;
+import org.nanopub.NanopubAlreadyFinalizedException;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class NanopubLookupTest {
+
+    // Well-formed nanopublication id: "RA" plus exactly 43 artifact-code characters.
+    private static final String VALID_ID = "https://w3id.org/np/RAFl3dEaZocvP1BAyakcX_cXhFiRQ6uO8K6qMA_3p3j_t";
+    // Same id with the last character lost, as happens with a mangled copy-paste.
+    private static final String TRUNCATED_ID = VALID_ID.substring(0, VALID_ID.length() - 1);
+
+    @Test
+    void wellFormedIdIsRecognized() {
+        assertTrue(NanopubLookup.isPotentialNanopubId(VALID_ID));
+        assertFalse(NanopubLookup.looksLikeMalformedNanopubId(VALID_ID));
+    }
+
+    @Test
+    void truncatedIdIsRecognizedAsMalformedNanopubId() {
+        assertFalse(NanopubLookup.isPotentialNanopubId(TRUNCATED_ID));
+        assertTrue(NanopubLookup.looksLikeMalformedNanopubId(TRUNCATED_ID));
+    }
+
+    @Test
+    void plainTermIriIsNeitherValidNorMalformedNanopubId() {
+        for (String termIri : new String[]{"http://example.com/my-term", "https://w3id.org/np/RAFl3dEa/term", "https://orcid.org/0000-0000-0000-0000"}) {
+            assertFalse(NanopubLookup.isPotentialNanopubId(termIri), termIri);
+            assertFalse(NanopubLookup.looksLikeMalformedNanopubId(termIri), termIri);
+        }
+    }
+
+    @Test
+    void missingIdIsNeitherValidNorMalformedNanopubId() {
+        assertFalse(NanopubLookup.isPotentialNanopubId(null));
+        assertFalse(NanopubLookup.isPotentialNanopubId(" "));
+        assertFalse(NanopubLookup.looksLikeMalformedNanopubId(null));
+        assertFalse(NanopubLookup.looksLikeMalformedNanopubId(" "));
+    }
+
+    @Test
+    void missingIdGivesInvalidIdWithMessage() {
+        NanopubLookup lookup = NanopubLookup.lookUp(null);
+        assertEquals(NanopubLookup.Status.INVALID_ID, lookup.getStatus());
+        assertFalse(lookup.isFound());
+        assertNotNull(lookup.getErrorMessage());
+    }
+
+    @Test
+    void malformedIdGivesInvalidIdWithoutRetrieval() {
+        NanopubLookup lookup = NanopubLookup.lookUp(TRUNCATED_ID, 10_000, id -> {
+            throw new AssertionError("must not try to retrieve a malformed id");
+        });
+        assertEquals(NanopubLookup.Status.INVALID_ID, lookup.getStatus());
+        assertTrue(lookup.getErrorMessage().contains(TRUNCATED_ID));
+        assertEquals(TRUNCATED_ID, lookup.getId());
+    }
+
+    @Test
+    void retrievedNanopubGivesFound() throws MalformedNanopubException, NanopubAlreadyFinalizedException {
+        Nanopub np = TestUtils.createNanopub(VALID_ID);
+        NanopubLookup lookup = NanopubLookup.lookUp(VALID_ID, 10_000, id -> np);
+        assertEquals(NanopubLookup.Status.FOUND, lookup.getStatus());
+        assertTrue(lookup.isFound());
+        assertSame(np, lookup.getNanopub());
+        assertNull(lookup.getErrorMessage());
+    }
+
+    @Test
+    void unavailableNanopubGivesNotFound() {
+        NanopubLookup lookup = NanopubLookup.lookUp(VALID_ID, 10_000, id -> null);
+        assertEquals(NanopubLookup.Status.NOT_FOUND, lookup.getStatus());
+        assertFalse(lookup.isFound());
+        assertNull(lookup.getNanopub());
+        assertEquals(VALID_ID, lookup.getId());
+    }
+
+    @Test
+    void slowRetrievalGivesTimeout() throws InterruptedException {
+        CountDownLatch release = new CountDownLatch(1);
+        try {
+            NanopubLookup lookup = NanopubLookup.lookUp(VALID_ID, 50, id -> {
+                try {
+                    release.await(10, TimeUnit.SECONDS);
+                } catch (InterruptedException ex) {
+                    Thread.currentThread().interrupt();
+                }
+                return null;
+            });
+            assertEquals(NanopubLookup.Status.TIMEOUT, lookup.getStatus());
+            assertFalse(lookup.isFound());
+        } finally {
+            release.countDown();
+        }
+    }
+
+    @Test
+    void nonNanopubTrustyUriGivesInvalidId() {
+        NanopubLookup lookup = NanopubLookup.lookUp(VALID_ID, 10_000, id -> {
+            throw new IllegalArgumentException("Not a trusty URI of type RA");
+        });
+        assertEquals(NanopubLookup.Status.INVALID_ID, lookup.getStatus());
+        assertTrue(lookup.getErrorMessage().contains("Not a trusty URI of type RA"));
+    }
+
+    @Test
+    void retrievalFailureGivesNotFound() {
+        NanopubLookup lookup = NanopubLookup.lookUp(VALID_ID, 10_000, id -> {
+            throw new IllegalStateException("network is down");
+        });
+        assertEquals(NanopubLookup.Status.NOT_FOUND, lookup.getStatus());
+    }
+
+    @Test
+    void foundWrapsAvailableNanopub() throws MalformedNanopubException, NanopubAlreadyFinalizedException {
+        Nanopub np = TestUtils.createNanopub(VALID_ID);
+        NanopubLookup lookup = NanopubLookup.found(np);
+        assertTrue(lookup.isFound());
+        assertSame(np, lookup.getNanopub());
+        assertEquals(VALID_ID, lookup.getId());
+    }
+
+}

--- a/src/test/java/com/knowledgepixels/nanodash/page/ErrorPageTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/page/ErrorPageTest.java
@@ -1,0 +1,33 @@
+package com.knowledgepixels.nanodash.page;
+
+import com.knowledgepixels.nanodash.WicketApplication;
+import org.apache.wicket.request.mapper.parameter.PageParameters;
+import org.apache.wicket.util.tester.WicketTester;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ErrorPageTest {
+
+    private WicketTester tester;
+
+    @BeforeEach
+    void setUp() {
+        tester = new WicketTester(new WicketApplication());
+    }
+
+    @Test
+    void rendersWithoutMessage() {
+        tester.startPage(ErrorPage.class);
+        tester.assertRenderedPage(ErrorPage.class);
+    }
+
+    // Details about what went wrong are shown to the user, so that e.g. a mistyped
+    // nanopublication identifier can be told apart from a malfunction (#270).
+    @Test
+    void rendersGivenMessage() {
+        tester.startPage(ErrorPage.class, new PageParameters().add(ErrorPage.MESSAGE_PARAM, "'x' is not a valid nanopublication identifier."));
+        tester.assertRenderedPage(ErrorPage.class);
+        tester.assertContains("is not a valid nanopublication identifier");
+    }
+
+}

--- a/src/test/java/com/knowledgepixels/nanodash/page/NanopubNotFoundPageTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/page/NanopubNotFoundPageTest.java
@@ -1,0 +1,96 @@
+package com.knowledgepixels.nanodash.page;
+
+import com.knowledgepixels.nanodash.NanopubLookup;
+import com.knowledgepixels.nanodash.WicketApplication;
+import com.knowledgepixels.nanodash.utils.TestUtils;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.wicket.RestartResponseException;
+import org.apache.wicket.request.mapper.parameter.PageParameters;
+import org.apache.wicket.util.tester.WicketTester;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.nanopub.MalformedNanopubException;
+import org.nanopub.NanopubAlreadyFinalizedException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class NanopubNotFoundPageTest {
+
+    // Well-formed nanopublication id: "RA" plus exactly 43 artifact-code characters.
+    private static final String VALID_NANOPUB_URI = "https://w3id.org/np/RAFl3dEaZocvP1BAyakcX_cXhFiRQ6uO8K6qMA_3p3j_t";
+
+    private WicketTester tester;
+
+    @BeforeEach
+    void setUp() {
+        tester = new WicketTester(new WicketApplication());
+    }
+
+    @Test
+    void getMountPathReturnsCorrectPath() {
+        NanopubNotFoundPage page = new NanopubNotFoundPage(new PageParameters().add(NanopubNotFoundPage.ID_PARAM, VALID_NANOPUB_URI));
+        assertEquals(NanopubNotFoundPage.MOUNT_PATH, page.getMountPath());
+        assertTrue(page.isErrorPage());
+    }
+
+    @Test
+    void rendersWithTheIdThatCouldNotBeResolved() {
+        tester.startPage(NanopubNotFoundPage.class, new PageParameters().add(NanopubNotFoundPage.ID_PARAM, VALID_NANOPUB_URI));
+        tester.assertRenderedPage(NanopubNotFoundPage.class);
+        tester.assertContains(VALID_NANOPUB_URI);
+        tester.assertContains("couldn't be found on the network");
+        assertEquals(HttpServletResponse.SC_NOT_FOUND, tester.getLastResponse().getStatus());
+    }
+
+    @Test
+    void rendersTimedOutLookupWithGatewayTimeoutStatus() {
+        tester.startPage(NanopubNotFoundPage.class, new PageParameters()
+                .add(NanopubNotFoundPage.ID_PARAM, VALID_NANOPUB_URI)
+                .add(NanopubNotFoundPage.TIMEOUT_PARAM, "true"));
+        tester.assertRenderedPage(NanopubNotFoundPage.class);
+        tester.assertContains("took too long");
+        assertEquals(HttpServletResponse.SC_GATEWAY_TIMEOUT, tester.getLastResponse().getStatus());
+    }
+
+    @Test
+    void unretrievableNanopubForwardsHere() {
+        NanopubLookup lookup = NanopubLookup.lookUp(VALID_NANOPUB_URI, 10_000, id -> null);
+        RestartResponseException ex = assertThrows(RestartResponseException.class, () -> NanopubNotFoundPage.forwardFor(lookup));
+        assertEquals(NanopubNotFoundPage.class, TestUtils.forwardedPageClass(ex));
+        assertEquals(VALID_NANOPUB_URI, TestUtils.forwardedPageParameters(ex).get(NanopubNotFoundPage.ID_PARAM).toString());
+    }
+
+    @Test
+    void timedOutLookupForwardsHereAndSaysSo() {
+        NanopubLookup lookup = NanopubLookup.lookUp(VALID_NANOPUB_URI, 1, id -> {
+            try {
+                Thread.sleep(2_000);
+            } catch (InterruptedException ex) {
+                Thread.currentThread().interrupt();
+            }
+            return null;
+        });
+        assertEquals(NanopubLookup.Status.TIMEOUT, lookup.getStatus());
+        RestartResponseException ex = assertThrows(RestartResponseException.class, () -> NanopubNotFoundPage.forwardFor(lookup));
+        assertEquals(NanopubNotFoundPage.class, TestUtils.forwardedPageClass(ex));
+        assertTrue(TestUtils.forwardedPageParameters(ex).get(NanopubNotFoundPage.TIMEOUT_PARAM).toBoolean(false));
+    }
+
+    // A malformed identifier is a problem with the request rather than with the network,
+    // so it goes to the error page, which spells out what is wrong with it (#270).
+    @Test
+    void malformedIdForwardsToErrorPageWithDetails() {
+        String malformedId = VALID_NANOPUB_URI.substring(0, VALID_NANOPUB_URI.length() - 1);
+        NanopubLookup lookup = NanopubLookup.lookUp(malformedId);
+        RestartResponseException ex = assertThrows(RestartResponseException.class, () -> NanopubNotFoundPage.forwardFor(lookup));
+        assertEquals(ErrorPage.class, TestUtils.forwardedPageClass(ex));
+        assertTrue(TestUtils.forwardedPageParameters(ex).get(ErrorPage.MESSAGE_PARAM).toString().contains(malformedId));
+    }
+
+    @Test
+    void foundNanopubHasNothingToForwardTo() throws MalformedNanopubException, NanopubAlreadyFinalizedException {
+        NanopubLookup lookup = NanopubLookup.found(TestUtils.createNanopub(VALID_NANOPUB_URI));
+        assertThrows(IllegalArgumentException.class, () -> NanopubNotFoundPage.forwardFor(lookup));
+    }
+
+}

--- a/src/test/java/com/knowledgepixels/nanodash/page/ViewPageTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/page/ViewPageTest.java
@@ -1,8 +1,9 @@
 package com.knowledgepixels.nanodash.page;
 
-import com.knowledgepixels.nanodash.Utils;
+import com.knowledgepixels.nanodash.NanopubLookup;
 import com.knowledgepixels.nanodash.WicketApplication;
 import com.knowledgepixels.nanodash.utils.TestUtils;
+import org.apache.wicket.RestartResponseException;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
 import org.apache.wicket.util.tester.WicketTester;
 import org.junit.jupiter.api.BeforeEach;
@@ -13,10 +14,14 @@ import org.nanopub.Nanopub;
 import org.nanopub.NanopubAlreadyFinalizedException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mockStatic;
 
 class ViewPageTest {
+
+    // Well-formed nanopublication id: "RA" plus exactly 43 artifact-code characters.
+    private static final String VALID_NANOPUB_URI = "https://w3id.org/np/RAFl3dEaZocvP1BAyakcX_cXhFiRQ6uO8K6qMA_3p3j_t";
 
     private WicketTester tester;
 
@@ -28,12 +33,38 @@ class ViewPageTest {
     @Test
     void getMountPathReturnsCorrectPath() throws MalformedNanopubException, NanopubAlreadyFinalizedException {
         Nanopub mockNanopub = TestUtils.createNanopub();
-        try (MockedStatic<Utils> utilsMock = mockStatic(Utils.class)) {
-            utilsMock.when(() -> Utils.getAsNanopub(anyString())).thenReturn(mockNanopub);
+        NanopubLookup found = NanopubLookup.found(mockNanopub);
+        try (MockedStatic<NanopubLookup> lookupMock = mockStatic(NanopubLookup.class)) {
+            lookupMock.when(() -> NanopubLookup.lookUp(anyString())).thenReturn(found);
 
             ViewPage page = new ViewPage(new PageParameters().add("id", TestUtils.NANOPUB_URI));
             assertEquals(ViewPage.MOUNT_PATH, page.getMountPath());
         }
+    }
+
+    // A nanopub that cannot be retrieved leaves this page with nothing to show, so the
+    // user is sent to the page explaining that instead of to a generic error (#270).
+    @Test
+    void unresolvableNanopubForwardsToNotFoundPage() {
+        NanopubLookup notFound = NanopubLookup.lookUp(VALID_NANOPUB_URI, 10_000, id -> null);
+        assertEquals(NanopubLookup.Status.NOT_FOUND, notFound.getStatus());
+        try (MockedStatic<NanopubLookup> lookupMock = mockStatic(NanopubLookup.class)) {
+            lookupMock.when(() -> NanopubLookup.lookUp(anyString())).thenReturn(notFound);
+
+            RestartResponseException ex = assertThrows(RestartResponseException.class,
+                    () -> new ViewPage(new PageParameters().add("id", VALID_NANOPUB_URI)));
+            assertEquals(NanopubNotFoundPage.class, TestUtils.forwardedPageClass(ex));
+        }
+    }
+
+    // A mistyped or truncated identifier is a different matter: there the user gets the
+    // error page, with the details of what is wrong with it (#270).
+    @Test
+    void malformedNanopubIdForwardsToErrorPage() {
+        String malformedId = VALID_NANOPUB_URI.substring(0, VALID_NANOPUB_URI.length() - 1);
+        RestartResponseException ex = assertThrows(RestartResponseException.class,
+                () -> new ViewPage(new PageParameters().add("id", malformedId)));
+        assertEquals(ErrorPage.class, TestUtils.forwardedPageClass(ex));
     }
 
 }

--- a/src/test/java/com/knowledgepixels/nanodash/utils/TestUtils.java
+++ b/src/test/java/com/knowledgepixels/nanodash/utils/TestUtils.java
@@ -1,5 +1,11 @@
 package com.knowledgepixels.nanodash.utils;
 
+import org.apache.wicket.RestartResponseException;
+import org.apache.wicket.core.request.handler.IPageClassRequestHandler;
+import org.apache.wicket.request.IRequestHandler;
+import org.apache.wicket.request.IRequestHandlerDelegate;
+import org.apache.wicket.request.component.IRequestablePage;
+import org.apache.wicket.request.mapper.parameter.PageParameters;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.ValueFactory;
@@ -61,6 +67,32 @@ public class TestUtils {
 
     public static void fillPubInfoGraph(NanopubCreator creator) throws NanopubAlreadyFinalizedException {
         creator.addPubinfoStatement(vf.createStatement(creator.getNanopubUri(), anyIri, anyIri));
+    }
+
+    /**
+     * Returns the request handler a page forward was made to, unwrapping the decorators
+     * Wicket puts around it.
+     */
+    private static IPageClassRequestHandler forwardHandler(RestartResponseException ex) {
+        IRequestHandler handler = ex.getReplacementRequestHandler();
+        while (handler instanceof IRequestHandlerDelegate delegate) {
+            handler = delegate.getDelegateHandler();
+        }
+        return (IPageClassRequestHandler) handler;
+    }
+
+    /**
+     * Returns the page a forward was made to.
+     */
+    public static Class<? extends IRequestablePage> forwardedPageClass(RestartResponseException ex) {
+        return forwardHandler(ex).getPageClass();
+    }
+
+    /**
+     * Returns the parameters a forward was made with.
+     */
+    public static PageParameters forwardedPageParameters(RestartResponseException ex) {
+        return forwardHandler(ex).getPageParameters();
     }
 
 }


### PR DESCRIPTION
Closes #270

Looking up a nanopublication that isn't on the network ended on the generic "An error has happened... :(" page, which reads as a broken server rather than a missing nanopub. Two different situations were landing there, and the issue asks for them to be told apart.

| Situation | Before | After |
| --- | --- | --- |
| Well-formed ID, not on the network | generic error page (`/view`), bare thing page (`/explore`) | "Nanopublication not found" page, HTTP 404 |
| Lookup exceeds its time budget | user waits, then the same | same page, worded for the timeout, HTTP 504 |
| Malformed / truncated trusty URI | generic error page | error page **with details** about what's wrong with the identifier |

### How

- **`NanopubLookup`** classifies a lookup as `FOUND` / `INVALID_ID` / `NOT_FOUND` /
  `TIMEOUT`. Identifiers are taken apart with trustyuri-java (`ArtifactCode`,
  `ModuleDirectory`), so a code of another module — `FA…` file codes are the same
  43 characters — is no longer mistaken for a nanopub ID.
- Retrieval gets a **15s budget** on the shared thread pool. It previously made
  three unbounded passes over every registry with the user waiting throughout.
  The fetch is deliberately *not* cancelled on timeout, so it fills the cache and
  the page's "try again" button usually succeeds.
- **`NanopubNotFoundPage`** explains the situation, shows the identifier, and
  offers retry / home. `forwardFor(lookup)` is the single routing point deciding
  between it and the error page.
- `ExplorePage` only intercepts references that are (or are apparently meant to
  be) nanopub identifiers, so plain term IRIs still render as things. A
  just-published nanopub short-circuits the lookup, so the publish confirmation
  is never bounced away while the nanopub is still propagating.

### Review notes

Five commits, each one concern, each compiling on its own; the behavior change
is confined to the last one but `refactor(NanopubLookup)` — worth reading
together with the first.

Two things worth a second opinion:
- The 15s budget is a constant, not configurable.
- `looksLikeMalformedNanopubId` decides when a broken ID is *apparently* meant to
  be a nanopub link. It requires the trailing segment to claim the RDF module, so
  a term IRI would have to end in `RA…` to be misread.

### Testing

`mvn test` — 900 tests, 0 failures. New: `NanopubLookupTest` (14, network-free
via an injected retrieval function), `NanopubNotFoundPageTest` (7, incl. real
render and status codes), `ErrorPageTest`; `ViewPageTest` extended with the two
forwarding paths.