### PR TITLE
feat(views): add header views (gen:HeaderView)

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/View.java
+++ b/src/main/java/com/knowledgepixels/nanodash/View.java
@@ -38,7 +38,8 @@ public class View implements Serializable {
             KPXL_TERMS.LIST_VIEW,
             KPXL_TERMS.PLAIN_PARAGRAPH_VIEW,
             KPXL_TERMS.NANOPUB_SET_VIEW,
-            KPXL_TERMS.ITEM_LIST_VIEW
+            KPXL_TERMS.ITEM_LIST_VIEW,
+            KPXL_TERMS.HEADER_VIEW
     );
 
     static Map<IRI, Integer> columnWidths = new HashMap<>();
@@ -270,6 +271,7 @@ public class View implements Serializable {
     private IRI governingSpace;
     private String label;
     private String title = "View";
+    private String description;
     private GrlcQuery query;
     private String queryField = "resource";
     private Integer pageSize;
@@ -314,6 +316,8 @@ public class View implements Serializable {
                     label = st.getObject().stringValue();
                 } else if (st.getPredicate().equals(DCTERMS.TITLE)) {
                     title = st.getObject().stringValue();
+                } else if (st.getPredicate().equals(DCTERMS.DESCRIPTION)) {
+                    description = st.getObject().stringValue();
                 } else if (st.getPredicate().equals(KPXL_TERMS.HAS_VIEW_QUERY)) {
                     query = GrlcQuery.get(st.getObject().stringValue());
                 } else if (st.getPredicate().equals(KPXL_TERMS.HAS_VIEW_QUERY_TARGET_FIELD)) {
@@ -373,7 +377,8 @@ public class View implements Serializable {
             }
         }
         if (!viewTypeFound) throw new IllegalArgumentException("Not a proper resource view nanopub: " + id);
-        if (query == null) throw new IllegalArgumentException("Query not found: " + id);
+        // Header views are the one display type without a query (issue #572).
+        if (query == null && !KPXL_TERMS.HEADER_VIEW.equals(viewType)) throw new IllegalArgumentException("Query not found: " + id);
     }
 
     /**
@@ -442,9 +447,19 @@ public class View implements Serializable {
     }
 
     /**
+     * Gets the description of the View ({@code dct:description}), shown below the
+     * title for header views.
+     *
+     * @return the description, or null if none is declared
+     */
+    public String getDescription() {
+        return description;
+    }
+
+    /**
      * Gets the GrlcQuery associated with the View.
      *
-     * @return the GrlcQuery associated with the View
+     * @return the GrlcQuery associated with the View, or null for a header view
      */
     public GrlcQuery getQuery() {
         return query;

--- a/src/main/java/com/knowledgepixels/nanodash/component/HeaderViewPanel.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/HeaderViewPanel.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html xmlns:wicket="http://wicket.apache.org">
+
+<head>
+  <link rel="stylesheet" href="../../../../../webapp/style.css?for-local-testing-only" type="text/css" media="screen"
+        title="Stylesheet"/>
+</head>
+<body style="margin-left: auto; margin-right: auto; max-width: 1420px">
+
+<wicket:panel>
+  <div class="view-header-titlerow">
+    <h3><span wicket:id="title">Header</span></h3>
+    <span class="buttons"><wicket:container wicket:id="np">[np]</wicket:container></span>
+  </div>
+  <p wicket:id="description" class="view-header-description">description</p>
+</wicket:panel>
+
+</body>
+
+</html>

--- a/src/main/java/com/knowledgepixels/nanodash/component/HeaderViewPanel.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/HeaderViewPanel.java
@@ -1,0 +1,94 @@
+package com.knowledgepixels.nanodash.component;
+
+import com.knowledgepixels.nanodash.QueryResult;
+import com.knowledgepixels.nanodash.SpaceMemberRole;
+import com.knowledgepixels.nanodash.View;
+import com.knowledgepixels.nanodash.ViewDisplay;
+import com.knowledgepixels.nanodash.component.menu.ViewDisplayMenu;
+import com.knowledgepixels.nanodash.domain.AbstractResourceWithProfile;
+import com.knowledgepixels.nanodash.domain.MaintainedResource;
+import com.knowledgepixels.nanodash.domain.Space;
+import com.knowledgepixels.nanodash.page.PublishPage;
+import com.knowledgepixels.nanodash.repository.MaintainedResourceRepository;
+import com.knowledgepixels.nanodash.template.Template;
+import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.panel.Panel;
+import org.apache.wicket.request.mapper.parameter.PageParameters;
+import org.eclipse.rdf4j.model.IRI;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The body of a header view ({@code gen:HeaderView}, issue #572): a section header
+ * at the view's structural position, showing the view's title, an optional
+ * description text below it, and the view's result-level actions as top entries of
+ * the view-display dropdown menu. Header views have no query, so this panel always
+ * renders synchronously.
+ */
+public class HeaderViewPanel extends Panel {
+
+    /**
+     * @param markupId            the Wicket markup id
+     * @param viewDisplay         the view display of the header view
+     * @param resourceWithProfile the resource whose page the header is on (actions
+     *                            need it for visibility gating; may be null)
+     * @param id                  the resource or part id the view is shown for
+     * @param contextId           the context id, or null
+     * @param refRoot             the pinned ref's root nanopub, or null
+     */
+    public HeaderViewPanel(String markupId, ViewDisplay viewDisplay, AbstractResourceWithProfile resourceWithProfile, String id, String contextId, String refRoot) {
+        super(markupId);
+        View view = viewDisplay.getView();
+        add(new Label("title", viewDisplay.getTitle()));
+        String description = view.getDescription();
+        add(new Label("description", description).setVisible(description != null && !description.isBlank()));
+
+        // Result-level actions become the top entries of the view-display menu,
+        // mirroring how the query-result components route their view-level actions.
+        List<QueryResult.MenuAction> menuActions = new ArrayList<>();
+        if (resourceWithProfile != null) {
+            for (IRI actionIri : view.getViewResultActionList()) {
+                if (!SpaceMemberRole.isViewerEntitled(view.getActionVisibleTo(actionIri), resourceWithProfile, refRoot)) continue;
+                Template t = view.getTemplateForAction(actionIri);
+                if (t == null) continue;
+                String targetField = view.getTemplateTargetFieldForAction(actionIri);
+                if (targetField == null) targetField = "resource";
+                String label = view.getLabelForAction(actionIri);
+                if (label == null) label = "action...";
+                if (!label.endsWith("...")) label += "...";
+                PageParameters params = new PageParameters().set("template", t.getId())
+                        .set("param_" + targetField, id)
+                        .set("context", contextId)
+                        .set("template-version", "latest");
+                if (id != null && contextId != null && !id.equals(contextId)) {
+                    params.set("part", id);
+                }
+                String partField = view.getTemplatePartFieldForAction(actionIri);
+                if (partField != null && contextId != null) {
+                    // The part field pre-fills a namespaced child IRI (the user fills the suffix).
+                    MaintainedResource r = MaintainedResourceRepository.get().findById(contextId);
+                    String namespace = null;
+                    if (r != null) {
+                        namespace = r.getNamespace();
+                    } else if (resourceWithProfile instanceof Space) {
+                        // The Space-creation templates' `space` placeholder has a fixed
+                        // `https://w3id.org/spaces/` prefix, so the pre-fill is relative to it.
+                        namespace = contextId.replaceFirst("https://w3id.org/spaces/", "") + "/";
+                    }
+                    if (namespace != null) {
+                        params.set("param_" + partField, namespace + "<SET-SUFFIX>");
+                    }
+                }
+                if (contextId != null) params.set("refresh-upon-publish", contextId);
+                menuActions.add(new QueryResult.MenuAction(label, PublishPage.class, params));
+            }
+        }
+        if (viewDisplay.getNanopubId() != null || !menuActions.isEmpty()) {
+            add(new ViewDisplayMenu("np", viewDisplay, null, resourceWithProfile, menuActions));
+        } else {
+            add(new Label("np").setVisible(false));
+        }
+    }
+
+}

--- a/src/main/java/com/knowledgepixels/nanodash/component/ViewList.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/ViewList.java
@@ -6,6 +6,7 @@ import com.knowledgepixels.nanodash.View;
 import com.knowledgepixels.nanodash.ViewDisplay;
 import com.knowledgepixels.nanodash.domain.AbstractResourceWithProfile;
 import com.knowledgepixels.nanodash.domain.Space;
+import com.knowledgepixels.nanodash.vocabulary.KPXL_TERMS;
 import org.apache.wicket.Component;
 import org.apache.wicket.behavior.AttributeAppender;
 import org.apache.wicket.markup.html.WebMarkupContainer;
@@ -112,6 +113,14 @@ public class ViewList extends Panel {
                         // build/render dereferences a null takes down the whole page render.
                         try {
                             View view = item.getModelObject().getView();
+                            if (KPXL_TERMS.HEADER_VIEW.equals(view.getViewType())) {
+                                // Header views have no query (issue #572), so they skip all the
+                                // query machinery below and render directly.
+                                Component header = new HeaderViewPanel("view", item.getModelObject(), resourceWithProfile, id, resourceWithProfile.getId(), refRoot);
+                                header.add(new AttributeAppender("class", " col-" + item.getModelObject().getDisplayWidth() + " section-header"));
+                                item.add(header);
+                                return;
+                            }
                             Multimap<String, String> queryRefParams = ArrayListMultimap.create();
                             for (String p : view.getQuery().getPlaceholdersList()) {
                                 String paramName = QueryTemplate.getParamName(p);

--- a/src/main/java/com/knowledgepixels/nanodash/component/menu/ViewDisplayMenu.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/menu/ViewDisplayMenu.java
@@ -42,7 +42,9 @@ public class ViewDisplayMenu extends BaseDisplayMenu {
      *
      * @param id           the Wicket component ID
      * @param viewDisplay  the view display this menu acts on (must have a non-null nanopub)
-     * @param queryRef     the query reference used by this view display
+     * @param queryRef     the query reference used by this view display, or null for a
+     *                     query-less view (a header view), which hides the
+     *                     query-dependent entries (show query, full screen, refresh)
      * @param pageResource the page-level resource used to determine whether "adjust" is visible
      * @param viewActions  the view-level actions to show as top entries (may be empty)
      */
@@ -71,12 +73,16 @@ public class ViewDisplayMenu extends BaseDisplayMenu {
         separator.setVisible(!viewActions.isEmpty());
         addEntry("separator", separator);
 
-        PageParameters showQueryParams = new PageParameters().set("id", queryRef.getQueryId());
-        for (var entry : queryRef.getParams().entries()) {
-            showQueryParams.add("queryparam_" + entry.getKey(), entry.getValue());
+        if (queryRef != null) {
+            PageParameters showQueryParams = new PageParameters().set("id", queryRef.getQueryId());
+            for (var entry : queryRef.getParams().entries()) {
+                showQueryParams.add("queryparam_" + entry.getKey(), entry.getValue());
+            }
+            addEntry("showQuery", new BookmarkablePageLink<Void>("showQuery", QueryPage.class, showQueryParams)
+                    .add(NavigationContext.pageContextFallback()));
+        } else {
+            addEntry("showQuery", new WebMarkupContainer("showQuery").setVisible(false));
         }
-        addEntry("showQuery", new BookmarkablePageLink<Void>("showQuery", QueryPage.class, showQueryParams)
-                .add(NavigationContext.pageContextFallback()));
 
         addEntry("showView", new BookmarkablePageLink<Void>("showView", ExplorePage.class,
                 new PageParameters().set("id", viewDisplay.getView().getNanopub().getUri()))
@@ -85,21 +91,25 @@ public class ViewDisplayMenu extends BaseDisplayMenu {
         // Full-screen version of this view on the standalone view-results page, with the
         // current query parameters carried along (magic ones excluded — the results page
         // re-binds them from the session, so carrying them would duplicate the bindings).
-        PageParameters fullScreenParams = new PageParameters().set("view", viewDisplay.getView().getId());
-        for (var entry : queryRef.getParams().entries()) {
-            if (MagicQueryParams.isMagic(entry.getKey())) continue;
-            fullScreenParams.add("queryparam_" + entry.getKey(), entry.getValue());
-        }
-        BookmarkablePageLink<Void> fullScreenLink = new BookmarkablePageLink<>("fullScreen", ViewResultsPage.class, fullScreenParams) {
-            @Override
-            protected void onConfigure() {
-                super.onConfigure();
-                // Self-referential on the full-screen page itself.
-                setVisible(!(getPage() instanceof ViewResultsPage));
+        if (queryRef != null) {
+            PageParameters fullScreenParams = new PageParameters().set("view", viewDisplay.getView().getId());
+            for (var entry : queryRef.getParams().entries()) {
+                if (MagicQueryParams.isMagic(entry.getKey())) continue;
+                fullScreenParams.add("queryparam_" + entry.getKey(), entry.getValue());
             }
-        };
-        fullScreenLink.add(NavigationContext.pageContextFallback());
-        addEntry("fullScreen", fullScreenLink);
+            BookmarkablePageLink<Void> fullScreenLink = new BookmarkablePageLink<>("fullScreen", ViewResultsPage.class, fullScreenParams) {
+                @Override
+                protected void onConfigure() {
+                    super.onConfigure();
+                    // Self-referential on the full-screen page itself.
+                    setVisible(!(getPage() instanceof ViewResultsPage));
+                }
+            };
+            fullScreenLink.add(NavigationContext.pageContextFallback());
+            addEntry("fullScreen", fullScreenLink);
+        } else {
+            addEntry("fullScreen", new WebMarkupContainer("fullScreen").setVisible(false));
+        }
 
         IRI nanopubId = viewDisplay.getNanopubId();
 
@@ -187,7 +197,7 @@ public class ViewDisplayMenu extends BaseDisplayMenu {
                 setResponsePage(getPage().getClass(), getPage().getPageParameters());
             }
         };
-        refreshLink.setVisible(session.getUserIri() != null);
+        refreshLink.setVisible(session.getUserIri() != null && queryRef != null);
         addEntry("refreshNow", refreshLink);
 
         BookmarkablePageLink<Void> viewDeclarationLink = new BookmarkablePageLink<>("viewDeclaration", ExplorePage.class,

--- a/src/main/java/com/knowledgepixels/nanodash/connector/GenConnectPage.html
+++ b/src/main/java/com/knowledgepixels/nanodash/connector/GenConnectPage.html
@@ -4,7 +4,7 @@
 <head>
 <meta charset="utf-8" />
 <title wicket:id="pagetitle">(journal): Connect Nanopublication | nanodash</title>
-<link rel="stylesheet" href="style.css?v=4.14.1" type="text/css" media="screen" title="Stylesheet" />
+<link rel="stylesheet" href="style.css?v=4.14.2" type="text/css" media="screen" title="Stylesheet" />
 <link rel="stylesheet" href="../../../../../../webapp/style.css?for-local-testing-only" type="text/css" media="screen" title="Stylesheet" />
 <link rel="icon" type="application/svg+xml" href="images/favicon.svg">
 </head>

--- a/src/main/java/com/knowledgepixels/nanodash/connector/GenNanopubPage.html
+++ b/src/main/java/com/knowledgepixels/nanodash/connector/GenNanopubPage.html
@@ -4,7 +4,7 @@
 <head>
 <meta charset="utf-8" />
 <title wicket:id="pagetitle">Nanopublication for (journal) | nanodash</title>
-<link rel="stylesheet" href="style.css?v=4.14.1" type="text/css" media="screen" title="Stylesheet" />
+<link rel="stylesheet" href="style.css?v=4.14.2" type="text/css" media="screen" title="Stylesheet" />
 <link rel="stylesheet" href="../../../../../../webapp/style.css?for-local-testing-only" type="text/css" media="screen" title="Stylesheet" />
 <link rel="icon" type="application/svg+xml" href="images/favicon.svg">
 </head>

--- a/src/main/java/com/knowledgepixels/nanodash/connector/GenOverviewPage.html
+++ b/src/main/java/com/knowledgepixels/nanodash/connector/GenOverviewPage.html
@@ -4,7 +4,7 @@
 <head>
 <meta charset="utf-8" />
 <title wicket:id="pagetitle">(journal) | nanodash</title>
-<link rel="stylesheet" href="style.css?v=4.14.1" type="text/css" media="screen" title="Stylesheet" />
+<link rel="stylesheet" href="style.css?v=4.14.2" type="text/css" media="screen" title="Stylesheet" />
 <link rel="stylesheet" href="../../../../../webapp/style.css?for-local-testing-only" type="text/css" media="screen" title="Stylesheet" />
 <link rel="icon" type="application/svg+xml" href="images/favicon.svg">
 </head>

--- a/src/main/java/com/knowledgepixels/nanodash/connector/GenPublishPage.html
+++ b/src/main/java/com/knowledgepixels/nanodash/connector/GenPublishPage.html
@@ -4,7 +4,7 @@
 <head>
 <meta charset="utf-8" />
 <title wicket:id="pagetitle">(journal): Publish Nanopublication | nanodash</title>
-<link rel="stylesheet" href="style.css?v=4.14.1" type="text/css" media="screen" title="Stylesheet" />
+<link rel="stylesheet" href="style.css?v=4.14.2" type="text/css" media="screen" title="Stylesheet" />
 <link rel="stylesheet" href="../../../../../../webapp/style.css?for-local-testing-only" type="text/css" media="screen" title="Stylesheet" />
 <link rel="icon" type="application/svg+xml" href="images/favicon.svg">
 </head>

--- a/src/main/java/com/knowledgepixels/nanodash/connector/GenSelectPage.html
+++ b/src/main/java/com/knowledgepixels/nanodash/connector/GenSelectPage.html
@@ -4,7 +4,7 @@
 <head>
 <meta charset="utf-8" />
 <title wicket:id="pagetitle">(journal): Create Nanopublication | nanodash</title>
-<link rel="stylesheet" href="style.css?v=4.14.1" type="text/css" media="screen" title="Stylesheet" />
+<link rel="stylesheet" href="style.css?v=4.14.2" type="text/css" media="screen" title="Stylesheet" />
 <link rel="stylesheet" href="../../../../../../webapp/style.css?for-local-testing-only" type="text/css" media="screen" title="Stylesheet" />
 <link rel="icon" type="application/svg+xml" href="images/favicon.svg">
 </head>

--- a/src/main/java/com/knowledgepixels/nanodash/page/OrcidLoginPage.html
+++ b/src/main/java/com/knowledgepixels/nanodash/page/OrcidLoginPage.html
@@ -7,7 +7,7 @@
 </wicket:remove>
   <meta charset="utf-8"/>
   <title>ORCID Login | nanodash</title>
-  <link rel="stylesheet" href="style.css?v=4.14.1" type="text/css" media="screen" title="Stylesheet"/>
+  <link rel="stylesheet" href="style.css?v=4.14.2" type="text/css" media="screen" title="Stylesheet"/>
   <link rel="stylesheet" href="../../../../../webapp/style.css?for-local-testing-only" type="text/css" media="screen"
         title="Stylesheet"/>
   <link rel="icon" type="application/svg+xml" href="images/favicon.svg">

--- a/src/main/java/com/knowledgepixels/nanodash/page/QueryPage.html
+++ b/src/main/java/com/knowledgepixels/nanodash/page/QueryPage.html
@@ -8,7 +8,7 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title wicket:id="pagetitle">... (query) | nanodash</title>
-<link rel="stylesheet" href="style.css?v=4.14.1" type="text/css" media="screen" title="Stylesheet" />
+<link rel="stylesheet" href="style.css?v=4.14.2" type="text/css" media="screen" title="Stylesheet" />
 <wicket:remove>
     <link rel="stylesheet" href="../../../../../webapp/style.css?for-local-testing-only" type="text/css" media="screen" title="Stylesheet" />
 </wicket:remove>

--- a/src/main/java/com/knowledgepixels/nanodash/page/ResultTablePage.html
+++ b/src/main/java/com/knowledgepixels/nanodash/page/ResultTablePage.html
@@ -7,7 +7,7 @@
 </wicket:remove>
 <meta charset="utf-8" />
 <title wicket:id="pagetitle">... (result table) | nanodash</title>
-<link rel="stylesheet" href="style.css?v=4.14.1" type="text/css" media="screen" title="Stylesheet" />
+<link rel="stylesheet" href="style.css?v=4.14.2" type="text/css" media="screen" title="Stylesheet" />
 <wicket:remove>
     <link rel="stylesheet" href="../../../../../webapp/style.css?for-local-testing-only" type="text/css" media="screen" title="Stylesheet" />
 </wicket:remove>

--- a/src/main/java/com/knowledgepixels/nanodash/page/ViewPage.html
+++ b/src/main/java/com/knowledgepixels/nanodash/page/ViewPage.html
@@ -7,7 +7,7 @@
 </wicket:remove>
 <meta charset="utf-8" />
 <title>nanopub view | nanodash</title>
-<link rel="stylesheet" href="style.css?v=4.14.1" type="text/css" media="screen" title="Stylesheet" />
+<link rel="stylesheet" href="style.css?v=4.14.2" type="text/css" media="screen" title="Stylesheet" />
 <wicket:remove>
     <link rel="stylesheet" href="../../../../../webapp/style.css?for-local-testing-only" type="text/css" media="screen" title="Stylesheet" />
 </wicket:remove>

--- a/src/main/java/com/knowledgepixels/nanodash/page/ViewResultsPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/ViewResultsPage.java
@@ -51,7 +51,8 @@ public class ViewResultsPage extends NanodashPage {
 
         String viewId = parameters.get("view").toString();
         View view = (viewId == null ? null : View.get(viewId));
-        if (view == null) {
+        if (view == null || view.getQuery() == null) {
+            // Query-less (header) views have no full-screen results to show.
             add(new Label("queryform").setVisible(false));
             add(new Label("results", "<span class=\"negative\">View not found: " + Strings.escapeMarkup(String.valueOf(viewId)) + "</span>").setEscapeModelStrings(false));
             return;

--- a/src/main/java/com/knowledgepixels/nanodash/vocabulary/KPXL_TERMS.java
+++ b/src/main/java/com/knowledgepixels/nanodash/vocabulary/KPXL_TERMS.java
@@ -24,6 +24,13 @@ public class KPXL_TERMS {
     public static final IRI ITEM_LIST_VIEW = VocabUtils.createIRI(NAMESPACE, "ItemListView");
 
     /**
+     * A view that renders just a section header at its structural position — a title,
+     * an optional description text, and optional result-level actions — with no query
+     * (issue #572). The only display type for which {@code gen:hasViewQuery} is absent.
+     */
+    public static final IRI HEADER_VIEW = VocabUtils.createIRI(NAMESPACE, "HeaderView");
+
+    /**
      * Marks a view as a query-form view: instead of query results, it renders a form
      * for the query's placeholders that are not auto-filled from the page context;
      * submitting leads to the full results page. Orthogonal to the display types

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -274,6 +274,33 @@ details summary {
   padding-bottom: 6px;
 }
 
+/* Header views (issue #572): the title row is a flex row like .paneltitlerow, so
+   the view-display menu sits right-aligned outside the h3 (keeping it in the body
+   font); the underline moves from the h3 to the row so it still spans full width. */
+[class*="col-"].section-header .view-header-titlerow {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  border-bottom: 2px solid #bdbdbd;
+  /* ...and the trimmed space goes below the line instead. */
+  margin-bottom: 15px;
+}
+
+[class*="col-"].section-header .view-header-titlerow h3 {
+  flex: 1;
+  border-bottom: none;
+  /* The h3's default bottom margin now falls inside the row, above the border,
+     so trim it to keep the title close to the line. */
+  margin-bottom: 5px;
+  padding-bottom: 0;
+}
+
+/* Description text of a header view, shown below the title. */
+[class*="col-"].section-header p.view-header-description {
+  margin: 0 0 5px 0;
+  color: #666;
+}
+
 /* View groups (ViewList): lay the view panels out on a 12-column grid instead of
    floats, so panels of different heights don't leave float-drop whitespace gaps.
    Each .listview item wraps a single col-N view panel; the item mirrors the


### PR DESCRIPTION
## Summary

Implements **header views** (#572): a new query-less display type that renders just a section header at its structural position — like the hardcoded "Structure" etc. headers on the About pages — with a title, an optional description text shown below it, and optional (result-level) action templates.

- `gen:HeaderView` added to `KPXL_TERMS` and to `View`'s supported display types; `dct:description` is parsed; the query-required check is skipped for header views (the one display type without `gen:hasViewQuery`).
- `ViewList` branches to the new `HeaderViewPanel` before any query machinery runs; the panel defaults to full width and reuses the `section-header` styling, so a header leads its position-group's section stripe.
- `HeaderViewPanel` renders a flex title row (menu right-aligned outside the `h3`, so it keeps the body font), the description paragraph below the line, and the view's result-level actions as top entries of the view-display dropdown.
- `ViewDisplayMenu` accepts a null query ref, hiding the query-dependent entries (show query, full screen, refresh now) while keeping show view / edit / deactivate / show nanopub.
- `ViewResultsPage` guards against query-less views; CSS cache param bumped.

## Ecosystem

- Creation template **"Declaring a header view"** published: [`RAZYU_kQ…`](https://w3id.org/np/RAZYU_kQZ0B3ruoNSeZOaKR6M93PJ-z1jlArXl7_H4EEU) — fixed `gen:ResourceView, gen:HeaderView` types, kind, label, title, optional description, applies-to fields, structural position, optional width, optional `gen:ViewResultAction`-only action group (no query fields).
- **No server-side changes needed**: `get-view-displays` (both variants) and all listing/resolution queries key on `gen:ResourceView` only, which header views keep alongside `gen:HeaderView`; verified against the published query nanopubs.
- **Older instances degrade gracefully**: the old `View` constructor's "Query not found" throw is swallowed per-row at display-list assembly, so header views are silently skipped (server-log line only), never a page error.

## Test plan

Verified end-to-end on a local instance against a live test header view ([`RAUqJMjX…/test-header-view`](https://w3id.org/np/RAUqJMjX0m3cwMl7gOdu9Ucese3JoEUeKjLRqT7k9mmsY)) displayed on the `test/group` space: renders full-width at position 5.1 with underline + description, dropdown right-aligned with the action entry (correct pre-filled publish link) and without the query-dependent entries.

Closes #572

🤖 Generated with [Claude Code](https://claude.com/claude-code)