### PR TITLE
Add SVG view display type (gen:SvgView)

### DIFF
--- a/docs/svg-views.md
+++ b/docs/svg-views.md
@@ -1,0 +1,81 @@
+# SVG views
+
+An **SVG view** (`gen:SvgView`) is a resource-view display type whose query returns
+ready-to-embed SVG markup, rendered inline on the page. Where the other display
+types lay out the query's rows as a table, list, or paragraphs, an SVG view's query
+computes the *visual itself* — e.g. a diagram laid out in SPARQL from the underlying
+data — and Nanodash only sanitizes and embeds it. The query API needs no changes for
+this: the SVG travels as an ordinary result-cell string.
+
+## View declaration
+
+Exactly like any other view, with `gen:SvgView` as the display type:
+
+```turtle
+sub:my-svg-view a gen:ResourceView, gen:SvgView ;
+  dct:isVersionOf sub:my-svg-view-kind ;
+  rdfs:label "My typology diagram view" ;
+  dct:title "🌳 Typology" ;
+  gen:hasViewQuery <query-np-uri> ;
+  gen:hasViewQueryTargetField "resource" ;
+  gen:appliesToInstancesOf gen:MaintainedResource .
+```
+
+Display/preset attachment, structural position, display width, governed versions,
+and view actions all work as for the other view types. Older Nanodash instances
+without SVG-view support skip the view silently (unknown display type), and the
+document export renders a "(view type not supported in document export)" note.
+
+## Query contract
+
+- **`svg`** — the complete SVG markup (`<svg ...>...</svg>`), one rendered figure
+  per result row. Typically such a query returns a single row.
+- **`title`** (optional) — a heading rendered above the figure, as in plain-paragraph
+  views.
+- **`np`** (optional) — the source nanopub, linked from the figure's dropdown menu.
+
+Entry actions and their query mappings work per row as usual.
+
+## Sanitization
+
+The markup is sanitized server-side (`Utils.sanitizeSvg`) to a **static SVG
+subset** before rendering; the query controls the visual but cannot inject
+scripting or styling:
+
+- **Elements**: `svg`, `g`, `defs`, `marker`, `title`, `desc`, `rect`, `circle`,
+  `ellipse`, `line`, `polyline`, `polygon`, `path`, `text`, `tspan`, `a`.
+- **Attributes**: geometry (`x`, `y`, `d`, `points`, `viewBox`, `transform`, …) and
+  presentation (`fill`, `stroke`, `font-size`, `text-anchor`, `opacity`, …); `href`
+  only on `a` and only with `http(s)` URLs.
+- **Dropped**: `script`, `style` (element and attribute), event handlers,
+  `foreignObject`, and external-reference elements (`use`, `image`).
+
+Authoring notes:
+
+- **Write explicit end tags** (`<rect ...></rect>`), not XML self-closing syntax
+  (`<rect .../>`); inline SVG is parsed under HTML rules where the self-closing
+  slash is ignored on these elements. The sanitizer normalizes self-closed tags as
+  a safety net, but emitting end tags keeps the markup valid in both worlds.
+- Use the **camelCase** spellings of SVG attributes (`viewBox`,
+  `preserveAspectRatio`); they are matched case-sensitively and passed through
+  verbatim.
+- XML-escape all data-derived text (`&` → `&amp;`, `<` → `&lt;`, `>` → `&gt;`) in
+  both text content and attribute values — the values come from published nanopub
+  data, which is untrusted.
+- Prefer **absolute coordinates** computed in the query (e.g. via rank subqueries)
+  over document-order-dependent constructs: `group_concat` does not reliably
+  preserve a subquery's ORDER BY, so output that depends on concatenation order
+  renders nondeterministically.
+- `<title>` children provide hover tooltips — useful when labels are truncated to
+  fit fixed-width boxes.
+
+The figure container (`.svg-view-content`) scales diagrams wider than their panel
+down to fit (`max-width: 100%`).
+
+## Example
+
+The first SVG-view query is "Get class typology diagram as SVG": given an
+ontology-like maintained resource, it renders the subclass typology of the
+resource's classes (root banner, branch group boxes in a two-column layout,
+per-branch item lists with a second indented level), with all boxes and positions
+computed in SPARQL and every label linked to its class IRI.

--- a/docs/svg-views.md
+++ b/docs/svg-views.md
@@ -70,7 +70,9 @@ Authoring notes:
   fit fixed-width boxes.
 
 The figure container (`.svg-view-content`) scales diagrams wider than their panel
-down to fit (`max-width: 100%`).
+down to fit (`max-width: 100%`), and text inside `a` links takes the page's link
+color and hover color via CSS (overriding the SVG's own `fill` attributes, which
+thus serve as the fallback for standalone rendering of the query output).
 
 ## Example
 

--- a/src/main/java/com/knowledgepixels/nanodash/Utils.java
+++ b/src/main/java/com/knowledgepixels/nanodash/Utils.java
@@ -571,6 +571,58 @@ public class Utils {
         return htmlSanitizePolicy.sanitize(rawHtml);
     }
 
+    // A conservative static-SVG subset for SVG views (QueryResultSvg): basic shapes,
+    // text, grouping, and links. Everything not allowed is dropped — in particular
+    // script/foreignObject/style and all event handlers, plus use/image, whose
+    // href would reach outside the sanitized document. Attribute-name matching is
+    // case-sensitive and the matched spelling is emitted verbatim, so the camelCase
+    // SVG attributes are listed in both spellings (browsers also map the lowercase
+    // form back via the SVG attribute-adjustment table, but the camelCase form
+    // works everywhere, including XML contexts).
+    private static final PolicyFactory svgSanitizePolicy = new HtmlPolicyBuilder()
+            .allowUrlProtocols("https", "http")
+            .allowElements("svg", "g", "defs", "marker", "title", "desc",
+                    "rect", "circle", "ellipse", "line", "polyline", "polygon", "path",
+                    "text", "tspan", "a")
+            .allowWithoutAttributes("svg", "g", "defs", "title", "desc", "text", "tspan", "a")
+            .allowAttributes("viewbox", "viewBox", "width", "height",
+                    "preserveaspectratio", "preserveAspectRatio", "xmlns",
+                    "x", "y", "x1", "y1", "x2", "y2", "cx", "cy", "r", "rx", "ry",
+                    "d", "points", "dx", "dy", "transform",
+                    "fill", "fill-opacity", "fill-rule",
+                    "stroke", "stroke-width", "stroke-opacity", "stroke-linecap",
+                    "stroke-linejoin", "stroke-dasharray", "opacity",
+                    "font-family", "font-size", "font-weight", "font-style",
+                    "text-anchor", "dominant-baseline", "text-decoration",
+                    "marker-start", "marker-mid", "marker-end",
+                    "markerwidth", "markerWidth", "markerheight", "markerHeight",
+                    "refx", "refX", "refy", "refY", "orient", "markerunits", "markerUnits",
+                    "id")
+            .globally()
+            .allowAttributes("href").onElements("a")
+            .toFactory();
+
+    // XML-style self-closed tags (<rect .../>): the HTML-parsing sanitizer ignores
+    // the slash on non-void elements and would re-parent all following siblings as
+    // children of the "unclosed" element — which in SVG makes them invisible (shape
+    // elements don't render children). Expanded to explicit end tags before
+    // sanitizing. Quoted attribute values (which may contain ">") are matched as
+    // units so the tag end is found correctly.
+    private static final Pattern SELF_CLOSED_TAG = Pattern.compile("<([a-zA-Z][a-zA-Z0-9-]*)((?:[^<>\"']|\"[^\"]*\"|'[^']*')*)/>");
+
+    /**
+     * Sanitizes SVG markup (as produced by an SVG view's query) down to a static
+     * subset that is safe to embed inline: shapes, text, grouping, and http(s)
+     * links, with no scripting, styling, or external-reference capability.
+     *
+     * @param rawSvg the raw SVG markup
+     * @return sanitized SVG markup
+     */
+    public static String sanitizeSvg(String rawSvg) {
+        String normalized = SELF_CLOSED_TAG.matcher(rawSvg).replaceAll("<$1$2></$1>");
+        return svgSanitizePolicy.sanitize(normalized);
+    }
+
     /**
      * Checks if a given string is likely to be HTML content.
      *

--- a/src/main/java/com/knowledgepixels/nanodash/View.java
+++ b/src/main/java/com/knowledgepixels/nanodash/View.java
@@ -37,6 +37,7 @@ public class View implements Serializable {
             KPXL_TERMS.PLAIN_PARAGRAPH_VIEW,
             KPXL_TERMS.NANOPUB_SET_VIEW,
             KPXL_TERMS.ITEM_LIST_VIEW,
+            KPXL_TERMS.SVG_VIEW,
             KPXL_TERMS.HEADER_VIEW
     );
 

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultComponentFactory.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultComponentFactory.java
@@ -69,6 +69,13 @@ public class QueryResultComponentFactory {
                     .contextId(contextId)
                     .refRoot(refRoot)
                     .build();
+        } else if (viewType.equals(KPXL_TERMS.SVG_VIEW)) {
+            return QueryResultSvgBuilder.create(markupId, queryRef, viewDisplay)
+                    .pageResource(resourceWithProfile)
+                    .contextId(contextId)
+                    .id(id)
+                    .refRoot(refRoot)
+                    .build();
         } else if (viewType.equals(KPXL_TERMS.ITEM_LIST_VIEW)) {
             return QueryResultItemListBuilder.create(markupId, queryRef, viewDisplay)
                     .resourceWithProfile(resourceWithProfile)

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultSvg.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultSvg.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html xmlns:wicket="http://wicket.apache.org">
+
+<head>
+  <link rel="stylesheet" href="../../../../../webapp/style.css?for-local-testing-only" type="text/css" media="screen"
+        title="Stylesheet"/>
+</head>
+<body style="margin-left: auto; margin-right: auto; max-width: 1420px">
+
+<wicket:panel>
+  <div class="paneltitlerow listpanel">
+    <h4 wicket:id="label">SVG</h4>
+    <span class="buttons"><wicket:container wicket:id="np">[np]</wicket:container></span>
+    <span wicket:id="buttons" class="buttons"></span>
+  </div>
+  <div wicket:id="svg-container">
+    <div wicket:id="figures">
+      <div wicket:id="header" class="paragraph-header">
+        <h5 wicket:id="title">[title]</h5>
+        <span class="buttons"><span wicket:id="pnp"></span></span>
+      </div>
+      <div wicket:id="content" class="svg-view-content">[svg]</div>
+    </div>
+    <p wicket:id="no-records" class="no-records-note">(nothing found)</p>
+  </div>
+</wicket:panel>
+
+</body>
+
+</html>

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultSvg.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultSvg.java
@@ -1,0 +1,94 @@
+package com.knowledgepixels.nanodash.component;
+
+import com.knowledgepixels.nanodash.NavigationContext;
+import com.knowledgepixels.nanodash.QueryResult;
+import com.knowledgepixels.nanodash.Utils;
+import com.knowledgepixels.nanodash.ViewDisplay;
+import com.knowledgepixels.nanodash.component.menu.EntryActionMenu;
+import com.knowledgepixels.nanodash.page.ExplorePage;
+import org.apache.wicket.behavior.AttributeAppender;
+import org.apache.wicket.markup.html.WebMarkupContainer;
+import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.link.AbstractLink;
+import org.apache.wicket.markup.html.link.BookmarkablePageLink;
+import org.apache.wicket.markup.html.list.ListItem;
+import org.apache.wicket.markup.html.list.ListView;
+import org.apache.wicket.model.Model;
+import org.apache.wicket.request.mapper.parameter.PageParameters;
+import org.nanopub.extra.services.ApiResponse;
+import org.nanopub.extra.services.ApiResponseEntry;
+import org.nanopub.extra.services.QueryRef;
+
+import java.util.List;
+
+/**
+ * Component for displaying query results as inline SVG (gen:SvgView). The query is
+ * expected to return ready-to-embed SVG markup in an "svg" column — one rendered
+ * figure per result row, with an optional "title" column as the figure's heading.
+ * The markup is sanitized to a static-SVG subset before rendering, so the query
+ * fully controls the visual but cannot inject scripting or styling.
+ */
+public class QueryResultSvg extends QueryResult {
+
+    /**
+     * Constructor for QueryResultSvg.
+     *
+     * @param markupId    the markup ID
+     * @param queryRef    the query reference
+     * @param response    the API response
+     * @param viewDisplay the view display
+     */
+    QueryResultSvg(String markupId, QueryRef queryRef, ApiResponse response, ViewDisplay viewDisplay) {
+        super(markupId, queryRef, response, viewDisplay);
+
+        String label = grlcQuery.getLabel();
+        if (viewDisplay.getTitle() != null) {
+            label = viewDisplay.getTitle();
+        }
+        add(new Label("label", label).setVisible(label != null && !label.isEmpty()));
+        setOutputMarkupId(true);
+
+        populateComponent();
+    }
+
+    @Override
+    protected void populateComponent() {
+        WebMarkupContainer container = new WebMarkupContainer("svg-container");
+        container.setOutputMarkupId(true);
+        container.add(new ListView<ApiResponseEntry>("figures", response.getData()) {
+            @Override
+            protected void populateItem(ListItem<ApiResponseEntry> item) {
+                String title = item.getModelObject().get("title");
+                boolean hasTitle = title != null && !title.isBlank();
+                // As in the plain-paragraph view: hide the empty heading for a
+                // title-less figure and float the source link into the corner.
+                WebMarkupContainer header = new WebMarkupContainer("header");
+                if (!hasTitle) header.add(new AttributeAppender("class", " no-title"));
+                header.add(new Label("title", title).setVisible(hasTitle));
+                List<AbstractLink> links = ViewActionMappings.buildEntryActionLinks(viewDisplay.getView(),
+                        item.getModelObject(), queryRef,
+                        resourceWithProfile != null ? resourceWithProfile : pageResource,
+                        contextId, partId, refRoot, postPublishTab);
+                String npId = item.getModelObject().get("np");
+                if (npId != null && !npId.isBlank()) {
+                    BookmarkablePageLink<Void> sourceLink = new BookmarkablePageLink<>("link", ExplorePage.class,
+                            new PageParameters().set("id", npId));
+                    sourceLink.add(NavigationContext.pageContextFallback());
+                    sourceLink.setBody(Model.of("<span class=\"actionmenu-icon\">↗︎</span>source")).setEscapeModelStrings(false);
+                    links.add(sourceLink);
+                }
+                if (links.isEmpty()) {
+                    header.add(new Label("pnp").setVisible(false));
+                } else {
+                    header.add(new EntryActionMenu("pnp", links));
+                }
+                item.add(header);
+                String svg = item.getModelObject().get("svg");
+                item.add(new Label("content", svg == null ? null : withContextInHtmlLinks(Utils.sanitizeSvg(svg))).setEscapeModelStrings(false));
+            }
+        });
+        container.add(new Label("no-records", "(nothing found)").setVisible(response.getData().isEmpty()));
+        add(container);
+    }
+
+}

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultSvgBuilder.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultSvgBuilder.java
@@ -1,0 +1,157 @@
+package com.knowledgepixels.nanodash.component;
+
+import com.knowledgepixels.nanodash.ApiCache;
+import com.knowledgepixels.nanodash.SpaceMemberRole;
+import com.knowledgepixels.nanodash.View;
+import com.knowledgepixels.nanodash.ViewDisplay;
+import com.knowledgepixels.nanodash.domain.AbstractResourceWithProfile;
+import com.knowledgepixels.nanodash.domain.MaintainedResource;
+import com.knowledgepixels.nanodash.page.PublishPage;
+import com.knowledgepixels.nanodash.repository.MaintainedResourceRepository;
+import com.knowledgepixels.nanodash.template.Template;
+import org.apache.wicket.Component;
+import org.apache.wicket.behavior.AttributeAppender;
+import org.apache.wicket.request.mapper.parameter.PageParameters;
+import org.eclipse.rdf4j.model.IRI;
+import org.nanopub.extra.services.ApiResponse;
+import org.nanopub.extra.services.QueryRef;
+
+import java.io.Serializable;
+
+/**
+ * Builder class for creating QueryResultSvg components.
+ */
+public class QueryResultSvgBuilder implements Serializable {
+
+    private String markupId;
+    private ViewDisplay viewDisplay;
+    private String contextId = null;
+    private QueryRef queryRef;
+    private String id = null;
+    private AbstractResourceWithProfile pageResource = null;
+    private String refRoot = null;
+
+    private void addResultButtons(QueryResultSvg resultSvg) {
+        View view = viewDisplay.getView();
+        if (view == null) return;
+        for (IRI actionIri : view.getViewResultActionList()) {
+            // Per-action role gating (docs/role-specific-views.md): skip an action
+            // whose gen:isVisibleTo the viewer does not satisfy.
+            if (!SpaceMemberRole.isViewerEntitled(view.getActionVisibleTo(actionIri), pageResource, refRoot)) continue;
+            Template t = view.getTemplateForAction(actionIri);
+            if (t == null) continue;
+            String targetField = view.getTemplateTargetFieldForAction(actionIri);
+            if (targetField == null) targetField = "resource";
+            String label = view.getLabelForAction(actionIri);
+            if (label == null) label = "action...";
+            if (!label.endsWith("...")) label += "...";
+            PageParameters params = new PageParameters().set("template", t.getId())
+                    .set("param_" + targetField, id)
+                    .set("context", contextId)
+                    .set("template-version", "latest");
+            if (id != null && contextId != null && !id.equals(contextId)) {
+                params.set("part", id);
+            }
+            String partField = view.getTemplatePartFieldForAction(actionIri);
+            if (partField != null) {
+                MaintainedResource r = MaintainedResourceRepository.get().findById(contextId);
+                if (r != null && r.getNamespace() != null) {
+                    params.set("param_" + partField, r.getNamespace() + "<SET-SUFFIX>");
+                }
+            }
+            String queryMapping = view.getTemplateQueryMapping(actionIri);
+            if (queryMapping != null && queryMapping.contains(":")) {
+                params.set("values-from-query", queryRef.getAsUrlString());
+                params.set("values-from-query-mapping", queryMapping);
+            }
+            params.set("refresh-upon-publish", queryRef.getAsUrlString());
+            resultSvg.addButton(label, PublishPage.class, params);
+        }
+    }
+
+    private QueryResultSvgBuilder(String markupId, QueryRef queryRef, ViewDisplay viewDisplay) {
+        this.markupId = markupId;
+        // Bind session-derived "magic" query parameters here on the request thread
+        // (ApiCache fetches on background threads where the session is absent).
+        this.queryRef = com.knowledgepixels.nanodash.MagicQueryParams.augment(queryRef);
+        this.viewDisplay = viewDisplay;
+    }
+
+    /**
+     * Creates a new QueryResultSvgBuilder instance.
+     *
+     * @param markupId    the markup ID for the component
+     * @param queryRef    the query reference
+     * @param viewDisplay the view display
+     * @return a new QueryResultSvgBuilder instance
+     */
+    public static QueryResultSvgBuilder create(String markupId, QueryRef queryRef, ViewDisplay viewDisplay) {
+        return new QueryResultSvgBuilder(markupId, queryRef, viewDisplay);
+    }
+
+    /**
+     * Sets the context ID for the QueryResultSvg.
+     *
+     * @param contextId the context ID
+     * @return the current QueryResultSvgBuilder instance
+     */
+    public QueryResultSvgBuilder contextId(String contextId) {
+        this.contextId = contextId;
+        return this;
+    }
+
+    public QueryResultSvgBuilder id(String id) {
+        this.id = id;
+        return this;
+    }
+
+    public QueryResultSvgBuilder pageResource(AbstractResourceWithProfile pageResource) {
+        this.pageResource = pageResource;
+        return this;
+    }
+
+    /**
+     * Pins this view to a specific ref (root definition), so action visibility is gated
+     * against that claimant's authority rather than the resource's representative ref.
+     * Used on {@code ?root=}-pinned pages. Null leaves it on the representative ref.
+     *
+     * @param refRoot the ref's root nanopub, or null
+     * @return the current QueryResultSvgBuilder instance
+     */
+    public QueryResultSvgBuilder refRoot(String refRoot) {
+        this.refRoot = refRoot;
+        return this;
+    }
+
+    /**
+     * Builds the QueryResultSvg component.
+     *
+     * @return the QueryResultSvg component
+     */
+    public Component build() {
+        ApiResponse response = ApiCache.retrieveResponseAsync(queryRef);
+        String colClass = " col-" + viewDisplay.getDisplayWidth();
+        if (response != null) {
+            QueryResultSvg resultSvg = new QueryResultSvg(markupId, queryRef, response, viewDisplay);
+            resultSvg.setPageResource(pageResource);
+            resultSvg.setContextId(contextId);
+            addResultButtons(resultSvg);
+            resultSvg.add(new AttributeAppender("class", colClass));
+            return resultSvg;
+        } else {
+            ApiResultComponent comp = new ApiResultComponent(markupId, queryRef) {
+                @Override
+                public Component getApiResultComponent(String markupId, ApiResponse response) {
+                    QueryResultSvg resultSvg = new QueryResultSvg(markupId, queryRef, response, viewDisplay);
+                    resultSvg.setPageResource(pageResource);
+                    resultSvg.setContextId(contextId);
+                    addResultButtons(resultSvg);
+                    return resultSvg;
+                }
+            };
+            comp.add(new AttributeAppender("class", colClass));
+            return comp;
+        }
+    }
+
+}

--- a/src/main/java/com/knowledgepixels/nanodash/vocabulary/KPXL_TERMS.java
+++ b/src/main/java/com/knowledgepixels/nanodash/vocabulary/KPXL_TERMS.java
@@ -24,6 +24,15 @@ public class KPXL_TERMS {
     public static final IRI ITEM_LIST_VIEW = VocabUtils.createIRI(NAMESPACE, "ItemListView");
 
     /**
+     * A view whose query returns ready-to-embed SVG markup in an {@code svg} result
+     * column, rendered inline after sanitization (one figure per result row, with an
+     * optional {@code title} column as its heading). Unlike the other display types,
+     * the query computes the visual itself — e.g. a diagram laid out in SPARQL from
+     * the underlying data.
+     */
+    public static final IRI SVG_VIEW = VocabUtils.createIRI(NAMESPACE, "SvgView");
+
+    /**
      * A view that renders just a section header at its structural position — a title,
      * an optional description text, and optional result-level actions — with no query
      * (issue #572). The only display type for which {@code gen:hasViewQuery} is absent.

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -2633,6 +2633,19 @@ div.navigator .goto a[disabled] {
   height: auto;
 }
 
+/* Links in SVG-view figures follow the page's link colors (matching the a /
+   a:hover rules above). CSS overrides the SVG's own fill presentation
+   attributes, which queries keep as a fallback for standalone rendering. */
+.svg-view-content a text,
+.svg-view-content a tspan {
+  fill: #0b73da;
+}
+
+.svg-view-content a:hover text,
+.svg-view-content a:hover tspan {
+  fill: #6eb2f7;
+}
+
 .paragraph-header span.buttons {
   float: none;
   margin: 0;

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -2622,6 +2622,17 @@ div.navigator .goto a[disabled] {
   margin: 0;
 }
 
+/* SVG view figures: scale down diagrams wider than the panel, keep ratio. */
+.svg-view-content {
+  margin-top: 8px;
+  overflow-x: auto;
+}
+
+.svg-view-content svg {
+  max-width: 100%;
+  height: auto;
+}
+
 .paragraph-header span.buttons {
   float: none;
   margin: 0;

--- a/src/test/java/com/knowledgepixels/nanodash/UtilsTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/UtilsTest.java
@@ -138,6 +138,62 @@ class UtilsTest {
     }
 
     @Test
+    void sanitizeSvgKeepsStaticSvgSubset() {
+        String rawSvg = "<svg viewBox=\"0 0 504 900\" width=\"504\" height=\"900\" font-family=\"sans-serif\">"
+                + "<rect x=\"20\" y=\"8\" width=\"464\" height=\"34\" rx=\"6\" fill=\"#dbeafe\" stroke=\"#93c5fd\"></rect>"
+                + "<g transform=\"translate(20,56)\">"
+                + "<line x1=\"0\" y1=\"28\" x2=\"222\" y2=\"28\" stroke=\"#cbd5e1\"></line>"
+                + "<path d=\"M 0 0 L 10 10\" stroke-width=\"2\"></path>"
+                + "<text x=\"10\" y=\"19\" font-size=\"11\" text-anchor=\"middle\">"
+                + "<a href=\"https://w3id.org/fair/fip/terms/Registry\"><tspan x=\"10\" dy=\"15\">Registry</tspan>"
+                + "<title>Registry (full label)</title></a>"
+                + "</text></g></svg>";
+        String sanitized = Utils.sanitizeSvg(rawSvg);
+        for (String kept : new String[] {"<svg", "viewBox=\"0 0 504 900\"", "<rect", "<g", "transform=", "<line",
+                "<path", "d=\"M 0 0 L 10 10\"", "<text", "text-anchor=", "<tspan", "dy=\"15\"",
+                "href=\"https://w3id.org/fair/fip/terms/Registry\"", "Registry",
+                "<title>Registry (full label)</title>"}) {
+            assertTrue(sanitized.contains(kept), "expected to keep: " + kept + " in: " + sanitized);
+        }
+    }
+
+    @Test
+    void sanitizeSvgExpandsSelfClosedElements() {
+        // The HTML-parsing sanitizer ignores XML self-closing on non-void elements;
+        // without normalization the <text> sibling would be swallowed into <rect>
+        // (and so not render, since SVG shapes don't render children).
+        String rawSvg = "<svg><rect width=\"5\" fill=\"#eee\"/><text>hi</text></svg>";
+        String sanitized = Utils.sanitizeSvg(rawSvg);
+        assertTrue(sanitized.contains("</rect><text>hi</text>"), "unexpected: " + sanitized);
+    }
+
+    @Test
+    void sanitizeSvgRemovesScriptingAndStyling() {
+        String rawSvg = "<svg width=\"10\" height=\"10\">"
+                + "<script>alert('XSS')</script>"
+                + "<rect width=\"10\" height=\"10\" onclick=\"alert('XSS')\" style=\"fill:red\"></rect>"
+                + "<foreignObject><body onload=\"alert('XSS')\">x</body></foreignObject>"
+                + "<use href=\"https://evil.example/x.svg#a\"></use>"
+                + "<image href=\"https://evil.example/x.svg\"></image>"
+                + "<style>rect { fill: red; }</style>"
+                + "</svg>";
+        String sanitized = Utils.sanitizeSvg(rawSvg);
+        for (String dropped : new String[] {"<script", "alert", "onclick", "onload", "style", "<foreignObject",
+                "<use", "<image", "evil.example"}) {
+            assertFalse(sanitized.contains(dropped), "expected to drop: " + dropped + " but got: " + sanitized);
+        }
+        assertTrue(sanitized.contains("<rect width=\"10\" height=\"10\""));
+    }
+
+    @Test
+    void sanitizeSvgRemovesUnsafeLinkProtocols() {
+        String rawSvg = "<svg><text><a href=\"javascript:alert('XSS')\"><tspan>click</tspan></a></text></svg>";
+        String sanitized = Utils.sanitizeSvg(rawSvg);
+        assertFalse(sanitized.contains("javascript"), "unexpected: " + sanitized);
+        assertTrue(sanitized.contains("click"));
+    }
+
+    @Test
     void isNanopubOfClass() throws MalformedNanopubException, NanopubAlreadyFinalizedException {
         Nanopub nanopub = TestUtils.createNanopub();
         IRI classIri = Values.iri("http://knowledgepixels.com/nanopubIri#any");


### PR DESCRIPTION
A new resource-view display type whose query returns **ready-to-embed SVG markup** in an `svg` result column, rendered inline after sanitization — one figure per result row, with an optional `title` column as its heading and the usual `np` source link and entry actions. Where the other display types lay out rows as tables/lists/paragraphs, an SVG view's query computes the *visual itself* (e.g. a class-typology diagram laid out in SPARQL from published class definitions). The query API needs no changes; the SVG travels as an ordinary result-cell string.

### What's in the change

- `KPXL_TERMS.SVG_VIEW` + registration in `View.supportedViewTypes` — declaration, governed resolution, and display/preset attachment work unchanged; older instances skip such views silently, exactly like header views (#572).
- `QueryResultSvg` (+ markup + builder), modeled on `QueryResultPlainParagraph`, dispatched from `QueryResultComponentFactory`. No filter field (not meaningful for figures).
- `Utils.sanitizeSvg` with a dedicated OWASP policy: a conservative static-SVG subset (shapes, text, grouping, `<title>` tooltips, http(s)-only links on `a`); `script`/`style`/event handlers/`foreignObject`/`use`/`image` are dropped. The existing `sanitizeHtml` policy is untouched.
- `.svg-view-content` CSS so oversized diagrams scale down responsively.
- `docs/svg-views.md` with the view declaration shape, query contract, and authoring rules.

### Pitfalls found while validating against a real generated diagram (pinned by unit tests)

1. The sanitizer's attribute matching is **case-sensitive**: camelCase SVG attributes (`viewBox`, `preserveAspectRatio`, …) are allowlisted in both spellings and pass through verbatim.
2. HTML parsing **ignores XML self-closing** on SVG elements, so `<rect .../>` would swallow all following siblings as children — which SVG shapes don't render. `sanitizeSvg` expands self-closed tags before sanitizing as a safety net; the docs tell query authors to emit explicit end tags.

Document export currently falls back to "(view type not supported in document export)" for SVG views; embedding the figure in exports can follow later.

Tested with a "Get class typology diagram as SVG" prototype query (signed, publishing separately): the sanitized output renders pixel-identically to the raw query output in a real browser, links and tooltips included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)