### PR TITLE
fix: carry the home resource as navigation context on the home page

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/page/HomePage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/HomePage.java
@@ -37,6 +37,17 @@ public class HomePage extends NanodashPage {
     }
 
     /**
+     * The home page shows the configured home resource, so it is that resource's page
+     * and acts as its navigation context: links from here (including the post-publish
+     * message link) carry the home resource along, even though no {@code context}
+     * parameter is in the URL.
+     */
+    @Override
+    public String getContextId() {
+        return NanodashPreferences.get().getHomeResource();
+    }
+
+    /**
      * Constructor for the home page.
      *
      * @param parameters the page parameters


### PR DESCRIPTION
The link in the "… has been successfully published" message did not carry the `context` parameter when the post-publish redirect landed on the home page.

## Cause

The link's context fallback works fine — the home page simply had no navigation context to give it. `HomePage` did not override `getContextId()`, even though it shows the configured home resource, so it returned null. `NavigationContext.redirectAfterPublish()` sends the home-resource case to `HomePage` without a `context` parameter, so the context was lost exactly there.

It was not only the published-message link: **no** link on the home page carried a context — nav bar, view items, action publish links, and the `forward-to-part=true` item links, which are gated on a non-empty context and were therefore silently inert.

`SpacePage`, `MaintainedResourcePage` and `UserPage` override `getContextId()`, and `ResourcePartPage` inherits it from the `context` parameter; all of those were verified to propagate the context correctly.

## Fix

`HomePage.getContextId()` returns the configured home resource.

`TitleBar.createBackContextRef()` already contains a guard for `HomePage` reporting itself as its own context, which is good evidence this override is what the design assumed.

## Verification

Rendered locally on a throwaway jetty instance (the message was triggered by passing `just-published=<existing np>` on the URL; nothing was published):

- before: `./explore?id=…RAKewEE…` → after: `./explore?id=…RAKewEE…&context=https://w3id.org/spaces/knowledgepixels/nanodash/r/home`
- nav links too: `./publish?context=…/r/home`, so publishing from home returns to home explicitly rather than by fallback
- the explore page reached from that link renders with a `< Home` back-crumb, no redirect loop
- the home page itself still shows no back-crumb
- `forward-to-part=true` links now actually evaluate; the one tried did not qualify as a part and stayed on the explore page, as intended

Note that anything on the home page depending on the context (e.g. part forwarding) now sees one — that is the point of the fix, but it is the behavioural change to watch for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)