### PR TITLE
Use the ror_display name for ROR lookup suggestions

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/LookupApis.java
+++ b/src/main/java/com/knowledgepixels/nanodash/LookupApis.java
@@ -61,6 +61,30 @@ public class LookupApis {
     }
 
     /**
+     * Picks the name to display for a ROR record. The ROR API does not order the names by
+     * display preference, so the entry flagged "ror_display" is used, falling back to a
+     * "label" entry and finally to the first name given.
+     *
+     * @param namesArray the "names" array of a ROR record (must not be empty)
+     * @return the name to show to the user
+     */
+    private static String getRorDisplayName(JSONArray namesArray) {
+        String labelName = null;
+        for (int i = 0; i < namesArray.length(); i++) {
+            JSONObject nameObject = namesArray.getJSONObject(i);
+            JSONArray types = nameObject.optJSONArray("types");
+            if (types == null) continue;
+            for (int j = 0; j < types.length(); j++) {
+                String type = types.getString(j);
+                if ("ror_display".equals(type)) return nameObject.getString("value");
+                if ("label".equals(type) && labelName == null) labelName = nameObject.getString("value");
+            }
+        }
+        if (labelName != null) return labelName;
+        return namesArray.getJSONObject(0).getString("value");
+    }
+
+    /**
      * Fetches possible values from an API based on the provided search term.
      *
      * @param apiString  the API endpoint URL to query
@@ -189,7 +213,7 @@ public class LookupApis {
                     String uri = responseArray.getJSONObject(i).getString("id");
                     JSONArray namesArray = responseArray.getJSONObject(i).getJSONArray("names");
                     if (namesArray.length() == 0) continue;
-                    String label = namesArray.getJSONObject(0).getString("value");
+                    String label = getRorDisplayName(namesArray);
                     if (!values.contains(uri)) {
                         values.add(uri);
                         labelMap.put(uri, label);

--- a/src/test/java/com/knowledgepixels/nanodash/LookupApisTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/LookupApisTest.java
@@ -47,6 +47,19 @@ class LookupApisTest {
     private static final String ROR_FIXTURE =
             "{\"items\":[{\"id\":\"https://ror.org/03vek6s52\",\"names\":[{\"value\":\"Harvard University\"}]}]}";
 
+    // The ROR API does not order names by display preference: here the display name comes last.
+    private static final String ROR_TYPED_NAMES_FIXTURE =
+            "{\"items\":[{\"id\":\"https://ror.org/04pp8hn57\",\"names\":[" +
+            "{\"types\":[\"alias\"],\"value\":\"Rijksuniversiteit Utrecht\"}," +
+            "{\"types\":[\"label\"],\"value\":\"Universiteit Utrecht\"}," +
+            "{\"types\":[\"ror_display\",\"label\"],\"value\":\"Utrecht University\"}]}]}";
+
+    // A record with names but no "ror_display" entry falls back to the "label" one.
+    private static final String ROR_NO_DISPLAY_FIXTURE =
+            "{\"items\":[{\"id\":\"https://ror.org/05mggs005\",\"names\":[" +
+            "{\"types\":[\"acronym\"],\"value\":\"PAMM\"}," +
+            "{\"types\":[\"label\"],\"value\":\"Stichting PAMM\"}]}]}";
+
     private static final String OPENAIRE_FIXTURE =
             "{\"results\":[{\"id\":\"abc123\",\"mainTitle\":\"Test Item\"}]}";
 
@@ -242,6 +255,30 @@ class LookupApisTest {
         assertValuesWithLabels(labelMap, values);
         assertTrue(values.stream().allMatch(v -> v.startsWith("https://ror.org/")),
                 "All URIs should be ROR organization URIs");
+    }
+
+    @Test
+    void getPossibleValues_rorPrefersDisplayName() throws Exception {
+        Map<String, String> labelMap = new HashMap<>();
+        List<String> values = new ArrayList<>();
+        try (var ignored = mockHttp(ROR_TYPED_NAMES_FIXTURE)) {
+            LookupApis.getPossibleValues("https://api.ror.org/organizations?query=", "utrecht", labelMap, values);
+        }
+        assertValuesWithLabels(labelMap, values);
+        assertEquals("Utrecht University", labelMap.get("https://ror.org/04pp8hn57"),
+                "The name flagged ror_display should be used, not the first one listed");
+    }
+
+    @Test
+    void getPossibleValues_rorFallsBackToLabelName() throws Exception {
+        Map<String, String> labelMap = new HashMap<>();
+        List<String> values = new ArrayList<>();
+        try (var ignored = mockHttp(ROR_NO_DISPLAY_FIXTURE)) {
+            LookupApis.getPossibleValues("https://api.ror.org/organizations?query=", "pamm", labelMap, values);
+        }
+        assertValuesWithLabels(labelMap, values);
+        assertEquals("Stichting PAMM", labelMap.get("https://ror.org/05mggs005"),
+                "Without a ror_display name, the label name should be used");
     }
 
     @Test


### PR DESCRIPTION
Fixes #586.

ROR guided-choice lookups labelled each suggestion with `names[0].value`, but the ROR API does not order `names` by display preference — the first entry is often an acronym or a local-language alias. The matched record was always correct; only the label was wrong.

| Typed | Before | After |
|---|---|---|
| `Utrecht University` | Rijksuniversiteit Utrecht | Utrecht University |
| `Jeroen Bosch Ziekenhuis` | JBZ | Jeroen Bosch Ziekenhuis |
| `PAMM` | PAMM | Stichting PAMM |

`getRorDisplayName()` now prefers the name flagged `ror_display`, falls back to a `label` name, and finally to `names[0]` — so records without `types` (including the existing `ROR_FIXTURE`) behave exactly as before.

Two tests added: one where the `ror_display` name is listed *last* among an alias and a label, and one with no `ror_display` entry at all. `LookupApisTest` passes: 130 run, 0 failures, 26 skipped (pre-existing `@Disabled` live-API tests).

Found while building ROR-based institution fields for the ZonMw ABR nanopublication demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ESh5Ts8pbr9e8Fp3veixV5