### PR TITLE
feat(views): switch Content-tab displays to unresolved query with client-side version resolution

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/QueryApiAccess.java
+++ b/src/main/java/com/knowledgepixels/nanodash/QueryApiAccess.java
@@ -111,6 +111,15 @@ public class QueryApiAccess {
     // governing space resolves to the newest member+-signed version of its (kind, space)
     // pair via a run-once governed sub-select, falling back to the pinned version.
     public static final String GET_VIEW_DISPLAYS_REF = "RActfK6Cb1qEPe6in0Ug7IThR_ckkgdNl0mKqF_HOGkqM/get-view-displays";
+    // Test head for dropping the server-side view-version resolution (its run-once resolution
+    // sub-select was the query's dominant cost, linear in the repo-wide view count; see
+    // nanopub-query doc/design-view-head-materialization.md): same inputs as GET_VIEW_DISPLAYS_REF
+    // and same columns plus ?viewKind and ?governedBySpace, but ?view carries the referenced
+    // version UNRESOLVED — except for gen:governedBy pins, where it is the space-governed
+    // resolution. Supersedes-head resolution happens caller-side per view (View.get with
+    // resolveLatest=true, memoized), which also covers the governed case, so the extra columns
+    // need not be consulted.
+    public static final String GET_VIEW_DISPLAYS_UNRESOLVED = "RAXdRFNLE1jB_NTaWrwIC9965SmZdZKB96VFnj1HvjdbY/get-view-displays-unresolved";
 
     // Spaces-repo queries (endpoint: nanopub-query .../repo/spaces)
     // v2: IRI-keyed get-spaces. Prior client head, retained for reference; deployments up

--- a/src/main/java/com/knowledgepixels/nanodash/ViewDisplay.java
+++ b/src/main/java/com/knowledgepixels/nanodash/ViewDisplay.java
@@ -94,20 +94,21 @@ public class ViewDisplay implements Serializable, Comparable<ViewDisplay> {
      * {@link com.knowledgepixels.nanodash.domain.AbstractResourceWithProfile} as
      * standalone displays.</p>
      *
-     * @param resourceId  the resource the preset is assigned to
-     * @param viewIri     the resolved view IRI (a {@code gen:hasView} /
-     *                    {@code gen:hasTopLevelView} target of the preset)
-     * @param topLevel    whether this came from {@code gen:hasTopLevelView} (shown
-     *                    at the top level of the resource page) vs. {@code gen:hasView}
-     *                    (shown at the part level, for parts matching the view's own
-     *                    class/namespace targeting)
-     * @param deactivated whether the underlying preset assignment is deactivated
+     * @param resourceId    the resource the preset is assigned to
+     * @param viewIri       the view IRI (a {@code gen:hasView} /
+     *                      {@code gen:hasTopLevelView} target of the preset)
+     * @param topLevel      whether this came from {@code gen:hasTopLevelView} (shown
+     *                      at the top level of the resource page) vs. {@code gen:hasView}
+     *                      (shown at the part level, for parts matching the view's own
+     *                      class/namespace targeting)
+     * @param deactivated   whether the underlying preset assignment is deactivated
+     * @param resolveLatest whether to resolve {@code viewIri} to its latest version
+     *                      here; pass false when the query already resolved it
+     *                      server-side, true for the unresolved query variant
      * @return the ViewDisplay, or null if the view could not be resolved
      */
-    public static ViewDisplay forPresetView(String resourceId, String viewIri, boolean topLevel, boolean deactivated) {
-        // viewIri is already latest-resolved by the get-view-displays query, so load
-        // it directly without a separate latest-version lookup.
-        View view = View.get(viewIri, false);
+    public static ViewDisplay forPresetView(String resourceId, String viewIri, boolean topLevel, boolean deactivated, boolean resolveLatest) {
+        View view = View.get(viewIri, resolveLatest);
         if (view == null) {
             logger.error("Couldn't resolve preset view: {}", viewIri);
             return null;

--- a/src/main/java/com/knowledgepixels/nanodash/domain/AbstractResourceWithProfile.java
+++ b/src/main/java/com/knowledgepixels/nanodash/domain/AbstractResourceWithProfile.java
@@ -303,19 +303,22 @@ public abstract class AbstractResourceWithProfile implements Serializable, Resou
         // Null on a cold cache or a failed (flaky federated) fetch — yield nothing for now; the
         // cache refreshes asynchronously and the page's auto-refresh repopulates it.
         if (response == null) return list;
+        // The unresolved query variant returns ?view as the referenced version, leaving
+        // latest-version resolution to us (View.get with resolveLatest=true, memoized;
+        // it also covers space-governed pins); the older resolved heads return ?view
+        // already latest-resolved server-side, so it is passed through as-is.
+        boolean viewsPreResolved = !QueryApiAccess.GET_VIEW_DISPLAYS_UNRESOLVED.equals(ref.getQueryId());
         for (ApiResponseEntry r : response.getData()) {
             try {
                 String display = r.get("display");
                 if (display != null && !display.isEmpty()) {
-                    // The query resolves ?view to its latest version server-side, so
-                    // pass it through to avoid a separate per-view latest-version lookup.
-                    list.add(ViewDisplay.get(display, r.get("view")));
+                    list.add(ViewDisplay.get(display, viewsPreResolved ? r.get("view") : null));
                 } else {
                     String view = r.get("view");
                     if (view == null || view.isEmpty()) continue;
                     boolean topLevel = KPXL_TERMS.TOP_LEVEL_VIEW_DISPLAY.stringValue().equals(r.get("displayType"));
                     boolean deactivated = KPXL_TERMS.DEACTIVATED_PRESET_ASSIGNMENT.stringValue().equals(r.get("displayMode"));
-                    ViewDisplay vd = ViewDisplay.forPresetView(id, view, topLevel, deactivated);
+                    ViewDisplay vd = ViewDisplay.forPresetView(id, view, topLevel, deactivated, !viewsPreResolved);
                     if (vd != null) list.add(vd);
                 }
             } catch (IllegalArgumentException ex) {
@@ -329,7 +332,7 @@ public abstract class AbstractResourceWithProfile implements Serializable, Resou
         Multimap<String, String> params = ArrayListMultimap.create();
         params.put("resource", id);
         params.put("root_np", refRoot);
-        return new QueryRef(QueryApiAccess.GET_VIEW_DISPLAYS_REF, params);
+        return new QueryRef(QueryApiAccess.GET_VIEW_DISPLAYS_UNRESOLVED, params);
     }
 
     /**


### PR DESCRIPTION
## Summary

Wires in the new `get-view-displays-unresolved` query head (`RAXdRFNLE1jB_NTaWrwIC9965SmZdZKB96VFnj1HvjdbY`) for the space Content tab. The new head drops the server-side repo-wide view-version resolution sub-select — the query's dominant and fragility-prone cost, linear in the total view count — and returns referenced view versions unresolved, leaving latest-version resolution to the caller.

- `QueryApiAccess`: new `GET_VIEW_DISPLAYS_UNRESOLVED` constant documenting the caller-side resolution contract.
- `AbstractResourceWithProfile.viewDisplaysRefQueryRef` now uses the new head; `buildViewDisplays` branches on the query id and stops passing the `?view` column through for the unresolved head, so `View.get(viewIri, true)` resolves each view — its existing memoized path (60s stale-while-revalidate) already implements the contract exactly: space-governed pins resolve space-based, everything else follows the supersedes chain.
- `ViewDisplay.forPresetView` gains a `resolveLatest` parameter for preset-supplied rows.
- The older resolved heads (IRI-keyed query for non-space resources, `DownloadRdfPage`) keep the pass-through behavior unchanged.

Client-side resolution runs against the meta repo, so view-version freshness no longer depends on the `gen:ResourceView` type repo, which can lag.

**Deploy note:** new Nanodash + old query is fine (just redundant resolution); old Nanodash + a future resolved-head retirement would pin stale versions — retire the old heads only after all instances carry this change.

## Test plan

- Verified on a local jetty against the live query API: openaire space Content tab renders fully — headers, correct section ordering from the latest view versions, and duplicate version rows (two `project-outputs-view` pins) collapse correctly through the per-kind latest-wins aggregation.
- Direct API call to the new query head answers fast and returns the expected unresolved rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)