### PR TITLE
fix: recognize space-governed updates in the "Status" line

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/GovernedVersions.java
+++ b/src/main/java/com/knowledgepixels/nanodash/GovernedVersions.java
@@ -1,0 +1,173 @@
+package com.knowledgepixels.nanodash;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import com.knowledgepixels.nanodash.vocabulary.KPXL_TERMS;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.vocabulary.DCTERMS;
+import org.nanopub.Nanopub;
+import org.nanopub.NanopubUtils;
+import org.nanopub.extra.services.ApiResponse;
+import org.nanopub.extra.services.QueryRef;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Helpers around space-governed versioning: definitions that float within a
+ * {@code (kind, space)} pair via {@code dct:isVersionOf} + {@code gen:governedBy}
+ * instead of via an {@code npx:supersedes} chain.
+ * <p>
+ * See docs/views-and-presets-as-maintained-resources.md and
+ * docs/template-identity-and-governance.md. The authority checks (signer is a
+ * current member+ of the space, kind is a maintained resource of that space,
+ * retracted versions skipped) all happen server-side in the
+ * {@link QueryApiAccess#GET_LATEST_GOVERNED_VERSION} query; this class only
+ * assembles its inputs and reads its single row.
+ */
+public class GovernedVersions {
+
+    private GovernedVersions() {
+    } // no instances allowed
+
+    /**
+     * The {@code (kind, space)} pair a governed definition version declares, as
+     * plain strings so it can be held by Wicket components across serialization.
+     */
+    public static class GovernedRef implements Serializable {
+
+        private final String kind;
+        private final String space;
+
+        private GovernedRef(String kind, String space) {
+            this.kind = kind;
+            this.space = space;
+        }
+
+        /**
+         * @return the definition kind, i.e. the {@code dct:isVersionOf} target
+         */
+        public String getKind() {
+            return kind;
+        }
+
+        /**
+         * @return the governing space, i.e. the {@code gen:governedBy} target
+         */
+        public String getSpace() {
+            return space;
+        }
+
+    }
+
+    /**
+     * Finds the space-governed definition embedded in the given nanopublication:
+     * an {@code npx:embeds} target that declares both {@code dct:isVersionOf} and
+     * {@code gen:governedBy} in the assertion. This is the same shape the
+     * {@link QueryApiAccess#GET_LATEST_GOVERNED_VERSION} query matches on, and it
+     * is type-agnostic — it covers governed views, templates, presets and queries
+     * alike.
+     *
+     * @param np the nanopublication to inspect
+     * @return the declared kind/space pair, or null if this nanopublication does
+     * not embed a governed definition
+     */
+    public static GovernedRef findGovernedRef(Nanopub np) {
+        if (np == null) return null;
+        Set<String> embedded = NanopubUtils.getEmbeddedIriIds(np);
+        if (embedded.isEmpty()) return null;
+        Map<String, String> kinds = new HashMap<>();
+        Map<String, String> spaces = new HashMap<>();
+        for (Statement st : np.getAssertion()) {
+            String subj = st.getSubject().stringValue();
+            if (!embedded.contains(subj)) continue;
+            if (!(st.getObject() instanceof IRI obj)) continue;
+            if (st.getPredicate().equals(DCTERMS.IS_VERSION_OF)) {
+                kinds.put(subj, obj.stringValue());
+            } else if (st.getPredicate().equals(KPXL_TERMS.GOVERNED_BY)) {
+                spaces.put(subj, obj.stringValue());
+            }
+        }
+        // Nanopublications embedding more than one governed definition aren't a
+        // thing we produce; taking the first match is enough.
+        for (Map.Entry<String, String> kind : kinds.entrySet()) {
+            String space = spaces.get(kind.getKey());
+            if (space != null) return new GovernedRef(kind.getValue(), space);
+        }
+        return null;
+    }
+
+    /**
+     * Builds the query reference resolving the current governed version of a
+     * {@code (kind, space)} pair.
+     *
+     * @param kindIri  the definition kind (the {@code dct:isVersionOf} target)
+     * @param spaceIri the governing space
+     * @return the query reference
+     */
+    public static QueryRef getQueryRef(String kindIri, String spaceIri) {
+        Multimap<String, String> params = ArrayListMultimap.create();
+        params.put("kind", kindIri);
+        params.put("space", spaceIri);
+        return new QueryRef(QueryApiAccess.GET_LATEST_GOVERNED_VERSION, params);
+    }
+
+    /**
+     * Builds the query reference resolving the current governed version for the
+     * given pair.
+     *
+     * @param ref the kind/space pair
+     * @return the query reference
+     */
+    public static QueryRef getQueryRef(GovernedRef ref) {
+        return getQueryRef(ref.getKind(), ref.getSpace());
+    }
+
+    /**
+     * Resolves the current governed version of a {@code (kind, space)} pair,
+     * blocking on the query if it isn't cached yet.
+     *
+     * @param kindIri  the definition kind (the {@code dct:isVersionOf} target)
+     * @param spaceIri the governing space
+     * @return the definition IRI of the current governed version, or null if
+     * there is no valid floating candidate (the caller then keeps its pin)
+     */
+    public static String getLatestVersionIriSync(String kindIri, String spaceIri) {
+        return getVersionIri(ApiCache.retrieveResponseSync(getQueryRef(kindIri, spaceIri), false));
+    }
+
+    /**
+     * Reads the definition IRI off a {@link QueryApiAccess#GET_LATEST_GOVERNED_VERSION}
+     * response.
+     *
+     * @param response the query response, may be null
+     * @return the {@code version} value of the single row, or null if the response
+     * is null or empty
+     */
+    public static String getVersionIri(ApiResponse response) {
+        return getValue(response, "version");
+    }
+
+    /**
+     * Reads the IRI of the nanopublication containing the current governed version
+     * off a {@link QueryApiAccess#GET_LATEST_GOVERNED_VERSION} response.
+     *
+     * @param response the query response, may be null
+     * @return the {@code np} value of the single row, or null if the response is
+     * null or empty
+     */
+    public static String getVersionNanopubIri(ApiResponse response) {
+        return getValue(response, "np");
+    }
+
+    private static String getValue(ApiResponse response, String key) {
+        if (response == null || response.getData().isEmpty()) return null;
+        String value = response.getData().get(0).get(key);
+        if (value == null || value.isEmpty()) return null;
+        return value;
+    }
+
+}

--- a/src/main/java/com/knowledgepixels/nanodash/View.java
+++ b/src/main/java/com/knowledgepixels/nanodash/View.java
@@ -19,8 +19,6 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Multimap;
 
 import java.io.Serializable;
 import java.util.*;
@@ -206,17 +204,12 @@ public class View implements Serializable {
      */
     private static View resolveGovernedVersion(View pinned) {
         try {
-            Multimap<String, String> params = ArrayListMultimap.create();
-            params.put("kind", pinned.getViewKindIri().stringValue());
-            params.put("space", pinned.getGoverningSpace().stringValue());
-            ApiResponse resp = ApiCache.retrieveResponseSync(new QueryRef(QueryApiAccess.GET_LATEST_GOVERNED_VERSION, params), false);
-            if (resp != null && !resp.getData().isEmpty()) {
-                String latestId = resp.getData().get(0).get("version");
-                if (latestId != null && !latestId.isEmpty() && !latestId.equals(pinned.getId())) {
-                    String latestNpId = latestId.replaceFirst("^(.*[^A-Za-z0-9-_]RA[A-Za-z0-9-_]{43})[^A-Za-z0-9-_].*$", "$1");
-                    View resolved = getExactVersion(latestId, latestNpId);
-                    if (resolved != null) return resolved;
-                }
+            String latestId = GovernedVersions.getLatestVersionIriSync(
+                    pinned.getViewKindIri().stringValue(), pinned.getGoverningSpace().stringValue());
+            if (latestId != null && !latestId.equals(pinned.getId())) {
+                String latestNpId = latestId.replaceFirst("^(.*[^A-Za-z0-9-_]RA[A-Za-z0-9-_]{43})[^A-Za-z0-9-_].*$", "$1");
+                View resolved = getExactVersion(latestId, latestNpId);
+                if (resolved != null) return resolved;
             }
         } catch (Exception ex) {
             logger.error("Error resolving governed version for view: {}", pinned.getId(), ex);

--- a/src/main/java/com/knowledgepixels/nanodash/component/JustPublishedMessagePanel.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/JustPublishedMessagePanel.java
@@ -1,5 +1,6 @@
 package com.knowledgepixels.nanodash.component;
 
+import com.knowledgepixels.nanodash.NavigationContext;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.markup.html.AjaxLink;
 import org.apache.wicket.markup.html.WebMarkupContainer;
@@ -59,7 +60,9 @@ public class JustPublishedMessagePanel extends Panel {
             Nanopub np = Utils.getAsNanopub(justPublishedId);
             String label = (np != null ? NanopubUtils.getLabel(np) : null);
             if (label == null || label.isEmpty()) label = Utils.getShortNameFromURI(justPublishedId);
-            confirmBox.add(new BookmarkablePageLink<Void>("link", ExplorePage.class, new PageParameters().set("id", justPublishedId)).setBody(Model.of(Utils.truncateLinkLabel(label))));
+            confirmBox.add(new BookmarkablePageLink<Void>("link", ExplorePage.class, new PageParameters().set("id", justPublishedId))
+                    .setBody(Model.of(Utils.truncateLinkLabel(label)))
+                    .add(NavigationContext.pageContextFallback()));
             // Remember a freshly-published introduction so the warning below clears.
             if (np != null && Utils.usesPredicateInAssertion(np, NPX.DECLARED_BY)) session.setIntroPublishedNow();
         } else {

--- a/src/main/java/com/knowledgepixels/nanodash/component/OutdatedSourceErrorItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/OutdatedSourceErrorItem.java
@@ -5,6 +5,7 @@ import org.apache.wicket.markup.html.link.BookmarkablePageLink;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
 
+import com.knowledgepixels.nanodash.NavigationContext;
 import com.knowledgepixels.nanodash.QueryApiAccess;
 import com.knowledgepixels.nanodash.page.ExplorePage;
 
@@ -29,7 +30,8 @@ public class OutdatedSourceErrorItem extends Panel {
         super(id);
         String sourceNpId = PublishForm.getSupersededOrOverriddenNanopubId(pageParams);
         String latestNpId = QueryApiAccess.getLatestVersionId(sourceNpId);
-        add(new BookmarkablePageLink<Void>("latest-link", ExplorePage.class, new PageParameters().set("id", latestNpId)));
+        add(new BookmarkablePageLink<Void>("latest-link", ExplorePage.class, new PageParameters().set("id", latestNpId))
+                .add(NavigationContext.pageContextFallback()));
         add(new BookmarkablePageLink<Void>("latest-action-link", publishPageClass, PublishForm.withSourceNanopub(pageParams, latestNpId)));
     }
 

--- a/src/main/java/com/knowledgepixels/nanodash/component/ReactionList.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/ReactionList.java
@@ -1,5 +1,6 @@
 package com.knowledgepixels.nanodash.component;
 
+import com.knowledgepixels.nanodash.NavigationContext;
 import com.knowledgepixels.nanodash.domain.User;
 import com.knowledgepixels.nanodash.Utils;
 import com.knowledgepixels.nanodash.page.ExplorePage;
@@ -43,6 +44,7 @@ public class ReactionList extends Panel {
                 item.add(new Label("reactiontext", "\"" + e.get("text") + "\" (" + e.get("reltext") + " the nanopublication above)"));
                 params.set("id", e.get("np"));
                 BookmarkablePageLink<Void> l = new BookmarkablePageLink<Void>("reactionlink", ExplorePage.class, params);
+                l.add(NavigationContext.pageContextFallback());
                 String pubkeyhash = Utils.createSha256HexHash(e.get("pubkey"));
                 String username = User.getShortDisplayNameForPubkeyhash(null, pubkeyhash);
                 l.add(new Label("reactionlinktext", "by " + username + " on " + e.get("date").substring(0, 10)));

--- a/src/main/java/com/knowledgepixels/nanodash/component/SpaceClaimantsPanel.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/SpaceClaimantsPanel.java
@@ -1,5 +1,6 @@
 package com.knowledgepixels.nanodash.component;
 
+import com.knowledgepixels.nanodash.NavigationContext;
 import com.knowledgepixels.nanodash.Utils;
 import com.knowledgepixels.nanodash.domain.Space;
 import com.knowledgepixels.nanodash.domain.User;
@@ -43,7 +44,9 @@ public class SpaceClaimantsPanel extends Panel {
                 // The currently-shown ref: the pinned one, or the representative when not pinned.
                 boolean current = effectiveRoot != null ? c.getRootNp().equals(effectiveRoot) : c.isRepresentative();
                 item.add(new BookmarkablePageLink<Void>("root-link", ExplorePage.class,
-                        new PageParameters().add("id", c.getRootNp())).setBody(Model.of(shortNp(c.getRootNp()))));
+                        new PageParameters().add("id", c.getRootNp()))
+                        .setBody(Model.of(shortNp(c.getRootNp())))
+                        .add(NavigationContext.pageContextFallback()));
                 item.add(new WebMarkupContainer("default").setVisible(c.isRepresentative()));
                 item.add(new WebMarkupContainer("current").setVisible(current));
                 // No "view this space" on the row you're already viewing.

--- a/src/main/java/com/knowledgepixels/nanodash/component/StatusLine.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/StatusLine.java
@@ -2,6 +2,7 @@ package com.knowledgepixels.nanodash.component;
 
 import com.knowledgepixels.nanodash.ApiCache;
 import com.knowledgepixels.nanodash.GovernedVersions;
+import com.knowledgepixels.nanodash.NavigationContext;
 import com.knowledgepixels.nanodash.QueryApiAccess;
 import com.knowledgepixels.nanodash.page.ExplorePage;
 import net.trustyuri.TrustyUriUtils;
@@ -109,6 +110,9 @@ public class StatusLine extends Panel {
                 BookmarkablePageLink<Void> link = new BookmarkablePageLink<>("npLink",
                         ExplorePage.class,
                         new PageParameters().add("id", id));
+                // Following a version link shouldn't drop out of the space/user/resource
+                // the nanopublication was reached under.
+                link.add(NavigationContext.pageContextFallback());
                 link.add(new Label("npLabel", shortLabel));
                 item.add(link);
             }

--- a/src/main/java/com/knowledgepixels/nanodash/component/StatusLine.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/StatusLine.java
@@ -1,6 +1,7 @@
 package com.knowledgepixels.nanodash.component;
 
 import com.knowledgepixels.nanodash.ApiCache;
+import com.knowledgepixels.nanodash.GovernedVersions;
 import com.knowledgepixels.nanodash.QueryApiAccess;
 import com.knowledgepixels.nanodash.page.ExplorePage;
 import net.trustyuri.TrustyUriUtils;
@@ -14,9 +15,12 @@ import org.apache.wicket.markup.html.list.ListView;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
+import org.nanopub.Nanopub;
 import org.nanopub.extra.services.ApiResponse;
 import org.nanopub.extra.services.ApiResponseEntry;
 import org.nanopub.extra.services.QueryRef;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -29,25 +33,39 @@ import java.util.List;
  * panel polls the cache every few seconds and updates itself in place once
  * verification succeeds — so users don't have to manually reload the page
  * after publishing.
+ * <p>
+ * Newer versions are found in two ways: via the {@code npx:supersedes} chain
+ * (and retractions) with the {@link QueryApiAccess#GET_NEWER_VERSIONS_OF_NP}
+ * query, and — for nanopublications embedding a space-governed definition — via
+ * the {@code (kind, space)} pair the definition floats within (issue #584). A
+ * governed new version carries no {@code npx:supersedes}, so the first query
+ * alone reports such a nanopublication as the latest version.
  */
 public class StatusLine extends Panel {
 
+    private static final Logger logger = LoggerFactory.getLogger(StatusLine.class);
+
     private static final Duration POLL_INTERVAL = Duration.ofSeconds(3);
     private static final long POLL_TIMEOUT_MS = 2 * 60 * 1000L;
+
+    private static final String LATEST_TEXT = "This is the latest version.";
+    private static final String NEWER_VERSION_TEXT = "This nanopublication has a <strong>newer version</strong>:";
 
     /**
      * Creates a new StatusLine component.
      *
      * @param markupId the Wicket markup ID for this component
-     * @param npId     the nanopublication ID to check for newer versions
+     * @param np       the nanopublication to check for newer versions
      * @return a new StatusLine component
      */
-    public static Component createComponent(String markupId, String npId) {
+    public static Component createComponent(String markupId, Nanopub np) {
+        final String npId = np.getUri().stringValue();
+        final GovernedVersions.GovernedRef governedRef = GovernedVersions.findGovernedRef(np);
         ApiResultComponent c = new ApiResultComponent(markupId, new QueryRef(QueryApiAccess.GET_NEWER_VERSIONS_OF_NP, "np", npId)) {
 
             @Override
             public Component getApiResultComponent(String markupId, ApiResponse response) {
-                return new StatusLine(markupId, npId, response);
+                return new StatusLine(markupId, npId, response, governedRef);
             }
 
         };
@@ -56,23 +74,31 @@ public class StatusLine extends Panel {
     }
 
     private final String npId;
+    private final GovernedVersions.GovernedRef governedRef;
     private final long pollStart = System.currentTimeMillis();
     private String statusText;
     private List<String> links = List.of();
     private boolean verified = false;
+    private boolean latestBySupersedes = false;
 
     /**
      * Constructs a StatusLine component with the given markup ID, nanopublication ID, and API response.
      *
-     * @param markupId the Wicket markup ID for this component
-     * @param npId     the nanopublication ID to check for newer versions
-     * @param response the API response containing data about newer versions or retractions
+     * @param markupId    the Wicket markup ID for this component
+     * @param npId        the nanopublication ID to check for newer versions
+     * @param response    the API response containing data about newer versions or retractions
+     * @param governedRef the kind/space pair of the space-governed definition this
+     *                    nanopublication embeds, or null if it embeds none
      */
-    StatusLine(String markupId, String npId, ApiResponse response) {
+    StatusLine(String markupId, String npId, ApiResponse response, GovernedVersions.GovernedRef governedRef) {
         super(markupId);
         this.npId = npId;
+        this.governedRef = governedRef;
         setOutputMarkupId(true);
-        applyResponse(response);
+        // Constructed from ApiResultComponent.getLazyLoadComponent, which already
+        // waits for its own query off the initial page render, so the governed
+        // lookup may block here too.
+        applyResponse(response, true);
 
         add(new Label("statusText", (IModel<String>) () -> statusText).setEscapeModelStrings(false));
         add(new ListView<String>("linkList", (IModel<List<String>>) () -> links) {
@@ -96,7 +122,10 @@ public class StatusLine extends Panel {
                     ApiCache.clearCache(queryRef, 0);
                     ApiResponse fresh = ApiCache.retrieveResponseAsync(queryRef);
                     if (fresh != null) {
-                        applyResponse(fresh);
+                        // On the Wicket request thread, so the governed lookup must
+                        // not block; a just-published version is the latest one
+                        // anyway, and a later page load resolves it either way.
+                        applyResponse(fresh, false);
                     }
                     if (verified || System.currentTimeMillis() - pollStart > POLL_TIMEOUT_MS) {
                         stop(target);
@@ -106,7 +135,7 @@ public class StatusLine extends Panel {
         }
     }
 
-    private void applyResponse(ApiResponse response) {
+    private void applyResponse(ApiResponse response, boolean mayBlock) {
         List<String> latest = new ArrayList<>();
         List<String> retractions = new ArrayList<>();
         for (ApiResponseEntry e : response.getData()) {
@@ -120,16 +149,18 @@ public class StatusLine extends Panel {
             }
         }
 
+        latestBySupersedes = false;
         if (latest.isEmpty() && retractions.isEmpty()) {
             statusText = "<em>This nanopublication doesn't seem to be properly published (yet). This can take a minute or two for new nanopublications.</em>";
             links = List.of();
             verified = false;
         } else if (!latest.isEmpty()) {
             if (latest.size() == 1 && latest.getFirst().equals(npId)) {
-                statusText = "This is the latest version.";
+                statusText = LATEST_TEXT;
                 links = List.of();
+                latestBySupersedes = true;
             } else if (latest.size() == 1) {
-                statusText = "This nanopublication has a <strong>newer version</strong>:";
+                statusText = NEWER_VERSION_TEXT;
                 links = latest;
             } else {
                 statusText = "This nanopublication has <strong>newer versions</strong>:";
@@ -140,6 +171,42 @@ public class StatusLine extends Panel {
             statusText = "This nanopublication has been <strong>retracted</strong>:";
             links = retractions;
             verified = true;
+        }
+        applyGovernedOverride(mayBlock);
+    }
+
+    /**
+     * Overrides the "latest version" verdict of the supersedes-based query when
+     * this nanopublication embeds a space-governed definition that has since
+     * floated on to a newer version. Only that verdict is overridden: the
+     * not-yet-indexed and retracted states keep their precedence.
+     * <p>
+     * The governed query already skips retracted versions and only counts
+     * versions signed by a current member+ of the governing space, so an empty
+     * result means "no valid floating candidate" — the pinned version stands and
+     * this nanopublication really is the current one.
+     *
+     * @param mayBlock whether the caller's thread may wait for the lookup; when
+     *                 false, an uncached result leaves the supersedes-based
+     *                 verdict in place
+     */
+    private void applyGovernedOverride(boolean mayBlock) {
+        if (governedRef == null || !latestBySupersedes) return;
+        ApiResponse response;
+        try {
+            QueryRef queryRef = GovernedVersions.getQueryRef(governedRef);
+            response = mayBlock ? ApiCache.retrieveResponseSync(queryRef, false) : ApiCache.retrieveResponseAsync(queryRef);
+        } catch (Exception ex) {
+            // The lookup only refines the supersedes-based verdict; on failure
+            // that verdict stands rather than the status line breaking.
+            logger.error("Error resolving governed version for nanopub: {}", npId, ex);
+            return;
+        }
+        if (response == null) return;
+        String governedNpId = GovernedVersions.getVersionNanopubIri(response);
+        if (governedNpId != null && !governedNpId.equals(npId)) {
+            statusText = NEWER_VERSION_TEXT;
+            links = new ArrayList<>(List.of(governedNpId));
         }
     }
 

--- a/src/main/java/com/knowledgepixels/nanodash/page/ExplorePage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/ExplorePage.java
@@ -343,7 +343,7 @@ public class ExplorePage extends NanodashPage {
         if (publishedNanopub != null) {
             add(new Label("statusLine").setVisible(false));
         } else if (np != null && SignatureUtils.seemsToHaveSignature(np)) {
-            add(StatusLine.createComponent("statusLine", np.getUri().stringValue()));
+            add(StatusLine.createComponent("statusLine", np));
         } else {
             add(new Label("statusLine").setVisible(false));
         }

--- a/src/main/java/com/knowledgepixels/nanodash/page/NanopubNotFoundPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/NanopubNotFoundPage.java
@@ -1,5 +1,6 @@
 package com.knowledgepixels.nanodash.page;
 
+import com.knowledgepixels.nanodash.NavigationContext;
 import com.knowledgepixels.nanodash.NanopubLookup;
 import com.knowledgepixels.nanodash.component.TitleBar;
 import jakarta.servlet.http.HttpServletResponse;
@@ -94,6 +95,7 @@ public class NanopubNotFoundPage extends NanodashPage {
         // Retrying is worth offering: a lookup that timed out here keeps running in the
         // background, so the nanopublication may well be in the cache by now.
         add(new BookmarkablePageLink<Void>("retry-link", ExplorePage.class, new PageParameters().set("id", id))
+                .add(NavigationContext.pageContextFallback())
                 .setVisible(!id.isEmpty()));
         add(new BookmarkablePageLink<Void>("home-link", HomePage.class));
     }

--- a/src/main/java/com/knowledgepixels/nanodash/page/ProjectPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/ProjectPage.java
@@ -1,5 +1,6 @@
 package com.knowledgepixels.nanodash.page;
 
+import com.knowledgepixels.nanodash.NavigationContext;
 import com.knowledgepixels.nanodash.*;
 import com.knowledgepixels.nanodash.component.*;
 import com.knowledgepixels.nanodash.domain.Project;
@@ -66,7 +67,8 @@ public class ProjectPage extends NanodashPage {
         add(new Label("pagetitle", project.getLabel() + " (project) | nanodash"));
         add(new Label("projectname", project.getLabel()));
         add(new ExternalLink("id", project.getId(), project.getId()));
-        add(new BookmarkablePageLink<Void>("np", ExplorePage.class, new PageParameters().set("id", np.getUri())));
+        add(new BookmarkablePageLink<Void>("np", ExplorePage.class, new PageParameters().set("id", np.getUri()))
+                .add(NavigationContext.pageContextFallback()));
         add(new Label("description", "<span class=\"internal\">" + Utils.sanitizeHtml(project.getDescription()) + "</span>").setEscapeModelStrings(false));
 
         final PageParameters params = new PageParameters();

--- a/src/main/java/com/knowledgepixels/nanodash/page/QueryPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/QueryPage.java
@@ -1,5 +1,6 @@
 package com.knowledgepixels.nanodash.page;
 
+import com.knowledgepixels.nanodash.NavigationContext;
 import com.github.jsonldjava.shaded.com.google.common.base.Charsets;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
@@ -96,7 +97,8 @@ public class QueryPage extends NanodashPage {
         }
 
         add(new Label("querylabel", q.getLabel()));
-        add(new BookmarkablePageLink<Void>("np", ExplorePage.class, new PageParameters().set("id", q.getNanopub().getUri().stringValue())));
+        add(new BookmarkablePageLink<Void>("np", ExplorePage.class, new PageParameters().set("id", q.getNanopub().getUri().stringValue()))
+                .add(NavigationContext.pageContextFallback()));
         // TODO Replace hard-coded domain with dynamic solution:
         add(new ExternalLink("openapi-this", "https://query.knowledgepixels.com/openapi/?url=spec/" + id));
         add(new ExternalLink("openapi-latest", "https://query.knowledgepixels.com/openapi/?url=spec/" + id + "%3Fapi-version=latest"));

--- a/src/main/java/com/knowledgepixels/nanodash/page/ReferencesPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/ReferencesPage.java
@@ -1,5 +1,6 @@
 package com.knowledgepixels.nanodash.page;
 
+import com.knowledgepixels.nanodash.NavigationContext;
 import com.knowledgepixels.nanodash.Utils;
 import com.knowledgepixels.nanodash.View;
 import com.knowledgepixels.nanodash.ViewDisplay;
@@ -44,7 +45,8 @@ public class ReferencesPage extends NanodashPage {
         add(new Label("pagetitle", shortName + " (references) | nanodash"));
         add(new Label("termname", shortName));
         add(new ExternalLinkWithActionsPanel("urilink", Model.of(ref)));
-        add(new BookmarkablePageLink<Void>("back-link", ExplorePage.class, new PageParameters().set("id", ref)));
+        add(new BookmarkablePageLink<Void>("back-link", ExplorePage.class, new PageParameters().set("id", ref))
+                .add(NavigationContext.pageContextFallback()));
 
         View view = View.get(REFERENCES_VIEW);
         QueryRef queryRef = new QueryRef(view.getQuery().getQueryId(), "ref", ref);

--- a/src/main/java/com/knowledgepixels/nanodash/template/TemplateData.java
+++ b/src/main/java/com/knowledgepixels/nanodash/template/TemplateData.java
@@ -1,8 +1,7 @@
 package com.knowledgepixels.nanodash.template;
 
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Multimap;
 import com.knowledgepixels.nanodash.ApiCache;
+import com.knowledgepixels.nanodash.GovernedVersions;
 import com.knowledgepixels.nanodash.QueryApiAccess;
 import com.knowledgepixels.nanodash.Utils;
 import net.trustyuri.TrustyUriUtils;
@@ -203,16 +202,11 @@ public class TemplateData implements Serializable {
      */
     private String resolveGovernedTemplateId(Template pinned) {
         try {
-            Multimap<String, String> params = ArrayListMultimap.create();
-            params.put("kind", pinned.getTemplateKindIri().stringValue());
-            params.put("space", pinned.getGoverningSpace().stringValue());
-            ApiResponse resp = ApiCache.retrieveResponseSync(new QueryRef(QueryApiAccess.GET_LATEST_GOVERNED_VERSION, params), false);
-            if (resp != null && !resp.getData().isEmpty()) {
-                String latestId = resp.getData().get(0).get("version");
-                if (latestId != null && !latestId.isEmpty()) {
-                    Template resolved = getTemplate(latestId);
-                    if (resolved != null) return resolved.getId();
-                }
+            String latestId = GovernedVersions.getLatestVersionIriSync(
+                    pinned.getTemplateKindIri().stringValue(), pinned.getGoverningSpace().stringValue());
+            if (latestId != null) {
+                Template resolved = getTemplate(latestId);
+                if (resolved != null) return resolved.getId();
             }
         } catch (Exception ex) {
             logger.error("Error resolving governed version for template: {}", pinned.getId(), ex);

--- a/src/test/java/com/knowledgepixels/nanodash/GovernedVersionsTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/GovernedVersionsTest.java
@@ -1,0 +1,70 @@
+package com.knowledgepixels.nanodash;
+
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.junit.jupiter.api.Test;
+import org.nanopub.MalformedNanopubException;
+import org.nanopub.Nanopub;
+import org.nanopub.NanopubImpl;
+import org.nanopub.extra.services.ApiResponse;
+import org.nanopub.extra.services.ApiResponseEntry;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class GovernedVersionsTest {
+
+    private static Nanopub load(String fileName) throws MalformedNanopubException, IOException {
+        return new NanopubImpl(new File("src/test/resources/" + fileName), RDFFormat.TRIG);
+    }
+
+    @Test
+    void findsGovernedRefOfEmbeddedDefinition() throws Exception {
+        GovernedVersions.GovernedRef ref = GovernedVersions.findGovernedRef(load("np-governed-definition.trig"));
+
+        assertNotNull(ref);
+        assertEquals("https://w3id.org/np/RAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/templateKind", ref.getKind());
+        assertEquals("https://w3id.org/spaces/knowledgepixels/nanoarguments", ref.getSpace());
+    }
+
+    @Test
+    void findsNoGovernedRefWithoutGovernedBy() throws Exception {
+        assertNull(GovernedVersions.findGovernedRef(load("np-nongoverned-definition.trig")));
+    }
+
+    @Test
+    void findsNoGovernedRefForNullNanopub() {
+        assertNull(GovernedVersions.findGovernedRef(null));
+    }
+
+    @Test
+    void queryRefCarriesKindAndSpace() {
+        String url = GovernedVersions.getQueryRef("https://example.org/kind", "https://example.org/space").getAsUrlString();
+
+        assertTrue(url.contains(QueryApiAccess.GET_LATEST_GOVERNED_VERSION));
+        assertTrue(url.contains("kind=" + Utils.urlEncode("https://example.org/kind")));
+        assertTrue(url.contains("space=" + Utils.urlEncode("https://example.org/space")));
+    }
+
+    @Test
+    void readsVersionAndNanopubOffResponse() {
+        ApiResponse response = new ApiResponse();
+        ApiResponseEntry entry = new ApiResponseEntry();
+        entry.add("version", "https://example.org/np/RAe/template");
+        entry.add("np", "https://example.org/np/RAe");
+        response.getData().add(entry);
+
+        assertEquals("https://example.org/np/RAe/template", GovernedVersions.getVersionIri(response));
+        assertEquals("https://example.org/np/RAe", GovernedVersions.getVersionNanopubIri(response));
+    }
+
+    @Test
+    void readsNothingOffEmptyOrMissingResponse() {
+        assertNull(GovernedVersions.getVersionIri(null));
+        assertNull(GovernedVersions.getVersionNanopubIri(null));
+        assertNull(GovernedVersions.getVersionIri(new ApiResponse()));
+        assertNull(GovernedVersions.getVersionNanopubIri(new ApiResponse()));
+    }
+
+}

--- a/src/test/java/com/knowledgepixels/nanodash/component/StatusLineTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/component/StatusLineTest.java
@@ -1,11 +1,17 @@
 package com.knowledgepixels.nanodash.component;
 
+import com.knowledgepixels.nanodash.GovernedVersions;
 import org.apache.wicket.Component;
 import org.apache.wicket.util.tester.WicketTester;
+import org.eclipse.rdf4j.rio.RDFFormat;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.nanopub.Nanopub;
+import org.nanopub.NanopubImpl;
 import org.nanopub.extra.services.ApiResponse;
 import org.nanopub.extra.services.ApiResponseEntry;
+
+import java.io.File;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -28,8 +34,9 @@ class StatusLineTest {
     }
 
     @Test
-    void createComponentReturnsNonNullComponent() throws InterruptedException {
-        Component component = StatusLine.createComponent("statusLine", "https://w3id.org/np/RA58YcJyv1h-UmS8jI6UfFP6_LTAh59GTgpU_4lvBv7a4");
+    void createComponentReturnsNonNullComponent() throws Exception {
+        Nanopub np = new NanopubImpl(new File("src/test/resources/np-statusline-example.trig"), RDFFormat.TRIG);
+        Component component = StatusLine.createComponent("statusLine", np);
         assertNotNull(component);
 
         ((ApiResultComponent) component).getLazyLoadComponent("statusLine");
@@ -50,7 +57,7 @@ class StatusLineTest {
     void statusLineDisplaysNewerVersionLinkWhenNewerVersionExists() {
         ApiResponse response = new ApiResponse();
         response.getData().add(entry(TRUSTY_A, "", ""));
-        StatusLine statusLine = new StatusLine("testMarkupId", TRUSTY_C, response);
+        StatusLine statusLine = new StatusLine("testMarkupId", TRUSTY_C, response, null);
 
         wicketTester.startComponentInPage(statusLine);
         String renderedHtml = wicketTester.getLastResponseAsString();
@@ -62,7 +69,7 @@ class StatusLineTest {
     void statusLineDisplaysRetractionMessageWhenRetracted() {
         ApiResponse response = new ApiResponse();
         response.getData().add(entry("", TRUSTY_A, ""));
-        StatusLine statusLine = new StatusLine("testMarkupId", TRUSTY_C, response);
+        StatusLine statusLine = new StatusLine("testMarkupId", TRUSTY_C, response, null);
 
         wicketTester.startComponentInPage(statusLine);
         String renderedHtml = wicketTester.getLastResponseAsString();
@@ -75,7 +82,7 @@ class StatusLineTest {
         ApiResponse response = new ApiResponse();
         response.getData().add(entry(TRUSTY_A, "", ""));
         response.getData().add(entry(TRUSTY_B, "", ""));
-        StatusLine statusLine = new StatusLine("testMarkupId", TRUSTY_C, response);
+        StatusLine statusLine = new StatusLine("testMarkupId", TRUSTY_C, response, null);
 
         wicketTester.startComponentInPage(statusLine);
         String renderedHtml = wicketTester.getLastResponseAsString();
@@ -86,12 +93,30 @@ class StatusLineTest {
     @Test
     void statusLineDisplaysMessageWhenNotProperlyPublished() {
         ApiResponse response = new ApiResponse();
-        StatusLine statusLine = new StatusLine("testMarkupId", "testNpId", response);
+        StatusLine statusLine = new StatusLine("testMarkupId", "testNpId", response, null);
 
         wicketTester.startComponentInPage(statusLine);
         String renderedHtml = wicketTester.getLastResponseAsString();
 
         assertTrue(renderedHtml.contains("This nanopublication doesn't seem to be properly published (yet)."));
+    }
+
+    @Test
+    void governedLookupDoesNotOverrideRetractionMessage() throws Exception {
+        // A governed definition that has been retracted keeps the retraction as its
+        // status: the governed lookup only overrides the "latest version" verdict
+        // (and, being guarded on that verdict, isn't even issued here).
+        Nanopub governed = new NanopubImpl(new File("src/test/resources/np-governed-definition.trig"), RDFFormat.TRIG);
+        GovernedVersions.GovernedRef governedRef = GovernedVersions.findGovernedRef(governed);
+        assertNotNull(governedRef);
+        ApiResponse response = new ApiResponse();
+        response.getData().add(entry("", TRUSTY_A, ""));
+        StatusLine statusLine = new StatusLine("testMarkupId", TRUSTY_C, response, governedRef);
+
+        wicketTester.startComponentInPage(statusLine);
+        String renderedHtml = wicketTester.getLastResponseAsString();
+
+        assertTrue(renderedHtml.contains("This nanopublication has been <strong>retracted</strong>:"));
     }
 
 }

--- a/src/test/resources/np-governed-definition.trig
+++ b/src/test/resources/np-governed-definition.trig
@@ -1,0 +1,40 @@
+@prefix this: <https://w3id.org/np/RAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA> .
+@prefix sub: <https://w3id.org/np/RAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/> .
+@prefix np: <http://www.nanopub.org/nschema#> .
+@prefix gen: <https://w3id.org/kpxl/gen/terms/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix nt: <https://w3id.org/np/o/ntemplate/> .
+@prefix npx: <http://purl.org/nanopub/x/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix orcid: <https://orcid.org/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+
+sub:Head {
+  this: a np:Nanopublication;
+    np:hasAssertion sub:assertion;
+    np:hasProvenance sub:provenance;
+    np:hasPublicationInfo sub:pubinfo .
+}
+
+sub:assertion {
+  sub:template a nt:AssertionTemplate;
+    rdfs:label "A space-governed template";
+    dct:isVersionOf sub:templateKind;
+    gen:governedBy <https://w3id.org/spaces/knowledgepixels/nanoarguments> .
+
+  # Not embedded, so not a governed definition of this nanopublication:
+  sub:somethingElse dct:isVersionOf sub:otherKind;
+    gen:governedBy <https://w3id.org/spaces/knowledgepixels/other> .
+}
+
+sub:provenance {
+  sub:assertion prov:wasAttributedTo orcid:0000-0002-1267-0234 .
+}
+
+sub:pubinfo {
+  this: dct:created "2026-07-13T07:07:32.752Z"^^xsd:dateTime;
+    dct:creator orcid:0000-0002-1267-0234;
+    npx:embeds sub:template;
+    npx:introduces sub:templateKind .
+}

--- a/src/test/resources/np-nongoverned-definition.trig
+++ b/src/test/resources/np-nongoverned-definition.trig
@@ -1,0 +1,34 @@
+@prefix this: <https://w3id.org/np/RABBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB> .
+@prefix sub: <https://w3id.org/np/RABBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB/> .
+@prefix np: <http://www.nanopub.org/nschema#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix nt: <https://w3id.org/np/o/ntemplate/> .
+@prefix npx: <http://purl.org/nanopub/x/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix orcid: <https://orcid.org/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+
+sub:Head {
+  this: a np:Nanopublication;
+    np:hasAssertion sub:assertion;
+    np:hasProvenance sub:provenance;
+    np:hasPublicationInfo sub:pubinfo .
+}
+
+sub:assertion {
+  sub:template a nt:AssertionTemplate;
+    rdfs:label "A template that floats via npx:supersedes only";
+    dct:isVersionOf sub:templateKind .
+}
+
+sub:provenance {
+  sub:assertion prov:wasAttributedTo orcid:0000-0002-1267-0234 .
+}
+
+sub:pubinfo {
+  this: dct:created "2026-07-13T07:07:32.752Z"^^xsd:dateTime;
+    dct:creator orcid:0000-0002-1267-0234;
+    npx:embeds sub:template;
+    npx:introduces sub:templateKind .
+}

--- a/src/test/resources/np-statusline-example.trig
+++ b/src/test/resources/np-statusline-example.trig
@@ -1,0 +1,39 @@
+@prefix this: <https://w3id.org/np/RA58YcJyv1h-UmS8jI6UfFP6_LTAh59GTgpU_4lvBv7a4> .
+@prefix sub: <https://w3id.org/np/RA58YcJyv1h-UmS8jI6UfFP6_LTAh59GTgpU_4lvBv7a4/> .
+@prefix np: <http://www.nanopub.org/nschema#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix pav: <http://purl.org/pav/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfg: <http://www.w3.org/2004/03/trix/rdfg-1/> .
+@prefix dce: <http://purl.org/dc/elements/1.1/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix npx: <http://purl.org/nanopub/x/> .
+
+sub:Head {
+  this: a np:Nanopublication;
+    np:hasAssertion sub:assertion;
+    np:hasProvenance sub:provenance;
+    np:hasPublicationInfo sub:pubinfo .
+}
+
+sub:assertion {
+  <https://orcid.org/0009-0008-3635-347X> npx:retracts <https://w3id.org/np/RA1Lhd0Rt5xuz63vjeUYgGJrgeUvH-7QKwAiPgj44WWgg> .
+}
+
+sub:provenance {
+  sub:assertion prov:wasAttributedTo <https://orcid.org/0009-0008-3635-347X> .
+}
+
+sub:pubinfo {
+  this: dct:creator <https://orcid.org/0009-0008-3635-347X> .
+  
+  sub:sig npx:hasAlgorithm "RSA";
+    npx:hasPublicKey "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApbztY8l4lWqVF8L/djJ1knoc7Nm5kVHT9NqSe0fXO9Hel3DRO2IyxJYVEvThhllBuHNtZK32ww23AlglArokhxPCSBPKvVgQS6r46khF2D85tnd5htaBq+bfjMqL+LDlQh3LdBpAqrLmsmfsPkU65CCxSGufBs2v39p41z5FkRXE1JKJ/UZe+1OUq+CibjOfo1g1Nz6HO0fZML7GnQBj5X9lvU0llmDk/sqdNMxAJDSQh2/Zh0kz7+Dm7vJOx3mNEXU4FuzVzKBYwTotvEcJod7Vot1fPOJXPGoNDVNKMQffCala9o4pqT739LS7R7ZFVMjzPkLUxYCjnEgOZI5t6wIDAQAB";
+    npx:hasSignature "b02egVbAt/XzvcLq12zscVfRJYYeC/d7Vc8bV+EEoYFT9Mk2zT2eE/wugXCTsB1DalLrtjyHd1r9xiBKyZuj161O8b5KKlYUYvEh4wpnd6xdJevGH9Ad9LK+VI3a5dNXVxJAKlYX87MvuHPohLeu0EHT1IochUDyAVWtU7roHaxJHZ6SB4FnJv6XrJ2detnkx2LeT6nNLUvPxgE62qjdML2hgEhZNDVTCma7/ub6gk0n5MIgtthX8IpafvJH9VvePtZg+L2pp3cGW2MQPFkG7fnnYlli6OX37yu1Q4YAS0JLubqPaUGL4rI82zkIT6CpLhJfU13TruqzzWZE30e1jQ==";
+    npx:hasSignatureTarget this:;
+    npx:signedBy <https://orcid.org/0009-0008-3635-347X> .
+}
+


### PR DESCRIPTION
Closes #584.

## Problem

The "Status" line resolved newer versions purely through the `npx:supersedes` chain (`get-newer-versions-of-np`). A space-governed definition floats within its `(kind, space)` pair instead, and its new versions carry **no** `npx:supersedes` — so a nanopublication superseded by governance was reported as "This is the latest version."

Confirmed on the issue's example:

- `RATxyPik…` (2026-07-13) — assertion declares `dct:isVersionOf sub:templateKind` + `gen:governedBy …/nanoarguments`
- `RAe-8U_a…` (2026-07-15) — same kind, same governing space, no `npx:supersedes`
- `get-latest-governed-version` returns `RAe-8U_a…` as the current winner

## Fix

When a nanopublication embeds a definition declaring both `dct:isVersionOf` and `gen:governedBy`, the status line also consults `GET_LATEST_GOVERNED_VERSION` and links the current governed version.

**Only the "latest version" verdict is overridden** — the not-yet-indexed and retracted states keep their precedence. The governed query already skips retracted versions and only counts versions signed by a current member+ of the governing space, so an empty result means "no valid floating candidate": the pin stands.

The lookup runs inside `ApiResultComponent.getLazyLoadComponent`, which already waits for its own query off the initial page render. The existing AJAX poll (armed only when the nanopublication isn't indexed yet) keeps its non-blocking path — an early attempt to re-run the governed lookup on each poll tick made `ExplorePage` 500 with `Could not deserialize object from byte[]`, since the extra polling forced page-store round-trips this page doesn't survive. Verified against a clean worktree that master does not have that failure; it is latent there on the not-yet-indexed path and left for a separate issue.

The `(kind, space)` parsing and the query are extracted into a new `GovernedVersions` helper, which `View` and `TemplateData` now share instead of each assembling the query themselves. Being type-agnostic, it covers governed views, templates, presets and queries alike.

## Second commit: navigation context on links

The status line's version link built its target from a fresh `PageParameters` holding only the id, so following it dropped the `context` param. Adds the existing `NavigationContext.pageContextFallback()` behavior there and to the sibling `ExplorePage` links that lost the context the same way (outdated-source "latest version" link, references back-link, not-found retry, just-published link, reaction links, space-claimants root link, query and project nanopub links).

Left alone: `PublishForm`'s "switch to latest version" and the outdated-source action link already copy the full page parameters, and the title bar's back-link points at the context resource itself.

## Verification

Driven headless against a local instance:

| nanopub | status line |
|---|---|
| `RATxyPik…` (issue's example) | "has a **newer version**: RAe-8U_a1c" → links to `RAe-8U_a1c…` |
| `RAe-8U_a…` (the governed winner) | "This is the latest version." |
| `RA58YcJyv…` (non-governed) | "This is the latest version." |

With `&context=…/nanoarguments` the link renders as `./explore?id=…RAe-8U_a…&context=…/nanoarguments` and the context survives onto the landed page; without a context, no spurious param appears. No deserialization errors in the log.

Tests: **992 pass, 0 failures, 0 errors** — including 6 new `GovernedVersions` unit tests and a new `StatusLine` test pinning the retraction-beats-governed precedence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)