### PR TITLE
fix: keep introduced-resource IRI on supersede/override for marker templates

### DIFF
--- a/docs/fill-modes.md
+++ b/docs/fill-modes.md
@@ -41,6 +41,16 @@ The source's introduced resource IRIs are **kept** (same identity), and the root
 definition is **kept** (a version chain shares one root). Offered only for your
 own nanopubs. Menu action: `UpdateAction` ("update").
 
+Keeping the introduced IRI applies **however the template declares the introduced
+resource** — as a sub-IRI of the template nanopub (`sub:class`), or as an absolute
+IRI in a foreign namespace carrying the `~~ARTIFACTCODE~~` marker (the idiom used
+by "Defining a biochementity"). The pin lives in `TemplateContext#processValue`
+and is keyed on `isIntroducedResource` alone; it must **not** be gated on
+`isLocalResource`, which `Template#tagIfUntypedLocal` only ever attaches to
+sub-IRIs of the template nanopub. Gating it there made supersede/override silently
+mint a *new* resource for marker-style templates — regression test:
+`OverrideIntroducedResourceIriTest`.
+
 ### Derive
 
 A **new, distinct resource** based on an existing one. `prov:wasDerivedFrom`

--- a/src/main/java/com/knowledgepixels/nanodash/template/TemplateContext.java
+++ b/src/main/java/com/knowledgepixels/nanodash/template/TemplateContext.java
@@ -527,12 +527,24 @@ public class TemplateContext implements Serializable {
                     processedValue = vf.createIRI(v);
                 }
             }
+        } else if (template.isIntroducedResource(iri)
+                && (fillMode == FillMode.SUPERSEDE || fillMode == FillMode.OVERRIDE)
+                && tfObjectGeneric instanceof String pinnedIri && !pinnedIri.isEmpty()) {
+            // An introduced resource keeps its IRI across versions (docs/fill-modes.md), so
+            // supersede/override pin the source's IRI that ValueFiller left in the (read-only)
+            // model. This must not be gated on isLocalResource: LOCAL_RESOURCE is only ever
+            // attached to sub-IRIs of the template nanopub (Template#tagIfUntypedLocal), while a
+            // template may introduce an absolute IRI in a foreign namespace via the
+            // "~~ARTIFACTCODE~~" marker (e.g. "Defining a biochementity"). Those used to fall
+            // through to the catch-all branch, keep the marker, and get a fresh artifact code
+            // substituted at signing time -- minting a new resource instead of a new version.
+            processedValue = vf.createIRI(pinnedIri);
         } else if (template.isLocalResource(iri)) {
-            String tfObject = (String) tfObjectGeneric;
             if (template.isIntroducedResource(iri) && (fillMode == FillMode.SUPERSEDE || fillMode == FillMode.OVERRIDE)) {
-                if (tf != null && tfObject != null && !tfObject.isEmpty()) {
-                    processedValue = vf.createIRI(tfObject);
-                }
+                // Pinned by the branch above whenever a source IRI is known. With no source
+                // value the slot stays unresolved rather than minting a fresh identity, so an
+                // introduced identifier the old version didn't declare yet stays fillable
+                // (issue #549).
             } else {
                 String prefix = Utils.getUriPrefix(iri);
                 processedValue = vf.createIRI(iri.stringValue().replace(prefix, targetNamespace));

--- a/src/test/java/com/knowledgepixels/nanodash/template/OverrideIntroducedResourceIriTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/template/OverrideIntroducedResourceIriTest.java
@@ -1,0 +1,80 @@
+package com.knowledgepixels.nanodash.template;
+
+import com.knowledgepixels.nanodash.Utils;
+import com.knowledgepixels.nanodash.WicketApplication;
+import com.knowledgepixels.nanodash.component.PublishForm.FillMode;
+import org.apache.wicket.model.Model;
+import org.apache.wicket.util.tester.WicketTester;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Value;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Overriding (and superseding) must keep the source's introduced-resource IRI, as
+ * documented in docs/fill-modes.md. The pinning in
+ * {@link TemplateContext#processValue} used to sit inside the
+ * {@code isLocalResource} branch, and {@code LOCAL_RESOURCE} is only ever attached
+ * to sub-IRIs of the template nanopub. A template whose introduced resource is an
+ * absolute IRI in a foreign namespace carrying the {@code ~~ARTIFACTCODE~~} marker
+ * — the idiom used by "Defining a biochementity" — therefore fell through to the
+ * catch-all branch, kept the marker, and had a fresh artifact code substituted at
+ * signing time. The override then minted a brand-new term instead of publishing a
+ * variant of the existing one.
+ */
+class OverrideIntroducedResourceIriTest {
+
+    // "Defining a biochementity" — introduced resource is
+    // https://w3id.org/peh/biochementities/~~ARTIFACTCODE~~ , not a template sub-IRI.
+    private static final String TEMPLATE = "https://w3id.org/np/RAD4mKOVqsJc7nAVVR0dXXcVFU2IOjrFywv2GspkpalfQ";
+    // What RepetitionGroup.transform hands to processValue (see StatementItem#transform).
+    private static final IRI RENDERED_INTRODUCED =
+            Utils.vf.createIRI("https://w3id.org/peh/biochementities/~~~ARTIFACTCODE~~~");
+    // The concrete IRI of the resource being overridden, as ValueFiller leaves it in
+    // the (read-only) component model on supersede/override.
+    private static final String SOURCE_IRI =
+            "https://w3id.org/peh/biochementities/RABgnhJuxuXZpUkUQVoi2femjGVEm2Ij-tRFFkwKgJ-AA";
+
+    private static final String TARGET_NAMESPACE = "https://example.org/np/~~~ARTIFACTCODE~~~/";
+
+    @BeforeEach
+    void setUp() {
+        new WicketTester(new WicketApplication());
+    }
+
+    @Test
+    void overrideKeepsIntroducedResourceIri() {
+        Value result = processIntroducedResource(FillMode.OVERRIDE);
+        assertEquals(SOURCE_IRI, result.stringValue(),
+                "override must keep the source's introduced-resource IRI, not re-mint it");
+    }
+
+    @Test
+    void supersedeKeepsIntroducedResourceIri() {
+        Value result = processIntroducedResource(FillMode.SUPERSEDE);
+        assertEquals(SOURCE_IRI, result.stringValue(),
+                "supersede must keep the source's introduced-resource IRI, not re-mint it");
+    }
+
+    @Test
+    void freshPublishStillMintsFromTheArtifactCodeMarker() {
+        TemplateContext context = new TemplateContext(ContextType.ASSERTION, TEMPLATE, "statement", TARGET_NAMESPACE);
+        context.initStatements();
+        // No fill mode and no seeded model: a fresh publish must keep the marker so the
+        // signer substitutes this nanopub's own artifact code.
+        Value result = context.processValue(RENDERED_INTRODUCED);
+        assertEquals(RENDERED_INTRODUCED.stringValue(), result.stringValue(),
+                "a fresh publish must still mint the term IRI from the artifact-code marker");
+    }
+
+    private Value processIntroducedResource(FillMode fillMode) {
+        TemplateContext context = new TemplateContext(ContextType.ASSERTION, TEMPLATE, "statement", TARGET_NAMESPACE);
+        context.setFillMode(fillMode);
+        context.initStatements();
+        context.getComponentModels().put(RENDERED_INTRODUCED, Model.of(SOURCE_IRI));
+        return context.processValue(RENDERED_INTRODUCED);
+    }
+
+}


### PR DESCRIPTION
## The bug

Overriding an existing biochementity minted a **brand-new term** instead of a variant of the existing one. The published nanopub introduced `.../biochementities/RArgnyM0…` (the new nanopub's own artifact code) rather than keeping the source's `.../biochementities/RABgnhJux…`, leaving two rival terms with the same label in the vocabulary.

This contradicts `docs/fill-modes.md`, which states that Override "**keeps** the source's introduced resource IRIs **and** its root definition".

## Root cause

The pin that preserves an introduced resource's identity across versions sat *inside* the `isLocalResource` branch of `TemplateContext#processValue`:

```java
} else if (template.isLocalResource(iri)) {
    if (template.isIntroducedResource(iri) && (fillMode == SUPERSEDE || fillMode == OVERRIDE)) {
        processedValue = vf.createIRI(tfObject);   // pin the source's IRI
    } else { /* mint a new one */ }
}
```

`LOCAL_RESOURCE` is only ever attached by `Template#tagIfUntypedLocal`, which bails unless the IRI is a sub-IRI of the template nanopub. A template that introduces an **absolute IRI in a foreign namespace** via the `~~ARTIFACTCODE~~` marker — the idiom used by "Defining a biochementity" — never gets that type. The branch was skipped entirely, the value fell through to the catch-all `else { processedValue = iri; }`, the marker survived to signing, and the signer substituted a fresh artifact code.

The two halves of the feature disagreed, which is why this was invisible in the UI:

- `ValueItem:58` pins the field read-only on `isIntroducedResource` **alone** — the form looked correct.
- `ValueFiller#transform` correctly declines to localize the source IRI on supersede/override, so the right value was sitting in the component model.
- `processValue` then never read it.

Templates whose introduced resource *is* a template sub-IRI (e.g. `sub:class` in "Defining a new class", declared `nt:IntroducedResource, nt:LocalResource, nt:UriPlaceholder`) were unaffected, which is why this went unnoticed.

**Not a regression from the override feature.** `git log -S` puts the `isLocalResource` gate before 9063a046 ("add override fill mode"), which only added `|| OVERRIDE` alongside the existing `SUPERSEDE`. Superseding a marker-style template through the form has always re-minted; override just made it easy to hit.

## The fix

Key the pin on `isIntroducedResource` plus a non-empty model value, in its own branch ahead of `isLocalResource`. Behaviour-preserving everywhere else:

- **empty model** under supersede/override → falls through to the (now explicitly no-op) inner branch, leaving the slot unresolved rather than minting a fresh identity, so an introduced identifier the old version didn't declare yet stays fillable (#549).
- **non-introduced local resources** → unchanged.
- **fresh publish** → unchanged, still mints from the marker.

## Tests

New `OverrideIntroducedResourceIriTest`, three cases: override keeps the IRI, supersede keeps the IRI, and a fresh publish still mints from the marker. Before the fix the first two failed exactly as observed in the wild (`expected .../RABgnhJux… but was .../~~~ARTIFACTCODE~~~`) while the control passed.

After: 3/3 green, and the full suite is **997 tests, 0 failures, 0 errors, 26 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)