### PR TITLE
fix: make the date-time picker more user-friendly

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/component/AjaxZonedDateTimePicker.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/AjaxZonedDateTimePicker.html
@@ -9,7 +9,7 @@
 
 <wicket:panel>
   <span wicket:id="datetime"></span>
-  <span class="k-input k-input-solid k-input-md k-rounded-md" style="width: 240px">
+  <span class="k-input k-input-solid k-input-md k-rounded-md timezone-picker">
       <select wicket:id="timezone-dropdown" class="k-input-inner"></select>
       <span class="k-input-button k-button k-button-md k-button-solid k-button-solid-base k-icon-button"><span
           class="k-icon k-i-globe-outline k-button-icon"></span>

--- a/src/main/java/com/knowledgepixels/nanodash/component/AjaxZonedDateTimePicker.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/AjaxZonedDateTimePicker.html
@@ -9,7 +9,7 @@
 
 <wicket:panel>
   <span wicket:id="datetime"></span>
-  <span class="k-input k-input-solid k-input-md k-rounded-md" style="width: 180px">
+  <span class="k-input k-input-solid k-input-md k-rounded-md" style="width: 240px">
       <select wicket:id="timezone-dropdown" class="k-input-inner"></select>
       <span class="k-input-button k-button k-button-md k-button-solid k-button-solid-base k-icon-button"><span
           class="k-icon k-i-globe-outline k-button-icon"></span>

--- a/src/main/java/com/knowledgepixels/nanodash/component/AjaxZonedDateTimePicker.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/AjaxZonedDateTimePicker.java
@@ -514,12 +514,20 @@ public class AjaxZonedDateTimePicker extends FormComponentPanel<ZonedDateTime> i
         };
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Keeps the date and time fields on the value, in both directions: a value that is cleared
+     * empties them too, rather than leaving them showing a date the field no longer holds.
+     */
     @Override
     public FormComponent<ZonedDateTime> setModelObject(ZonedDateTime zonedDateTime) {
         if (zonedDateTime != null) {
             dateTimePicker.setModelObject(Date.from(zonedDateTime.toLocalDateTime().atZone(ZoneId.systemDefault()).toInstant()));
             zoneDropDown.setModelObject(zonedDateTime.getZone());
             zoneIsDefault = false;
+        } else {
+            dateTimePicker.setModelObject(null);
         }
         return super.setModelObject(zonedDateTime);
     }

--- a/src/main/java/com/knowledgepixels/nanodash/component/AjaxZonedDateTimePicker.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/AjaxZonedDateTimePicker.java
@@ -11,13 +11,16 @@ import org.apache.wicket.model.Model;
 import org.apache.wicket.protocol.http.request.WebClientInfo;
 import org.apache.wicket.request.cycle.RequestCycle;
 import org.apache.wicket.util.convert.IConverter;
+import org.apache.wicket.util.convert.converter.DateConverter;
 import org.apache.wicket.util.convert.converter.ZonedDateTimeConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wicketstuff.kendo.ui.form.datetime.AjaxDateTimePicker;
 import org.wicketstuff.kendo.ui.form.datetime.DateTimePicker;
 
+import java.text.DateFormat;
 import java.text.ParseException;
+import java.text.ParsePosition;
 import java.text.SimpleDateFormat;
 import java.time.*;
 import java.util.*;
@@ -65,13 +68,16 @@ public class AjaxZonedDateTimePicker extends FormComponentPanel<ZonedDateTime> i
     private IModel<ZoneId> zoneIdModel = Model.of((ZoneId) null);
     private IModel<Date> dateModel = Model.of((Date) null);
     private final DropDownChoice<ZoneId> zoneDropDown;
-    private final DateTimePicker dateTimePicker;
+    private DateTimePicker dateTimePicker;
     private final List<ZoneId> zones;
     private String datePattern, timePattern;
 
     // True as long as the selected zone is just our default guess, i.e. neither the user nor an
     // existing value has determined it. Only then may the detected client zone still overrule it.
     private boolean zoneIsDefault;
+
+    // Whether the time field asks for seconds, which it only does for a value that has them.
+    private boolean secondsShown;
 
     public AjaxZonedDateTimePicker(String id, IModel<ZonedDateTime> model, String datePattern, String timePattern) {
         super(id);
@@ -82,30 +88,8 @@ public class AjaxZonedDateTimePicker extends FormComponentPanel<ZonedDateTime> i
         }
         this.datePattern = datePattern;
         this.timePattern = timePattern;
-        this.dateTimePicker = new AjaxDateTimePicker("datetime", dateModel, datePattern, timePattern) {
-            @Override
-            protected void onInitialize() {
-                super.onInitialize();
-                // Prevent Edge's autofill from overwriting the Kendo-formatted date/time values with a mismatched format:
-                datePicker.add(new org.apache.wicket.AttributeModifier("autocomplete", "off"));
-                datePicker.add(new org.apache.wicket.AttributeModifier("data-form-type", "other"));
-                timePicker.add(new org.apache.wicket.AttributeModifier("autocomplete", "off"));
-                timePicker.add(new org.apache.wicket.AttributeModifier("data-form-type", "other"));
-            }
-            @Override
-            public void onValueChanged(IPartialPageRequestHandler handler) {
-                Date selectedDate = this.getModelObject();
-                if (zoneIdModel.getObject() == null) {
-                    dateTimePicker.setModelObject(selectedDate);
-                    logger.info("Date selected without timezone: {}", dateModel.getObject());
-                } else {
-                    ZonedDateTime currentZonedDateTime = LocalDateTime.ofInstant(selectedDate.toInstant(), ZoneId.systemDefault()).atZone(zoneIdModel.getObject());
-                    zonedDateTimeModel.setObject(currentZonedDateTime);
-                    logger.info("Date selected: {}", dateModel.getObject());
-                    logger.info("Selected datetime with current timezone: {}", zonedDateTimeModel.getObject());
-                }
-            }
-        };
+        this.secondsShown = hasSeconds(timePattern) || hasSeconds(model.getObject());
+        this.dateTimePicker = newDateTimePicker();
 
         this.zonedDateTimeModel = model;
 
@@ -150,6 +134,107 @@ public class AjaxZonedDateTimePicker extends FormComponentPanel<ZonedDateTime> i
         });
         add(zoneDropDown);
         add(dateTimePicker);
+    }
+
+    /**
+     * Creates the date and time fields, asking for seconds or not, as {@link #secondsShown} has it.
+     */
+    private DateTimePicker newDateTimePicker() {
+        return new AjaxDateTimePicker("datetime", dateModel, datePattern, getTimePattern()) {
+            @Override
+            protected void onInitialize() {
+                super.onInitialize();
+                // Prevent Edge's autofill from overwriting the Kendo-formatted date/time values with a mismatched format:
+                datePicker.add(new org.apache.wicket.AttributeModifier("autocomplete", "off"));
+                datePicker.add(new org.apache.wicket.AttributeModifier("data-form-type", "other"));
+                timePicker.add(new org.apache.wicket.AttributeModifier("autocomplete", "off"));
+                timePicker.add(new org.apache.wicket.AttributeModifier("data-form-type", "other"));
+            }
+            @Override
+            @SuppressWarnings("unchecked")
+            public <C> IConverter<C> getConverter(Class<C> type) {
+                if (Date.class.isAssignableFrom(type)) {
+                    return (IConverter<C>) newDateTimeConverter();
+                }
+                return super.getConverter(type);
+            }
+            @Override
+            public void onValueChanged(IPartialPageRequestHandler handler) {
+                Date selectedDate = this.getModelObject();
+                if (zoneIdModel.getObject() == null) {
+                    this.setModelObject(selectedDate);
+                    logger.info("Date selected without timezone: {}", dateModel.getObject());
+                } else {
+                    ZonedDateTime currentZonedDateTime = LocalDateTime.ofInstant(selectedDate.toInstant(), ZoneId.systemDefault()).atZone(zoneIdModel.getObject());
+                    zonedDateTimeModel.setObject(currentZonedDateTime);
+                    logger.info("Date selected: {}", dateModel.getObject());
+                    logger.info("Selected datetime with current timezone: {}", zonedDateTimeModel.getObject());
+                }
+            }
+        };
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Starts asking for seconds as soon as the value at hand has them, so that a value which does
+     * carry seconds is shown in full and can be edited, rather than appearing rounded to the minute.
+     */
+    @Override
+    protected void onConfigure() {
+        super.onConfigure();
+        if (!secondsShown && hasSeconds(getModelObject())) {
+            secondsShown = true;
+            dateTimePicker = newDateTimePicker();
+            addOrReplace(dateTimePicker);
+        }
+    }
+
+    /**
+     * Returns a converter for the date and time fields that accepts a time with seconds as well, so
+     * that a user who types them is taken at their word by a field that only asks for minutes.
+     */
+    private IConverter<Date> newDateTimeConverter() {
+        List<String> patterns = new ArrayList<>();
+        patterns.add(datePattern + " " + getTimePattern());
+        if (!secondsShown) patterns.add(datePattern + " " + withSeconds(timePattern));
+        return new DateConverter() {
+            @Override
+            public DateFormat getDateFormat(Locale locale) {
+                return new SimpleDateFormat(patterns.get(0), locale != null ? locale : Locale.getDefault());
+            }
+
+            @Override
+            public Date convertToObject(String value, Locale locale) {
+                if (value == null || value.trim().isEmpty()) return null;
+                for (String pattern : patterns) {
+                    ParsePosition position = new ParsePosition(0);
+                    Date date = new SimpleDateFormat(pattern, locale != null ? locale : Locale.getDefault()).parse(value, position);
+                    if (date != null && position.getIndex() == value.length()) return date;
+                }
+                throw newConversionException("Cannot parse '" + value + "' as a date and time", value, locale);
+            }
+        };
+    }
+
+    /**
+     * Returns the pattern the time field is asking for, which is the given one plus seconds where
+     * the value has them.
+     */
+    private String getTimePattern() {
+        return secondsShown ? withSeconds(timePattern) : timePattern;
+    }
+
+    private static String withSeconds(String timePattern) {
+        return hasSeconds(timePattern) ? timePattern : timePattern + ":ss";
+    }
+
+    private static boolean hasSeconds(String timePattern) {
+        return timePattern.contains("s");
+    }
+
+    private static boolean hasSeconds(ZonedDateTime value) {
+        return value != null && (value.getSecond() != 0 || value.getNano() != 0);
     }
 
     /**
@@ -318,7 +403,7 @@ public class AjaxZonedDateTimePicker extends FormComponentPanel<ZonedDateTime> i
     @Override
     public String getTextFormat() {
         logger.info("Getting text format.");
-        return String.format("%s %s", this.datePattern, this.timePattern);
+        return String.format("%s %s", this.datePattern, this.getTimePattern());
     }
 
     @Override

--- a/src/main/java/com/knowledgepixels/nanodash/component/AjaxZonedDateTimePicker.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/AjaxZonedDateTimePicker.java
@@ -25,6 +25,41 @@ import java.util.stream.Collectors;
 
 public class AjaxZonedDateTimePicker extends FormComponentPanel<ZonedDateTime> implements AbstractTextComponent.ITextFormatProvider {
 
+    private static final int MAX_LABEL_ZONES = 3;
+
+    // The prefixes of the regular zone ids; all others are legacy aliases (US/Eastern), single-country
+    // names (Japan), or artificial zones (Etc/GMT+3, CET), which we don't want to name in the labels.
+    private static final List<String> REGION_PREFIXES = List.of("Africa/", "America/", "Antarctica/",
+            "Arctic/", "Asia/", "Atlantic/", "Australia/", "Europe/", "Indian/", "Pacific/");
+
+    // The only places we name in the labels, most widely known first. Naming just these keeps the
+    // labels free of the duplicate (Asia/Calcutta), obsolete (Australia/North) and remote
+    // (Antarctica/DumontDUrville) zone ids that a zone list is otherwise full of. The tail of the
+    // list is what gives the more unusual offsets a place name at all.
+    private static final List<String> WELL_KNOWN_ZONES = List.of(
+            "Europe/London", "America/New_York", "Asia/Tokyo", "Europe/Paris", "Asia/Shanghai",
+            "America/Los_Angeles", "America/Chicago", "Europe/Berlin", "Europe/Madrid", "Europe/Rome",
+            "Europe/Amsterdam", "Europe/Lisbon", "Europe/Athens", "Europe/Istanbul", "Europe/Kyiv",
+            "Europe/Moscow", "Africa/Lagos", "Africa/Cairo", "Africa/Nairobi", "Africa/Johannesburg",
+            "Africa/Casablanca", "Africa/Accra", "America/Toronto", "America/Vancouver",
+            "America/Mexico_City", "America/Denver", "America/Phoenix", "America/Halifax",
+            "America/Bogota", "America/Lima", "America/Santiago", "America/Sao_Paulo",
+            "America/Argentina/Buenos_Aires", "America/Anchorage", "Asia/Jerusalem", "Asia/Dubai",
+            "Asia/Baghdad", "Asia/Tehran", "Asia/Karachi", "Asia/Kolkata", "Asia/Dhaka",
+            "Asia/Bangkok", "Asia/Jakarta", "Asia/Ho_Chi_Minh", "Asia/Hong_Kong", "Asia/Singapore",
+            "Asia/Manila", "Asia/Seoul", "Australia/Perth", "Australia/Adelaide", "Australia/Brisbane",
+            "Australia/Sydney", "Pacific/Auckland", "Pacific/Honolulu", "Atlantic/Reykjavik",
+            // Below: places that are the only ones to give their offset a name.
+            "America/St_Johns", "America/Puerto_Rico", "America/Caracas", "America/Noronha",
+            "America/Nuuk", "America/Adak", "Atlantic/Azores", "Atlantic/Cape_Verde",
+            "Atlantic/South_Georgia", "Asia/Baku", "Europe/Samara", "Asia/Kabul", "Asia/Tashkent",
+            "Asia/Yekaterinburg", "Asia/Colombo", "Asia/Kathmandu", "Asia/Almaty", "Asia/Yangon",
+            "Asia/Yakutsk", "Asia/Vladivostok", "Asia/Magadan", "Asia/Kamchatka", "Indian/Maldives",
+            "Australia/Eucla", "Australia/Darwin", "Australia/Lord_Howe", "Pacific/Guam",
+            "Pacific/Noumea", "Pacific/Fiji", "Pacific/Chatham", "Pacific/Apia", "Pacific/Tongatapu",
+            "Pacific/Kiritimati", "Pacific/Pago_Pago", "Pacific/Niue", "Pacific/Tahiti",
+            "Pacific/Marquesas", "Pacific/Gambier", "Pacific/Pitcairn");
+
     private final Logger logger = LoggerFactory.getLogger(AjaxZonedDateTimePicker.class);
     private IModel<ZonedDateTime> zonedDateTimeModel = Model.of((ZonedDateTime) null);
     private IModel<ZoneId> zoneIdModel = Model.of((ZoneId) null);
@@ -73,19 +108,20 @@ public class AjaxZonedDateTimePicker extends FormComponentPanel<ZonedDateTime> i
         };
 
         this.zonedDateTimeModel = model;
+
+        Instant now = Instant.now();
+        Map<ZoneOffset, List<ZoneId>> timezoneGroups = getZonesByCurrentOffset(now);
+        this.zones = new ArrayList<>(timezoneGroups.keySet());
+        sortByOffset(zones, now);
+
         if (this.zonedDateTimeModel.getObject() != null) {
             this.zoneIdModel = Model.of(model.getObject().getZone());
-        }
-
-        Map<ZoneOffset, List<ZoneId>> timezoneGroups = ZoneId.getAvailableZoneIds().stream()
-                .map(ZoneId::of)
-                .collect(Collectors.groupingBy(x -> x.getRules().getStandardOffset(Instant.now())));
-        this.zones = new ArrayList<>(timezoneGroups.keySet());
-        zones.sort(Comparator.comparing(zoneId -> zoneId.getRules().getStandardOffset(Instant.now()).getTotalSeconds()));
-
-        if (zoneIdModel.getObject() == null) {
+            // An existing value can carry an offset that no zone is currently at, and the dropdown
+            // has to show it nonetheless:
+            ensureZoneChoice(zoneIdModel.getObject(), now);
+        } else {
             // No zone given by an existing value, so we preselect the one the user is most likely in:
-            zoneIdModel.setObject(resolveZoneChoice(getUserZoneId(), zones, Instant.now()));
+            zoneIdModel.setObject(selectZoneChoice(getUserZoneId(), now));
             zoneIsDefault = true;
             if (getClientZoneId() == null) {
                 // The client's zone isn't known yet (typically the first page view of a session), so
@@ -100,10 +136,7 @@ public class AjaxZonedDateTimePicker extends FormComponentPanel<ZonedDateTime> i
         }
 
         this.zoneDropDown = new DropDownChoice<>("timezone-dropdown", zoneIdModel, zones,
-                (IChoiceRenderer<ZoneId>) zoneId -> String.format("%s : %s", zoneId, timezoneGroups.get(zoneId).stream()
-                        .map(ZoneId::getId)
-                        .limit(3)
-                        .collect(Collectors.joining(", ")))
+                (IChoiceRenderer<ZoneId>) zoneId -> getZoneChoiceLabel(zoneId, timezoneGroups.getOrDefault(zoneId, List.of()), getUserZoneId())
         );
 
         this.zoneDropDown.setOutputMarkupId(true);
@@ -117,6 +150,89 @@ public class AjaxZonedDateTimePicker extends FormComponentPanel<ZonedDateTime> i
         });
         add(zoneDropDown);
         add(dateTimePicker);
+    }
+
+    /**
+     * Groups all time zones by the offset they are currently at, so that a zone is found under the
+     * offset it is really at right now, including daylight saving time. Legacy and artificial zone
+     * ids (like {@code US/Eastern} or {@code Etc/GMT+3}) are left out: they duplicate the regular
+     * zones, and would offer offsets that no place is at.
+     *
+     * @param instant the instant to determine the zones' offsets at
+     * @return the zones of each currently used offset
+     */
+    public static Map<ZoneOffset, List<ZoneId>> getZonesByCurrentOffset(Instant instant) {
+        return ZoneId.getAvailableZoneIds().stream()
+                .filter(id -> REGION_PREFIXES.stream().anyMatch(id::startsWith))
+                .map(ZoneId::of)
+                .collect(Collectors.groupingBy(zoneId -> zoneId.getRules().getOffset(instant)));
+    }
+
+    /**
+     * Returns the label of the given zone choice, for example {@code "UTC+02:00 — Rome, Paris,
+     * Berlin"}: the offset, followed by the places that are currently at it. The user's own place is
+     * named first, so that they recognize the zone that is preselected for them.
+     *
+     * @param choice   the zone choice to label
+     * @param atOffset the zones that are currently at the choice's offset
+     * @param userZone the user's own time zone, or null if unknown
+     * @return the label of the given zone choice
+     */
+    public static String getZoneChoiceLabel(ZoneId choice, List<ZoneId> atOffset, ZoneId userZone) {
+        String examples = atOffset.stream()
+                .filter(zoneId -> getExampleRank(zoneId, userZone) < Integer.MAX_VALUE)
+                .sorted(Comparator.comparingInt(zoneId -> getExampleRank(zoneId, userZone)))
+                .limit(MAX_LABEL_ZONES)
+                .map(AjaxZonedDateTimePicker::getPlaceName)
+                .collect(Collectors.joining(", "));
+        String offsetLabel = getOffsetLabel(choice);
+        return examples.isEmpty() ? offsetLabel : offsetLabel + " — " + examples;
+    }
+
+    /**
+     * Returns the offset as shown in the dropdown, for example {@code "UTC-05:30"} or, for the zero
+     * offset, just {@code "UTC"}.
+     *
+     * @param zone the zone to label
+     * @return the label of the given zone's offset
+     */
+    public static String getOffsetLabel(ZoneId zone) {
+        int seconds = (zone instanceof ZoneOffset offset ? offset : zone.getRules().getOffset(Instant.now())).getTotalSeconds();
+        if (seconds == 0) return "UTC";
+        return String.format("UTC%s%02d:%02d", seconds < 0 ? "-" : "+", Math.abs(seconds) / 3600, Math.abs(seconds) % 3600 / 60);
+    }
+
+    /**
+     * Returns the place of the given zone as shown in the labels, for example {@code "New York"} for
+     * {@code America/New_York}.
+     */
+    private static String getPlaceName(ZoneId zoneId) {
+        String id = zoneId.getId();
+        return id.substring(id.lastIndexOf('/') + 1).replace('_', ' ');
+    }
+
+    /**
+     * Ranks the given zone as an example in a label: the user's own zone comes first, followed by
+     * the well-known ones in their given order, followed by all others.
+     */
+    private static int getExampleRank(ZoneId zoneId, ZoneId userZone) {
+        if (zoneId.equals(userZone)) return -1;
+        int index = WELL_KNOWN_ZONES.indexOf(zoneId.getId());
+        return index < 0 ? Integer.MAX_VALUE : index;
+    }
+
+    /**
+     * Adds the given zone to the choices if it isn't among them already, keeping them ordered by
+     * offset.
+     */
+    private void ensureZoneChoice(ZoneId zone, Instant instant) {
+        if (zone == null || zones.contains(zone)) return;
+        zones.add(zone);
+        sortByOffset(zones, instant);
+    }
+
+    private static void sortByOffset(List<ZoneId> zones, Instant instant) {
+        zones.sort(Comparator.comparingInt(zoneId -> zoneId.getRules().getOffset(instant).getTotalSeconds()));
     }
 
     /**
@@ -144,22 +260,13 @@ public class AjaxZonedDateTimePicker extends FormComponentPanel<ZonedDateTime> i
     }
 
     /**
-     * Returns the entry of the given zone choices that matches the given zone at the given instant.
-     * The choices are offsets, so we match the offset the zone is actually at (including daylight
-     * saving time), and fall back to its standard offset if that isn't among the choices.
-     *
-     * @param zone    the zone to match
-     * @param choices the available zone choices
-     * @param instant the instant to determine the zone's offset at
-     * @return the matching choice, or null if there is none
+     * Returns the choice for the given zone, which is the offset that zone is at at the given
+     * instant, daylight saving time included, and makes sure it is among the choices.
      */
-    public static ZoneId resolveZoneChoice(ZoneId zone, List<? extends ZoneId> choices, Instant instant) {
-        if (zone == null) return null;
+    private ZoneOffset selectZoneChoice(ZoneId zone, Instant instant) {
         ZoneOffset offset = zone.getRules().getOffset(instant);
-        if (choices.contains(offset)) return offset;
-        ZoneOffset standardOffset = zone.getRules().getStandardOffset(instant);
-        if (choices.contains(standardOffset)) return standardOffset;
-        return null;
+        ensureZoneChoice(offset, instant);
+        return offset;
     }
 
     /**
@@ -170,8 +277,8 @@ public class AjaxZonedDateTimePicker extends FormComponentPanel<ZonedDateTime> i
         if (!zoneIsDefault) return;
         TimeZone timeZone = clientInfo.getProperties().getTimeZone();
         if (timeZone == null) return;
-        ZoneId choice = resolveZoneChoice(timeZone.toZoneId(), zones, Instant.now());
-        if (choice == null || choice.equals(zoneIdModel.getObject())) return;
+        ZoneId choice = selectZoneChoice(timeZone.toZoneId(), Instant.now());
+        if (choice.equals(zoneIdModel.getObject())) return;
         logger.info("Setting time zone to the one reported by the browser: {}", choice);
         zoneIdModel.setObject(choice);
         // The date/time fields keep the local time the user sees, so only the zone needs repainting:

--- a/src/main/java/com/knowledgepixels/nanodash/component/AjaxZonedDateTimePicker.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/AjaxZonedDateTimePicker.java
@@ -1,11 +1,15 @@
 package com.knowledgepixels.nanodash.component;
 
+import org.apache.wicket.Session;
+import org.apache.wicket.ajax.AjaxClientInfoBehavior;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.form.OnChangeAjaxBehavior;
 import org.apache.wicket.core.request.handler.IPartialPageRequestHandler;
 import org.apache.wicket.markup.html.form.*;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
+import org.apache.wicket.protocol.http.request.WebClientInfo;
+import org.apache.wicket.request.cycle.RequestCycle;
 import org.apache.wicket.util.convert.IConverter;
 import org.apache.wicket.util.convert.converter.ZonedDateTimeConverter;
 import org.slf4j.Logger;
@@ -27,7 +31,12 @@ public class AjaxZonedDateTimePicker extends FormComponentPanel<ZonedDateTime> i
     private IModel<Date> dateModel = Model.of((Date) null);
     private final DropDownChoice<ZoneId> zoneDropDown;
     private final DateTimePicker dateTimePicker;
+    private final List<ZoneId> zones;
     private String datePattern, timePattern;
+
+    // True as long as the selected zone is just our default guess, i.e. neither the user nor an
+    // existing value has determined it. Only then may the detected client zone still overrule it.
+    private boolean zoneIsDefault;
 
     public AjaxZonedDateTimePicker(String id, IModel<ZonedDateTime> model, String datePattern, String timePattern) {
         super(id);
@@ -71,8 +80,24 @@ public class AjaxZonedDateTimePicker extends FormComponentPanel<ZonedDateTime> i
         Map<ZoneOffset, List<ZoneId>> timezoneGroups = ZoneId.getAvailableZoneIds().stream()
                 .map(ZoneId::of)
                 .collect(Collectors.groupingBy(x -> x.getRules().getStandardOffset(Instant.now())));
-        List<ZoneId> zones = new ArrayList<>(timezoneGroups.keySet());
+        this.zones = new ArrayList<>(timezoneGroups.keySet());
         zones.sort(Comparator.comparing(zoneId -> zoneId.getRules().getStandardOffset(Instant.now()).getTotalSeconds()));
+
+        if (zoneIdModel.getObject() == null) {
+            // No zone given by an existing value, so we preselect the one the user is most likely in:
+            zoneIdModel.setObject(resolveZoneChoice(getUserZoneId(), zones, Instant.now()));
+            zoneIsDefault = true;
+            if (getClientZoneId() == null) {
+                // The client's zone isn't known yet (typically the first page view of a session), so
+                // we ask the browser for it and correct our guess as soon as the answer comes in:
+                add(new AjaxClientInfoBehavior() {
+                    @Override
+                    protected void onClientInfo(AjaxRequestTarget target, WebClientInfo clientInfo) {
+                        applyClientZone(clientInfo, target);
+                    }
+                });
+            }
+        }
 
         this.zoneDropDown = new DropDownChoice<>("timezone-dropdown", zoneIdModel, zones,
                 (IChoiceRenderer<ZoneId>) zoneId -> String.format("%s : %s", zoneId, timezoneGroups.get(zoneId).stream()
@@ -85,6 +110,7 @@ public class AjaxZonedDateTimePicker extends FormComponentPanel<ZonedDateTime> i
         this.zoneDropDown.add(new OnChangeAjaxBehavior() {
             @Override
             protected void onUpdate(AjaxRequestTarget ajaxRequestTarget) {
+                zoneIsDefault = false;
                 updateZoneSelection();
                 ajaxRequestTarget.add(AjaxZonedDateTimePicker.this);
             }
@@ -93,10 +119,72 @@ public class AjaxZonedDateTimePicker extends FormComponentPanel<ZonedDateTime> i
         add(dateTimePicker);
     }
 
+    /**
+     * Returns the time zone the user is most likely in: the one reported by their browser, or the
+     * time zone of this Nanodash instance if the browser hasn't told us (yet). The latter is the
+     * user's own time zone too when Nanodash runs locally.
+     *
+     * @return the user's time zone, never null
+     */
+    public static ZoneId getUserZoneId() {
+        ZoneId clientZone = getClientZoneId();
+        return clientZone != null ? clientZone : ZoneId.systemDefault();
+    }
+
+    /**
+     * Returns the time zone reported by the user's browser, or null if it hasn't been collected yet.
+     *
+     * @return the client's time zone, or null
+     */
+    public static ZoneId getClientZoneId() {
+        if (!Session.exists() || RequestCycle.get() == null) return null;
+        if (!(Session.get().getClientInfo() instanceof WebClientInfo clientInfo)) return null;
+        TimeZone timeZone = clientInfo.getProperties().getTimeZone();
+        return timeZone == null ? null : timeZone.toZoneId();
+    }
+
+    /**
+     * Returns the entry of the given zone choices that matches the given zone at the given instant.
+     * The choices are offsets, so we match the offset the zone is actually at (including daylight
+     * saving time), and fall back to its standard offset if that isn't among the choices.
+     *
+     * @param zone    the zone to match
+     * @param choices the available zone choices
+     * @param instant the instant to determine the zone's offset at
+     * @return the matching choice, or null if there is none
+     */
+    public static ZoneId resolveZoneChoice(ZoneId zone, List<? extends ZoneId> choices, Instant instant) {
+        if (zone == null) return null;
+        ZoneOffset offset = zone.getRules().getOffset(instant);
+        if (choices.contains(offset)) return offset;
+        ZoneOffset standardOffset = zone.getRules().getStandardOffset(instant);
+        if (choices.contains(standardOffset)) return standardOffset;
+        return null;
+    }
+
+    /**
+     * Applies the time zone the browser just reported, unless the zone was determined by the user or
+     * by an existing value in the meantime.
+     */
+    private void applyClientZone(WebClientInfo clientInfo, AjaxRequestTarget target) {
+        if (!zoneIsDefault) return;
+        TimeZone timeZone = clientInfo.getProperties().getTimeZone();
+        if (timeZone == null) return;
+        ZoneId choice = resolveZoneChoice(timeZone.toZoneId(), zones, Instant.now());
+        if (choice == null || choice.equals(zoneIdModel.getObject())) return;
+        logger.info("Setting time zone to the one reported by the browser: {}", choice);
+        zoneIdModel.setObject(choice);
+        // The date/time fields keep the local time the user sees, so only the zone needs repainting:
+        updateZoneSelection();
+        target.add(zoneDropDown);
+    }
+
     private void updateZoneSelection() {
         ZoneId selectedZone = zoneIdModel.getObject();
         logger.info("Selected time zone: {}", selectedZone);
+        if (selectedZone == null) return;
         if (zonedDateTimeModel.getObject() == null) {
+            if (dateTimePicker.getModelObject() == null) return;
             zonedDateTimeModel.setObject(ZonedDateTime.of(LocalDateTime.ofInstant(dateTimePicker.getModelObject().toInstant(), ZoneId.systemDefault()), selectedZone));
             logger.info("Initializing datetime with selected timezone: {}", zonedDateTimeModel.getObject());
         }
@@ -163,6 +251,7 @@ public class AjaxZonedDateTimePicker extends FormComponentPanel<ZonedDateTime> i
         if (zonedDateTime != null) {
             dateTimePicker.setModelObject(Date.from(zonedDateTime.toLocalDateTime().atZone(ZoneId.systemDefault()).toInstant()));
             zoneDropDown.setModelObject(zonedDateTime.getZone());
+            zoneIsDefault = false;
         }
         return super.setModelObject(zonedDateTime);
     }

--- a/src/main/java/com/knowledgepixels/nanodash/component/AjaxZonedDateTimePicker.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/AjaxZonedDateTimePicker.java
@@ -421,6 +421,82 @@ public class AjaxZonedDateTimePicker extends FormComponentPanel<ZonedDateTime> i
         }
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Builds the value from what was actually submitted in the date, time and zone fields, as a
+     * {@link FormComponentPanel} is meant to. Reading the model instead would make the value depend
+     * on an ajax call having stored it there first, which loses whatever the user typed straight
+     * into the fields.
+     */
+    @Override
+    public void convertInput() {
+        if (!isDateTimeSubmitted()) {
+            // The date and time fields took no part in this request (an ajax update of some other
+            // component, say), so there is no input to convert: keep the value we have.
+            setConvertedInput(getModelObject());
+            return;
+        }
+        Date date = dateTimePicker.getConvertedInput();
+        if (date == null) {
+            setConvertedInput(null);
+            return;
+        }
+        setConvertedInput(LocalDateTime.ofInstant(date.toInstant(), ZoneId.systemDefault()).atZone(getSubmittedZone()));
+    }
+
+    /**
+     * Returns whether the date and time fields were submitted in this request, which they are on a
+     * form submit even when the user left them empty.
+     */
+    private boolean isDateTimeSubmitted() {
+        for (String fieldId : new String[]{"datepicker", "timepicker"}) {
+            if (dateTimePicker.get(fieldId) instanceof FormComponent<?> field
+                    && !getRequest().getRequestParameters().getParameterValue(field.getInputName()).isNull()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns the zone to read the entered date and time in: the one just submitted, or the one
+     * currently selected if the dropdown was not part of this request.
+     */
+    private ZoneId getSubmittedZone() {
+        ZoneId submitted = zoneDropDown.getConvertedInput();
+        if (submitted != null) return submitted;
+        return zoneIdModel.getObject() != null ? zoneIdModel.getObject() : getUserZoneId();
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Leaves the model alone while the date or time field holds something that could not be
+     * converted, such as a date without a time. Wicket skips {@link #convertInput()} for a panel
+     * whose children are in error, so updating the model here would store a null over a value the
+     * user can still see in the fields.
+     */
+    @Override
+    public void updateModel() {
+        if (!isValid()) return;
+        super.updateModel();
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Keeps what the user typed in the date and time fields while they are in error. A half-entered
+     * value has no model to fall back on, so clearing the fields' input -- which
+     * {@link FormComponentPanel#clearInput()} does for the whole panel -- is what empties them when
+     * the page comes back with an error, unlike every other field on the form.
+     */
+    @Override
+    public void clearInput() {
+        if (!isValid()) return;
+        super.clearInput();
+    }
+
     @Override
     public <C> IConverter<C> getConverter(Class<C> type) {
         return (IConverter<C>) this.newConverter();

--- a/src/main/java/com/knowledgepixels/nanodash/component/LiteralDateTimeItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/LiteralDateTimeItem.java
@@ -15,8 +15,10 @@ import org.eclipse.rdf4j.model.vocabulary.XSD;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.text.SimpleDateFormat;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
 
 /**
  * A component that represents a text field for entering literal values.
@@ -24,9 +26,22 @@ import java.time.ZonedDateTime;
 public class LiteralDateTimeItem extends AbstractContextComponent {
 
     private final static Logger logger = LoggerFactory.getLogger(LiteralDateTimeItem.class);
-    public static final SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+
+    /**
+     * How a date-time value is written into a literal. Seconds are always written, so that a time
+     * entered without them is recorded as :00 rather than left out, and a fraction of a second is
+     * written only where the value has one.
+     */
+    public static final DateTimeFormatter format = new DateTimeFormatterBuilder()
+            .appendPattern("yyyy-MM-dd'T'HH:mm:ss")
+            .appendFraction(ChronoField.NANO_OF_SECOND, 0, 9, true)
+            .appendOffsetId()
+            .toFormatter();
     private final String DATE_PATTERN = "d MMM yyyy";
-    private final String TIME_PATTERN = "HH:mm:ss";
+    // Seconds are left out: they are hardly ever what a user wants to fill in, and they end up as
+    // :00 in the literal. The picker asks for them anyway once a value has them (see
+    // AjaxZonedDateTimePicker#onConfigure), and takes them when they are typed.
+    private final String TIME_PATTERN = "HH:mm";
 
     private AjaxZonedDateTimePicker zonedDateTimePicker;
     private final Label datatypeComp;

--- a/src/main/java/com/knowledgepixels/nanodash/script/nanodash.js
+++ b/src/main/java/com/knowledgepixels/nanodash/script/nanodash.js
@@ -188,6 +188,18 @@ function updateElements() {
   scrollToAnchor();
 };
 
+/* Kendo's date and time pickers only open their popup from the button beside the field, so
+   clicking the field itself does nothing visible. Clicking a date or time field looks like it
+   should offer the calendar or the clock, so here it does. Delegated from the document, so
+   pickers that arrive with a Wicket AJAX response are covered too. */
+$(document).on('click', 'input.k-input-inner', function () {
+  var field = $(this);
+  var picker = field.data('kendoDatePicker') || field.data('kendoTimePicker') || field.data('kendoDateTimePicker');
+  if (!picker || typeof picker.open !== 'function') return;
+  if (picker.popup && picker.popup.visible()) return;
+  picker.open();
+});
+
 $(document).on('mouseenter', '.tooltip, .expltooltip', function () {
   var tip = $(this).children('.tooltiptext, .expltooltiptext');
   if (!tip.length) return;

--- a/src/main/java/com/knowledgepixels/nanodash/template/TemplateContext.java
+++ b/src/main/java/com/knowledgepixels/nanodash/template/TemplateContext.java
@@ -5,6 +5,7 @@ import com.knowledgepixels.nanodash.LocalUri;
 import com.knowledgepixels.nanodash.NanodashSession;
 import com.knowledgepixels.nanodash.Utils;
 import com.knowledgepixels.nanodash.component.LiteralDateItem;
+import com.knowledgepixels.nanodash.component.LiteralDateTimeItem;
 import com.knowledgepixels.nanodash.component.PublishForm.FillMode;
 import com.knowledgepixels.nanodash.component.StatementItem;
 import org.apache.wicket.Component;
@@ -555,7 +556,7 @@ public class TemplateContext implements Serializable {
             if (XSD.DATETIME.equals(datatype)) {
                 ZonedDateTime tfObject = (ZonedDateTime) tfObjectGeneric;
                 if (tfObject != null) {
-                    processedValue = vf.createLiteral(tfObject);
+                    processedValue = vf.createLiteral(LiteralDateTimeItem.format.format(tfObject), datatype);
                 }
             } else if (XSD.DATE.equals(datatype)) {
                 Date tfObject = (Date) tfObjectGeneric;

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -2780,6 +2780,33 @@ td div:has(.button-list) {
   width: 100% !important;
 }
 
+/* Time zone picker: the whole box opens the dropdown, the globe included. The select covers the
+   box, and the globe is drawn on top of it without taking the clicks for itself; the select's own
+   arrow is hidden, as the globe is the button this box shows. The tag is in the selector below to
+   outweigh Kendo's own .k-input {width: 100%} whichever way round the stylesheets are loaded. */
+span.timezone-picker {
+  width: 240px;
+  position: relative;
+  cursor: pointer;
+}
+
+.timezone-picker select.k-input-inner {
+  appearance: none;
+  -webkit-appearance: none;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  padding-right: 2.5em;
+}
+
+.timezone-picker .k-input-button {
+  position: absolute;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  pointer-events: none;
+}
+
 .date-container {
   display: inline-block;
   position: relative;

--- a/src/test/java/com/knowledgepixels/nanodash/component/AjaxZonedDateTimePickerTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/component/AjaxZonedDateTimePickerTest.java
@@ -1,0 +1,135 @@
+package com.knowledgepixels.nanodash.component;
+
+import com.knowledgepixels.nanodash.WicketApplication;
+import org.apache.wicket.ajax.AjaxClientInfoBehavior;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.Model;
+import org.apache.wicket.util.tester.WicketTester;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.wicketstuff.kendo.ui.form.datetime.AjaxDateTimePicker;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Date;
+import java.util.List;
+import java.util.TimeZone;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for the time zone preselection of {@link AjaxZonedDateTimePicker}.
+ */
+public class AjaxZonedDateTimePickerTest {
+
+    private static final String DATE_PATTERN = "d MMM yyyy";
+    private static final String TIME_PATTERN = "HH:mm:ss";
+
+    private static final Instant SUMMER = Instant.parse("2026-07-01T12:00:00Z");
+    private static final Instant WINTER = Instant.parse("2026-01-01T12:00:00Z");
+
+    private WicketTester tester;
+    private TimeZone defaultTimeZone;
+
+    @BeforeEach
+    void setUp() {
+        tester = new WicketTester(new WicketApplication());
+        defaultTimeZone = TimeZone.getDefault();
+    }
+
+    @AfterEach
+    void tearDown() {
+        TimeZone.setDefault(defaultTimeZone);
+        tester.destroy();
+    }
+
+    private AjaxZonedDateTimePicker newPicker(ZonedDateTime value) {
+        IModel<ZonedDateTime> model = Model.of(value);
+        return new AjaxZonedDateTimePicker("zoned-datetime", model, DATE_PATTERN, TIME_PATTERN);
+    }
+
+    private List<? extends ZoneId> zoneChoices() {
+        return newPicker(null).getZoneDropDown().getChoices();
+    }
+
+    @Test
+    void zoneIsPreselectedForNewValues() {
+        TimeZone.setDefault(TimeZone.getTimeZone("Europe/Rome"));
+        AjaxZonedDateTimePicker picker = newPicker(null);
+        ZoneId selected = picker.getZoneDropDown().getModelObject();
+        assertNotNull(selected, "a time zone must be preselected");
+        assertEquals(ZoneId.of("Europe/Rome").getRules().getOffset(Instant.now()), selected);
+    }
+
+    @Test
+    void zoneOfExistingValueIsKept() {
+        TimeZone.setDefault(TimeZone.getTimeZone("Europe/Rome"));
+        AjaxZonedDateTimePicker picker = newPicker(ZonedDateTime.parse("2020-05-17T10:15:00-04:00"));
+        assertEquals(ZoneOffset.ofHours(-4), picker.getZoneDropDown().getModelObject());
+    }
+
+    @Test
+    void resolveZoneChoiceFollowsDaylightSavingTime() {
+        List<? extends ZoneId> choices = zoneChoices();
+        ZoneId rome = ZoneId.of("Europe/Rome");
+        assertEquals(ZoneOffset.ofHours(2), AjaxZonedDateTimePicker.resolveZoneChoice(rome, choices, SUMMER));
+        assertEquals(ZoneOffset.ofHours(1), AjaxZonedDateTimePicker.resolveZoneChoice(rome, choices, WINTER));
+    }
+
+    @Test
+    void resolveZoneChoiceHandlesOffsetsAndUnknownZones() {
+        List<? extends ZoneId> choices = zoneChoices();
+        assertEquals(ZoneOffset.UTC, AjaxZonedDateTimePicker.resolveZoneChoice(ZoneOffset.UTC, choices, SUMMER));
+        assertEquals(ZoneOffset.ofHours(-4), AjaxZonedDateTimePicker.resolveZoneChoice(ZoneOffset.ofHours(-4), choices, SUMMER));
+        assertNull(AjaxZonedDateTimePicker.resolveZoneChoice(null, choices, SUMMER));
+        // An offset that no zone has as its standard offset cannot be matched:
+        assertNull(AjaxZonedDateTimePicker.resolveZoneChoice(ZoneOffset.ofHoursMinutes(7, 7), choices, SUMMER));
+    }
+
+    @Test
+    void pickedDateGetsThePreselectedZone() {
+        TimeZone.setDefault(TimeZone.getTimeZone("Europe/Rome"));
+        AjaxZonedDateTimePicker picker = newPicker(null);
+        tester.startComponentInPage(picker);
+        AjaxDateTimePicker dateTimePicker = (AjaxDateTimePicker) picker.getDateTimePicker();
+        dateTimePicker.setModelObject(Date.from(LocalDateTime.of(2026, 5, 17, 10, 15).atZone(ZoneId.systemDefault()).toInstant()));
+        // Simulate the user picking a date/time without touching the time zone dropdown:
+        dateTimePicker.onValueChanged(null);
+        ZonedDateTime value = picker.getModelObject();
+        assertNotNull(value, "picking a date must yield a value even if the zone is left untouched");
+        assertEquals(ZoneId.of("Europe/Rome").getRules().getOffset(Instant.now()), value.getZone());
+        assertEquals(LocalDateTime.of(2026, 5, 17, 10, 15), value.toLocalDateTime());
+    }
+
+    @Test
+    void browserZoneReplacesThePreselectedZone() {
+        TimeZone.setDefault(TimeZone.getTimeZone("Europe/Rome"));
+        AjaxZonedDateTimePicker picker = newPicker(null);
+        tester.startComponentInPage(picker);
+        List<AjaxClientInfoBehavior> behaviors = picker.getBehaviors(AjaxClientInfoBehavior.class);
+        assertEquals(1, behaviors.size(), "the browser's time zone must be requested when it is unknown");
+        tester.getRequest().setParameter("jsTimeZone", "America/New_York");
+        tester.executeBehavior(behaviors.get(0));
+        assertEquals(ZoneId.of("America/New_York").getRules().getOffset(Instant.now()), picker.getZoneDropDown().getModelObject());
+        // Now that the browser has reported its time zone, it is used right away and not asked again:
+        assertEquals(ZoneId.of("America/New_York"), AjaxZonedDateTimePicker.getClientZoneId());
+        AjaxZonedDateTimePicker nextPicker = newPicker(null);
+        assertEquals(ZoneId.of("America/New_York").getRules().getOffset(Instant.now()), nextPicker.getZoneDropDown().getModelObject());
+        assertTrue(nextPicker.getBehaviors(AjaxClientInfoBehavior.class).isEmpty());
+    }
+
+    @Test
+    void clientZoneIsUnknownOutsideOfARequest() {
+        assertNull(AjaxZonedDateTimePicker.getClientZoneId());
+        TimeZone.setDefault(TimeZone.getTimeZone("Europe/Rome"));
+        assertEquals(ZoneId.of("Europe/Rome"), AjaxZonedDateTimePicker.getUserZoneId());
+    }
+
+}

--- a/src/test/java/com/knowledgepixels/nanodash/component/AjaxZonedDateTimePickerTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/component/AjaxZonedDateTimePickerTest.java
@@ -4,6 +4,8 @@ import com.knowledgepixels.nanodash.WicketApplication;
 import org.apache.wicket.ajax.AjaxClientInfoBehavior;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
+import org.apache.wicket.util.convert.ConversionException;
+import org.apache.wicket.util.convert.IConverter;
 import org.apache.wicket.util.tester.WicketTester;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -17,10 +19,12 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -32,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class AjaxZonedDateTimePickerTest {
 
     private static final String DATE_PATTERN = "d MMM yyyy";
-    private static final String TIME_PATTERN = "HH:mm:ss";
+    private static final String TIME_PATTERN = "HH:mm";
 
     private static final Instant SUMMER = Instant.parse("2026-07-01T12:00:00Z");
     private static final Instant WINTER = Instant.parse("2026-01-01T12:00:00Z");
@@ -174,6 +178,46 @@ public class AjaxZonedDateTimePickerTest {
         AjaxZonedDateTimePicker nextPicker = newPicker(null);
         assertEquals(ZoneId.of("America/New_York").getRules().getOffset(Instant.now()), nextPicker.getZoneDropDown().getModelObject());
         assertTrue(nextPicker.getBehaviors(AjaxClientInfoBehavior.class).isEmpty());
+    }
+
+    @Test
+    void secondsAreNotAskedForByDefault() {
+        AjaxZonedDateTimePicker picker = newPicker(null);
+        tester.startComponentInPage(picker);
+        assertEquals("d MMM yyyy HH:mm", picker.getTextFormat());
+        // A time picked without seconds is a time at zero seconds:
+        AjaxDateTimePicker dateTimePicker = (AjaxDateTimePicker) picker.getDateTimePicker();
+        dateTimePicker.setModelObject(Date.from(LocalDateTime.of(2026, 5, 17, 10, 15).atZone(ZoneId.systemDefault()).toInstant()));
+        dateTimePicker.onValueChanged(null);
+        assertEquals(0, picker.getModelObject().getSecond());
+    }
+
+    @Test
+    void secondsAreAskedForOnceTheValueHasThem() {
+        assertEquals("d MMM yyyy HH:mm:ss", newPicker(ZonedDateTime.parse("2020-05-17T10:15:30Z")).getTextFormat());
+        // A value that arrives after the picker was built, as when filling in an existing nanopub:
+        AjaxZonedDateTimePicker picker = newPicker(null);
+        tester.startComponentInPage(picker);
+        assertEquals("d MMM yyyy HH:mm", picker.getTextFormat());
+        picker.setModelObject(ZonedDateTime.parse("2020-05-17T10:15:30Z"));
+        tester.startComponentInPage(picker);
+        assertEquals("d MMM yyyy HH:mm:ss", picker.getTextFormat());
+        tester.assertContains("10:15:30");
+    }
+
+    @Test
+    void typedSecondsAreTakenByAFieldThatOnlyAsksForMinutes() {
+        AjaxZonedDateTimePicker picker = newPicker(null);
+        tester.startComponentInPage(picker);
+        IConverter<Date> converter = picker.getDateTimePicker().getConverter(Date.class);
+        assertEquals(LocalDateTime.of(2026, 5, 17, 10, 15, 0), toLocalDateTime(converter.convertToObject("17 May 2026 10:15", Locale.US)));
+        assertEquals(LocalDateTime.of(2026, 5, 17, 10, 15, 30), toLocalDateTime(converter.convertToObject("17 May 2026 10:15:30", Locale.US)));
+        assertNull(converter.convertToObject("", Locale.US));
+        assertThrows(ConversionException.class, () -> converter.convertToObject("17 May 2026 10:15 pm-ish", Locale.US));
+    }
+
+    private LocalDateTime toLocalDateTime(Date date) {
+        return LocalDateTime.ofInstant(date.toInstant(), ZoneId.systemDefault());
     }
 
     @Test

--- a/src/test/java/com/knowledgepixels/nanodash/component/AjaxZonedDateTimePickerTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/component/AjaxZonedDateTimePickerTest.java
@@ -17,9 +17,11 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.TimeZone;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -76,21 +78,70 @@ public class AjaxZonedDateTimePickerTest {
     }
 
     @Test
-    void resolveZoneChoiceFollowsDaylightSavingTime() {
-        List<? extends ZoneId> choices = zoneChoices();
-        ZoneId rome = ZoneId.of("Europe/Rome");
-        assertEquals(ZoneOffset.ofHours(2), AjaxZonedDateTimePicker.resolveZoneChoice(rome, choices, SUMMER));
-        assertEquals(ZoneOffset.ofHours(1), AjaxZonedDateTimePicker.resolveZoneChoice(rome, choices, WINTER));
+    void unusualOffsetOfExistingValueIsAddedToTheChoices() {
+        AjaxZonedDateTimePicker picker = newPicker(ZonedDateTime.parse("2020-05-17T10:15:00+01:23"));
+        ZoneOffset offset = ZoneOffset.ofHoursMinutes(1, 23);
+        assertEquals(offset, picker.getZoneDropDown().getModelObject());
+        assertTrue(picker.getZoneDropDown().getChoices().contains(offset), "the value's offset must be selectable");
     }
 
     @Test
-    void resolveZoneChoiceHandlesOffsetsAndUnknownZones() {
+    void choicesAreOrderedByOffset() {
         List<? extends ZoneId> choices = zoneChoices();
-        assertEquals(ZoneOffset.UTC, AjaxZonedDateTimePicker.resolveZoneChoice(ZoneOffset.UTC, choices, SUMMER));
-        assertEquals(ZoneOffset.ofHours(-4), AjaxZonedDateTimePicker.resolveZoneChoice(ZoneOffset.ofHours(-4), choices, SUMMER));
-        assertNull(AjaxZonedDateTimePicker.resolveZoneChoice(null, choices, SUMMER));
-        // An offset that no zone has as its standard offset cannot be matched:
-        assertNull(AjaxZonedDateTimePicker.resolveZoneChoice(ZoneOffset.ofHoursMinutes(7, 7), choices, SUMMER));
+        List<Integer> offsets = choices.stream().map(zone -> ((ZoneOffset) zone).getTotalSeconds()).toList();
+        assertEquals(offsets.stream().sorted().toList(), offsets);
+        assertTrue(choices.contains(ZoneOffset.UTC));
+    }
+
+    @Test
+    void zonesAreGroupedByTheOffsetTheyAreCurrentlyAt() {
+        ZoneId rome = ZoneId.of("Europe/Rome");
+        assertTrue(AjaxZonedDateTimePicker.getZonesByCurrentOffset(SUMMER).get(ZoneOffset.ofHours(2)).contains(rome));
+        assertTrue(AjaxZonedDateTimePicker.getZonesByCurrentOffset(WINTER).get(ZoneOffset.ofHours(1)).contains(rome));
+        assertFalse(AjaxZonedDateTimePicker.getZonesByCurrentOffset(SUMMER).get(ZoneOffset.ofHours(1)).contains(rome));
+    }
+
+    @Test
+    void legacyAndArtificialZonesAreLeftOut() {
+        List<String> ids = AjaxZonedDateTimePicker.getZonesByCurrentOffset(SUMMER).values().stream()
+                .flatMap(List::stream).map(ZoneId::getId).toList();
+        assertTrue(ids.contains("America/New_York"));
+        for (String excluded : new String[]{"US/Eastern", "Etc/GMT+3", "CET", "Japan", "UTC"}) {
+            assertFalse(ids.contains(excluded), excluded + " must not be used as an example zone");
+        }
+    }
+
+    @Test
+    void labelsNameThePlacesAtTheOffset() {
+        ZoneOffset summerOffsetOfRome = ZoneOffset.ofHours(2);
+        List<ZoneId> atOffset = AjaxZonedDateTimePicker.getZonesByCurrentOffset(SUMMER).get(summerOffsetOfRome);
+        assertEquals("UTC+02:00 — Paris, Berlin, Madrid",
+                AjaxZonedDateTimePicker.getZoneChoiceLabel(summerOffsetOfRome, atOffset, null));
+        // The user's own place is named first, so that they recognize their preselected zone:
+        assertEquals("UTC+02:00 — Rome, Paris, Berlin",
+                AjaxZonedDateTimePicker.getZoneChoiceLabel(summerOffsetOfRome, atOffset, ZoneId.of("Europe/Rome")));
+    }
+
+    @Test
+    void labelsNameNeitherDuplicateNorObscurePlaces() {
+        Map<ZoneOffset, List<ZoneId>> groups = AjaxZonedDateTimePicker.getZonesByCurrentOffset(SUMMER);
+        // Asia/Calcutta is a duplicate of Asia/Kolkata, and there are a dozen more zones at +05:30:
+        ZoneOffset offset = ZoneOffset.ofHoursMinutes(5, 30);
+        assertEquals("UTC+05:30 — Kolkata, Colombo", AjaxZonedDateTimePicker.getZoneChoiceLabel(offset, groups.get(offset), null));
+        // Every offset a place is at is named by at least one of them:
+        for (Map.Entry<ZoneOffset, List<ZoneId>> group : groups.entrySet()) {
+            String label = AjaxZonedDateTimePicker.getZoneChoiceLabel(group.getKey(), group.getValue(), null);
+            assertTrue(label.contains(" — "), "no place is named for " + group.getKey() + ": " + label);
+        }
+    }
+
+    @Test
+    void offsetsAreLabelledAsUtcOffsets() {
+        assertEquals("UTC", AjaxZonedDateTimePicker.getOffsetLabel(ZoneOffset.UTC));
+        assertEquals("UTC+05:30", AjaxZonedDateTimePicker.getOffsetLabel(ZoneOffset.ofHoursMinutes(5, 30)));
+        assertEquals("UTC-03:30", AjaxZonedDateTimePicker.getOffsetLabel(ZoneOffset.ofHoursMinutes(-3, -30)));
+        // Offsets without any place at them are labelled by the offset alone:
+        assertEquals("UTC+01:23", AjaxZonedDateTimePicker.getZoneChoiceLabel(ZoneOffset.ofHoursMinutes(1, 23), List.of(), null));
     }
 
     @Test

--- a/src/test/java/com/knowledgepixels/nanodash/component/DateTimeKeepValueTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/component/DateTimeKeepValueTest.java
@@ -189,6 +189,27 @@ class DateTimeKeepValueTest {
     }
 
     /**
+     * The same, with the rest of the form left invalid so that Wicket does not get as far as
+     * updating the form's models. Clearing the value has to empty the fields by itself, or the
+     * date stays on screen as a value the field no longer holds.
+     */
+    @Test
+    void emptyingADateTimeClearsTheFieldsEvenIfTheFormIsInvalid() throws Exception {
+        startForm("https://w3id.org/np/RAAbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_Dtm05", true);
+        picker().setModelObject(ZonedDateTime.parse("2026-08-17T14:30+02:00"));
+
+        // The other fields are left empty, so the form does not validate:
+        FormTester form = tester.newFormTester("panel:form");
+        form.setValue(DATE_FIELD, "");
+        form.setValue(TIME_FIELD, "");
+        form.submit();
+
+        assertNull(picker().getModelObject());
+        assertEquals("", renderedValue(DATE_FIELD));
+        assertEquals("", renderedValue(TIME_FIELD));
+    }
+
+    /**
      * An ajax request that does not carry the date and time fields (the zone dropdown, the client
      * time zone, another field on the form) must leave the entered value alone.
      */

--- a/src/test/java/com/knowledgepixels/nanodash/component/DateTimeKeepValueTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/component/DateTimeKeepValueTest.java
@@ -1,0 +1,206 @@
+package com.knowledgepixels.nanodash.component;
+
+import com.knowledgepixels.nanodash.WicketApplication;
+import com.knowledgepixels.nanodash.page.PublishPage;
+import com.knowledgepixels.nanodash.template.TemplateData;
+import org.apache.wicket.request.mapper.parameter.PageParameters;
+import org.apache.wicket.util.tester.FormTester;
+import org.apache.wicket.util.tester.WicketTester;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.eclipse.rdf4j.model.vocabulary.XSD;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.nanopub.Nanopub;
+import org.nanopub.NanopubCreator;
+import org.nanopub.vocabulary.NTEMPLATE;
+
+import java.time.ZonedDateTime;
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Tests that a date-time field keeps what the user entered when the publish form comes back with
+ * an error, just like every other field on it.
+ */
+class DateTimeKeepValueTest {
+
+    private static final ValueFactory vf = SimpleValueFactory.getInstance();
+
+    private static final String PICKER =
+            "panel:form:statements:1:statement:statement-group:0:statement:obj:value:zoned-datetime";
+    private static final String NAME_FIELD =
+            "statements:0:statement:statement-group:0:statement:obj:value:textfield";
+    private static final String DATE_FIELD =
+            "statements:1:statement:statement-group:0:statement:obj:value:zoned-datetime:datetime:datepicker";
+    private static final String TIME_FIELD =
+            "statements:1:statement:statement-group:0:statement:obj:value:zoned-datetime:datetime:timepicker";
+
+    private WicketTester tester;
+
+    @BeforeEach
+    void setUp() {
+        tester = new WicketTester(new WicketApplication());
+        tester.getSession().setLocale(Locale.ENGLISH);
+    }
+
+    @AfterEach
+    void tearDown() {
+        tester.destroy();
+    }
+
+    /**
+     * Registers a template with a plain literal ("the name") and a date-time literal ("the
+     * moment"). Each test needs its own nanopub URI, because templates are cached by URI.
+     */
+    private static String registerTemplate(String npUri) throws Exception {
+        return registerTemplate(npUri, false);
+    }
+
+    private static String registerTemplate(String npUri, boolean momentIsOptional) throws Exception {
+        IRI st1 = vf.createIRI(npUri + "/st1");
+        IRI st2 = vf.createIRI(npUri + "/st2");
+        IRI thing = vf.createIRI(npUri + "/thing");
+        IRI name = vf.createIRI(npUri + "/name");
+        IRI moment = vf.createIRI(npUri + "/moment");
+        NanopubCreator creator = new NanopubCreator(npUri);
+        creator.addProvenanceStatement(vf.createStatement(creator.getAssertionUri(), RDFS.SEEALSO, creator.getAssertionUri()));
+        creator.addPubinfoStatement(vf.createStatement(creator.getNanopubUri(), RDFS.SEEALSO, creator.getNanopubUri()));
+        IRI templateNode = creator.getAssertionUri();
+        creator.addAssertionStatement(templateNode, RDF.TYPE, NTEMPLATE.ASSERTION_TEMPLATE);
+        creator.addAssertionStatement(templateNode, RDFS.LABEL, vf.createLiteral("Datetime test template"));
+        creator.addAssertionStatement(templateNode, NTEMPLATE.HAS_STATEMENT, st1);
+        creator.addAssertionStatement(templateNode, NTEMPLATE.HAS_STATEMENT, st2);
+        creator.addAssertionStatement(st1, RDF.SUBJECT, thing);
+        creator.addAssertionStatement(st1, RDF.PREDICATE, RDFS.LABEL);
+        creator.addAssertionStatement(st1, RDF.OBJECT, name);
+        if (momentIsOptional) creator.addAssertionStatement(st2, RDF.TYPE, NTEMPLATE.OPTIONAL_STATEMENT);
+        creator.addAssertionStatement(st2, RDF.SUBJECT, thing);
+        creator.addAssertionStatement(st2, RDF.PREDICATE, RDFS.COMMENT);
+        creator.addAssertionStatement(st2, RDF.OBJECT, moment);
+        creator.addAssertionStatement(thing, RDF.TYPE, NTEMPLATE.URI_PLACEHOLDER);
+        creator.addAssertionStatement(thing, RDFS.LABEL, vf.createLiteral("the thing"));
+        creator.addAssertionStatement(name, RDF.TYPE, NTEMPLATE.LITERAL_PLACEHOLDER);
+        creator.addAssertionStatement(name, RDFS.LABEL, vf.createLiteral("the name"));
+        creator.addAssertionStatement(moment, RDF.TYPE, NTEMPLATE.LITERAL_PLACEHOLDER);
+        creator.addAssertionStatement(moment, NTEMPLATE.HAS_DATATYPE, XSD.DATETIME);
+        creator.addAssertionStatement(moment, RDFS.LABEL, vf.createLiteral("the moment"));
+        Nanopub np = creator.finalizeNanopub();
+        TemplateData.get().registerTemplate(np);
+        return npUri;
+    }
+
+    private void startForm(String npUri) throws Exception {
+        startForm(npUri, false);
+    }
+
+    private void startForm(String npUri, boolean momentIsOptional) throws Exception {
+        PageParameters params = new PageParameters().add("template", registerTemplate(npUri, momentIsOptional));
+        tester.startComponentInPage(new PublishForm("panel", params, PublishPage.class, null));
+    }
+
+    /**
+     * Fills in everything but the consent checkbox, so that submitting fails and the page comes
+     * back with an error.
+     */
+    private FormTester filledForm() {
+        FormTester form = tester.newFormTester("panel:form");
+        form.setValue("statements:0:statement:statement-group:0:statement:subj:value:textfield", "http://example.org/thing");
+        form.setValue(NAME_FIELD, "some name");
+        form.setValue("statements:1:statement:statement-group:0:statement:subj:value:textfield", "http://example.org/thing");
+        return form;
+    }
+
+    private AjaxZonedDateTimePicker picker() {
+        return (AjaxZonedDateTimePicker) tester.getComponentFromLastRenderedPage(PICKER);
+    }
+
+    /**
+     * Returns the value the given field is rendered with, so that what the user gets to see is
+     * what is asserted on.
+     */
+    private String renderedValue(String fieldPath) {
+        String name = "name=\"" + fieldPath + "\"";
+        for (String line : tester.getLastResponseAsString().split("\n")) {
+            int at = line.indexOf(name);
+            if (at < 0) continue;
+            String before = line.substring(0, at);
+            int valueAt = before.lastIndexOf("value=\"");
+            if (valueAt < 0) return "";
+            return before.substring(valueAt + "value=\"".length(), before.indexOf('"', valueAt + "value=\"".length()));
+        }
+        throw new AssertionError("field not rendered: " + fieldPath);
+    }
+
+    @Test
+    void completeDateTimeSurvivesFailedPublish() throws Exception {
+        startForm("https://w3id.org/np/RAAbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_Dtm01");
+        FormTester form = filledForm();
+        form.setValue(DATE_FIELD, "17 Aug 2026");
+        form.setValue(TIME_FIELD, "14:30");
+        form.submit();
+
+        assertEquals("some name", renderedValue(NAME_FIELD), "the other fields keep their value");
+        assertEquals("17 Aug 2026", renderedValue(DATE_FIELD));
+        assertEquals("14:30", renderedValue(TIME_FIELD));
+        // The submitted date and time reach the model, rather than only the fields:
+        assertEquals("2026-08-17T14:30", picker().getModelObject().toLocalDateTime().toString());
+    }
+
+    /**
+     * A date without a time is exactly the kind of half-entered value that makes the page come
+     * back with an error; the date the user typed has to still be there.
+     */
+    @Test
+    void partialDateTimeSurvivesFailedPublish() throws Exception {
+        startForm("https://w3id.org/np/RAAbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_Dtm02");
+        FormTester form = filledForm();
+        form.setValue(DATE_FIELD, "17 Aug 2026");
+        form.submit();
+
+        assertEquals("some name", renderedValue(NAME_FIELD), "the other fields keep their value");
+        assertEquals("17 Aug 2026", renderedValue(DATE_FIELD));
+        assertEquals("", renderedValue(TIME_FIELD));
+    }
+
+    /**
+     * The other way round: a date-time the user empties out must not be kept alive by the value
+     * that is still in the model.
+     */
+    @Test
+    void emptyingADateTimeClearsTheValue() throws Exception {
+        startForm("https://w3id.org/np/RAAbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_Dtm03", true);
+        picker().setModelObject(ZonedDateTime.parse("2026-08-17T14:30+02:00"));
+
+        FormTester form = filledForm();
+        form.setValue(DATE_FIELD, "");
+        form.setValue(TIME_FIELD, "");
+        form.submit();
+
+        assertNull(picker().getModelObject(), "an emptied date-time field clears the value");
+        assertEquals("", renderedValue(DATE_FIELD));
+        assertEquals("", renderedValue(TIME_FIELD));
+    }
+
+    /**
+     * An ajax request that does not carry the date and time fields (the zone dropdown, the client
+     * time zone, another field on the form) must leave the entered value alone.
+     */
+    @Test
+    void ajaxWithoutTheDateTimeFieldsKeepsTheValue() throws Exception {
+        startForm("https://w3id.org/np/RAAbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_Dtm04");
+        ZonedDateTime value = ZonedDateTime.parse("2026-08-17T14:30+02:00");
+        picker().setModelObject(value);
+
+        tester.executeAjaxEvent(PICKER, "change");
+
+        assertEquals(value, picker().getModelObject());
+    }
+
+}

--- a/src/test/java/com/knowledgepixels/nanodash/template/LiteralPlaceholderDatatypeTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/template/LiteralPlaceholderDatatypeTest.java
@@ -18,6 +18,8 @@ import org.mockito.MockedStatic;
 import org.nanopub.NanopubCreator;
 import org.nanopub.vocabulary.NTEMPLATE;
 
+import java.time.ZonedDateTime;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -110,6 +112,25 @@ public class LiteralPlaceholderDatatypeTest {
         Literal l = (Literal) result;
         assertEquals("42", l.stringValue());
         assertEquals(XSD.NAMESPACE + "integer", l.getDatatype().stringValue());
+    }
+
+    @Test
+    void dateTimeLiteralAlwaysHasSeconds() throws Exception {
+        mockTemplate(XSD.DATETIME, null);
+        TemplateContext context = new TemplateContext(ContextType.ASSERTION, NP_URI, "statement", (String) null);
+        // A time entered without seconds, which is what the picker asks for by default:
+        context.getComponentModels().put(VALUE, Model.of(ZonedDateTime.parse("2026-05-17T10:15+02:00")));
+        Literal l = (Literal) context.processValue(VALUE);
+        assertEquals("2026-05-17T10:15:00+02:00", l.stringValue());
+        assertEquals(XSD.DATETIME, l.getDatatype());
+    }
+
+    @Test
+    void dateTimeLiteralKeepsEnteredSeconds() throws Exception {
+        mockTemplate(XSD.DATETIME, null);
+        TemplateContext context = new TemplateContext(ContextType.ASSERTION, NP_URI, "statement", (String) null);
+        context.getComponentModels().put(VALUE, Model.of(ZonedDateTime.parse("2026-05-17T10:15:30Z")));
+        assertEquals("2026-05-17T10:15:30Z", context.processValue(VALUE).stringValue());
     }
 
     @Test


### PR DESCRIPTION
Five fixes to the date-time field on the publish form, each in its own commit.

## The time zone dropdown started out empty

Until a zone was selected the picker produced **no value at all** — `onValueChanged` only wrote to the value model when a zone was set, so picking a date and time without touching the dropdown silently left the field empty. The dropdown now starts on the zone the user is most likely in, taken from the browser (asked for via `AjaxClientInfoBehavior` on a session's first page view, when Wicket doesn't know it yet) and falling back to the instance's own zone. A zone determined by the user or by an existing value is never overruled, so editing an existing nanopub keeps its offset.

Also fixes an NPE when the zone was changed before a date was picked, which the preselection makes easy to reach. Closes #596.

## The choices were standard offsets, so half the year they were wrong

Someone in Rome had to pick `+01:00 : Africa/Cairo, ...` in July. Zones are now grouped by the offset they are at *right now*, DST included, so the preselected entry stamps the time on the user's own clock. Labels went from `+02:00 : Africa/Cairo, Africa/Gaborone, Africa/Johannesburg` to `UTC+02:00 — Rome, Paris, Berlin`: place names instead of zone ids, well-known places only, and the user's own place named first in their own entry.

## The time field asked for seconds

They were almost always `:00` typed out by hand. It asks for hours and minutes now, and the literal still gets `:00`. Seconds come back when they matter: a value that carries them makes the field ask for them again, so filling in an existing nanopub shows the whole time instead of rounding it down behind the user's back, and seconds typed into the shorter field are taken as typed.

Date-time literals are now written by our own formatter rather than RDF4J's, which left the seconds out of a whole minute (`10:15`) and appended a tenth to everything else (`10:15:30.0`). They read `2026-05-17T10:15:00Z` now, with a fraction only where the value has one.

## The two halves took clicks in opposite places

The date and time fields opened their popup only from the button beside them; clicking the field did nothing. The zone box was the other way round — clicking the text opened the dropdown, while the globe that looks like a button was inert decoration. Both take a click anywhere now.

## A date-time field emptied itself when the form came back with an error

Every other field kept what the user had entered. The picker is a `FormComponentPanel` but never converted its own input — it read the model back instead, so the value only got there if an ajax call had stored it first. `PublishForm.onValidate()` calls `processInput()` on every component, and Wicket skips `convertInput()` for a panel whose children are in error. The panel itself carried no error message, so `processInput()` went on to clear the date and time fields' input and write the resulting `null` over the model. A date whose time wasn't filled in yet — the very thing that makes the page come back with an error — was left with nothing to render from.

It now converts from the date, time and zone fields as a `FormComponentPanel` is meant to, and leaves both the model and the fields' input alone while the children are in error. This also gets a complete date and time into the model on submit, which it didn't do before unless the kendo ajax had fired.

⚠️ Behaviour change worth a look: emptying a **required** date-time now reports the field as required, rather than silently publishing the value that was there before.

## Tests

`AjaxZonedDateTimePickerTest` covers the preselection, the grouping and the labels; `DateTimeKeepValueTest` drives a real `PublishForm` with an `xsd:dateTime` placeholder and covers the four value-retention cases. Full suite green (1055 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
