### PR TITLE
Show outdated view results with a spinner instead of a bare spinner (#599)

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/ApiCache.java
+++ b/src/main/java/com/knowledgepixels/nanodash/ApiCache.java
@@ -16,6 +16,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
@@ -68,6 +69,15 @@ public class ApiCache {
     private transient static ConcurrentMap<String, Long> lastRefresh = new ConcurrentHashMap<>();
     private transient static ConcurrentMap<String, Long> refreshStart = new ConcurrentHashMap<>();
     private transient static ConcurrentMap<String, Long> runAfter = new ConcurrentHashMap<>();
+
+    // Cache ids that must be re-fetched before their entry counts as current again: a
+    // genuine browser reload or an explicit clearCache (e.g. after publishing). The
+    // cached value itself is deliberately kept, so callers can go on showing the
+    // outdated content while the refresh runs instead of only a spinner (issue #599);
+    // it is retrieved with retrieveStaleResponse(). The flag is dropped once a refresh
+    // attempt has completed, successfully or not.
+    private static final Set<String> forcedRefresh = ConcurrentHashMap.newKeySet();
+
     private static final Logger logger = LoggerFactory.getLogger(ApiCache.class);
 
     // Guava fires removal notifications also when an entry is REPLACED (every routine
@@ -84,6 +94,7 @@ public class ApiCache {
         lastRefresh.remove(cacheId);
         failed.remove(cacheId);
         runAfter.remove(cacheId);
+        forcedRefresh.remove(cacheId);
     }
 
     /**
@@ -169,7 +180,11 @@ public class ApiCache {
             // lastRefresh can be missing for a cached entry (racing invalidation or
             // refresh); treat that as stale rather than NPEing on the unboxing.
             Long lastRefreshTime = lastRefresh.get(cacheId);
-            needsRefresh = lastRefreshTime == null || timeNow - lastRefreshTime > REFRESH_AGE_THRESHOLD_MS;
+            // A pending forced refresh (clearCache, e.g. after publishing) always counts as
+            // stale here: the entry is kept only so the UI can show the outdated content,
+            // never to be handed to a synchronous caller as if it were current.
+            needsRefresh = forcedRefresh.contains(cacheId) || lastRefreshTime == null
+                    || timeNow - lastRefreshTime > REFRESH_AGE_THRESHOLD_MS;
         }
         Integer failedCount = failed.get(cacheId);
         if (failedCount != null && failedCount > 2) {
@@ -207,18 +222,21 @@ public class ApiCache {
                 lastRefresh.put(cacheId, System.currentTimeMillis());
             } finally {
                 refreshStart.remove(cacheId);
+                forcedRefresh.remove(cacheId);
             }
-        } else if (cachedResponses.getIfPresent(cacheId) == null && isRunning(cacheId)) {
-            // Another thread is doing the first fetch of this query and we have
-            // nothing cached yet. Wait for it rather than returning null: a null
-            // here lets a caller (e.g. SpaceRepository) memoise an EMPTY snapshot,
-            // which then poisons MaintainedResourceRepository.build() and breaks
-            // the home page until the next refresh. This adds no new work; it only
-            // waits on the refresh already in flight.
+        } else if (isRunning(cacheId)
+                && (cachedResponses.getIfPresent(cacheId) == null || forcedRefresh.contains(cacheId))) {
+            // Another thread is fetching this query and what we hold is either nothing at
+            // all or an entry that is only being kept for the stale-content display. Wait
+            // for that fetch rather than returning null or the outdated entry: a null here
+            // lets a caller (e.g. SpaceRepository) memoise an EMPTY snapshot, which then
+            // poisons MaintainedResourceRepository.build() and breaks the home page until
+            // the next refresh. This adds no new work; it only waits on the refresh
+            // already in flight.
             try {
                 long deadline = timeNow + SYNC_WAIT_FOR_INFLIGHT_MS;
                 while (isRunning(cacheId)
-                        && cachedResponses.getIfPresent(cacheId) == null
+                        && (cachedResponses.getIfPresent(cacheId) == null || forcedRefresh.contains(cacheId))
                         && System.currentTimeMillis() < deadline) {
                     Thread.sleep(50);
                 }
@@ -240,15 +258,17 @@ public class ApiCache {
         String cacheId = queryRef.getAsUrlString();
         logger.debug("Retrieving cached API response asynchronously for {}", cacheId);
         if (isForcedReload(cacheId)) {
-            cachedResponses.invalidate(cacheId);
-            lastRefresh.remove(cacheId);
+            // Keep the entry (see retrieveStaleResponse) but stop treating it as current,
+            // so the reload re-queries while the outdated content stays on screen.
+            forcedRefresh.add(cacheId);
         }
+        boolean forced = forcedRefresh.contains(cacheId);
         boolean isCached = false;
         boolean needsRefresh = true;
         if (cachedResponses.getIfPresent(cacheId) != null) {
             Long lastRefreshTime = lastRefresh.get(cacheId);
-            isCached = lastRefreshTime != null && timeNow - lastRefreshTime < MAX_CACHE_AGE_MS;
-            needsRefresh = lastRefreshTime == null || timeNow - lastRefreshTime > REFRESH_AGE_THRESHOLD_MS;
+            isCached = !forced && lastRefreshTime != null && timeNow - lastRefreshTime < MAX_CACHE_AGE_MS;
+            needsRefresh = forced || lastRefreshTime == null || timeNow - lastRefreshTime > REFRESH_AGE_THRESHOLD_MS;
         }
         Integer failedCount = failed.get(cacheId);
         if (failedCount != null && failedCount > 2) {
@@ -285,6 +305,9 @@ public class ApiCache {
                     lastRefresh.put(cacheId, System.currentTimeMillis());
                 } finally {
                     refreshStart.remove(cacheId);
+                    // Dropped on failure too: a query we cannot reach must not keep every
+                    // later render on the stale path, re-submitting a refresh each time.
+                    forcedRefresh.remove(cacheId);
                 }
             });
         }
@@ -400,15 +423,17 @@ public class ApiCache {
         String cacheId = queryRef.getAsUrlString();
         logger.debug("Retrieving cached RDF model asynchronously for {}", cacheId);
         if (isForcedReload(cacheId)) {
-            cachedRdfModels.invalidate(cacheId);
-            lastRefresh.remove(cacheId);
+            // As in retrieveResponseAsync: mark for re-fetch but keep the model, so a failed
+            // refresh still has the previous one to fall back on.
+            forcedRefresh.add(cacheId);
         }
+        boolean forced = forcedRefresh.contains(cacheId);
         boolean isCached = false;
         boolean needsRefresh = true;
         if (cachedRdfModels.getIfPresent(cacheId) != null) {
             Long lastRefreshTime = lastRefresh.get(cacheId);
-            isCached = lastRefreshTime != null && timeNow - lastRefreshTime < MAX_CACHE_AGE_MS;
-            needsRefresh = lastRefreshTime == null || timeNow - lastRefreshTime > REFRESH_AGE_THRESHOLD_MS;
+            isCached = !forced && lastRefreshTime != null && timeNow - lastRefreshTime < MAX_CACHE_AGE_MS;
+            needsRefresh = forced || lastRefreshTime == null || timeNow - lastRefreshTime > REFRESH_AGE_THRESHOLD_MS;
         }
         Integer failedCount = failed.get(cacheId);
         if (failedCount != null && failedCount > 2) {
@@ -444,6 +469,7 @@ public class ApiCache {
                     lastRefresh.put(cacheId, System.currentTimeMillis());
                 } finally {
                     refreshStart.remove(cacheId);
+                    forcedRefresh.remove(cacheId);
                 }
             });
         }
@@ -455,7 +481,24 @@ public class ApiCache {
     }
 
     /**
-     * Clears the cached response for a specific query reference and sets a delay before the next refresh can occur.
+     * Returns whatever response is cached for a query reference, however outdated, without
+     * triggering a refresh or any other side effect. Meant for showing the previous content
+     * while a refresh is in flight (issue #599) — never as a substitute for the current data,
+     * which is what {@link #retrieveResponseAsync(QueryRef)} and
+     * {@link #retrieveResponseSync(QueryRef, boolean)} return.
+     *
+     * @param queryRef The query reference
+     * @return The cached response of any age, or null if nothing is cached.
+     */
+    public static ApiResponse retrieveStaleResponse(QueryRef queryRef) {
+        return cachedResponses.getIfPresent(queryRef.getAsUrlString());
+    }
+
+    /**
+     * Marks the cached response for a specific query reference as outdated and sets a delay
+     * before the next refresh can occur. The previous response is kept and remains available
+     * through {@link #retrieveStaleResponse(QueryRef)} until the refresh lands, but it is no
+     * longer served as current data.
      *
      * @param queryRef   The query reference for which to clear the cache.
      * @param waitMillis The amount of time in milliseconds to wait before allowing the cache to be refreshed again.
@@ -464,7 +507,7 @@ public class ApiCache {
         if (waitMillis < 0) {
             throw new IllegalArgumentException("waitMillis must be non-negative");
         }
-        cachedResponses.invalidate(queryRef.getAsUrlString());
+        forcedRefresh.add(queryRef.getAsUrlString());
         runAfter.put(queryRef.getAsUrlString(), System.currentTimeMillis() + waitMillis);
     }
 

--- a/src/main/java/com/knowledgepixels/nanodash/ApiCache.java
+++ b/src/main/java/com/knowledgepixels/nanodash/ApiCache.java
@@ -191,22 +191,38 @@ public class ApiCache {
             failed.remove(cacheId);
             throw new RuntimeException("Query failed: " + cacheId);
         }
+        // Waiting around is for background threads. A request thread must not sit out an
+        // ingest delay or a politeness pause on the user's time: it takes what the cache has
+        // and leaves the refresh to a thread that can afford to wait.
+        boolean onRequestThread = RequestCycle.get() != null;
+        Long after = runAfter.get(cacheId);
+        boolean waitingForIngest = after != null && System.currentTimeMillis() < after;
+        if (onRequestThread && waitingForIngest) {
+            logger.debug("Not waiting out the ingest delay for {} on a request thread", cacheId);
+            // Hand the refresh to the background, where waiting out the delay costs nobody
+            // anything, and answer with what we have meanwhile.
+            retrieveResponseAsync(queryRef);
+            return cachedResponses.getIfPresent(cacheId);
+        }
         if ((needsRefresh || forced) && !isRunning(cacheId)) {
             logger.info("Refreshing cache for {}", cacheId);
             refreshStart.put(cacheId, timeNow);
             try {
-                Long after = runAfter.get(cacheId);
-                if (after != null) {
+                if (waitingForIngest) {
                     while (System.currentTimeMillis() < after) {
                         Thread.sleep(100);
                     }
-                    runAfter.remove(cacheId);
                 }
-                if (failed.get(cacheId) != null) {
-                    // 1 second pause between failed attempts;
-                    Thread.sleep(1000);
+                if (after != null) runAfter.remove(cacheId);
+                if (!onRequestThread) {
+                    if (failed.get(cacheId) != null) {
+                        // 1 second pause between failed attempts;
+                        Thread.sleep(1000);
+                    }
+                    // Jitter, so that background refreshes of many queries do not arrive at
+                    // the API in lockstep. Pure latency on a request thread, so skipped there.
+                    Thread.sleep(100 + new Random().nextLong(400));
                 }
-                Thread.sleep(100 + new Random().nextLong(400));
             } catch (InterruptedException ex) {
                 logger.error("Interrupted while waiting to refresh cache: {}", ex.getMessage());
             }

--- a/src/main/java/com/knowledgepixels/nanodash/QueryResult.java
+++ b/src/main/java/com/knowledgepixels/nanodash/QueryResult.java
@@ -3,6 +3,8 @@ package com.knowledgepixels.nanodash;
 import com.knowledgepixels.nanodash.component.menu.ViewDisplayMenu;
 import com.knowledgepixels.nanodash.domain.AbstractResourceWithProfile;
 import com.knowledgepixels.nanodash.page.NanodashPage;
+import org.apache.wicket.Component;
+import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
@@ -57,6 +59,36 @@ public abstract class QueryResult extends Panel {
         this.viewDisplay = viewDisplay;
         this.response = response;
         this.grlcQuery = GrlcQuery.get(queryRef);
+
+        // The spinner shown beside the title while this view's results are being brought up
+        // to date; hidden until someone turns it on (see RefreshingResultPanel). It lives in
+        // the title row, right after the title, where the row's own layout keeps it clear of
+        // everything — see the .refresh-spinner rules in style.css.
+        refreshIndicator = new WebMarkupContainer("refresh-indicator");
+        refreshIndicator.setOutputMarkupPlaceholderTag(true);
+        refreshIndicator.setVisible(false);
+        add(refreshIndicator);
+    }
+
+    private final WebMarkupContainer refreshIndicator;
+
+    /**
+     * Shows or hides the spinner beside this view's title.
+     *
+     * @param refreshing true while the view's results are being brought up to date
+     */
+    public void setRefreshing(boolean refreshing) {
+        refreshIndicator.setVisible(refreshing);
+    }
+
+    /**
+     * The spinner component itself, so a caller that turns it off over Ajax can repaint just
+     * that instead of the whole view.
+     *
+     * @return the refresh indicator
+     */
+    public Component getRefreshIndicator() {
+        return refreshIndicator;
     }
 
     @Override

--- a/src/main/java/com/knowledgepixels/nanodash/QueryResult.java
+++ b/src/main/java/com/knowledgepixels/nanodash/QueryResult.java
@@ -1,5 +1,6 @@
 package com.knowledgepixels.nanodash;
 
+import com.knowledgepixels.nanodash.component.QueryResultComponentFactory;
 import com.knowledgepixels.nanodash.component.menu.ViewDisplayMenu;
 import com.knowledgepixels.nanodash.domain.AbstractResourceWithProfile;
 import com.knowledgepixels.nanodash.page.NanodashPage;
@@ -60,6 +61,12 @@ public abstract class QueryResult extends Panel {
         this.response = response;
         this.grlcQuery = GrlcQuery.get(queryRef);
 
+        // Every view carries an id in the rendered page, so that it can be replaced on its
+        // own over Ajax — which is how "refresh now" updates one view without re-rendering
+        // the page. Without it the replacement would be written under an id the browser has
+        // never seen, leaving the old markup (and its now-removed links) in place.
+        setOutputMarkupId(true);
+
         // The spinner shown beside the title while this view's results are being brought up
         // to date; hidden until someone turns it on (see RefreshingResultPanel). It lives in
         // the title row, right after the title, where the row's own layout keeps it clear of
@@ -89,6 +96,28 @@ public abstract class QueryResult extends Panel {
      */
     public Component getRefreshIndicator() {
         return refreshIndicator;
+    }
+
+    /**
+     * Builds this view again from the current state of the cache, as a component that can
+     * take this one's place. Used to refresh a single view where it stands (see the "refresh
+     * now" entry of its menu) instead of re-rendering the page around it.
+     * <p>
+     * With the view's results just marked as outdated, the rebuild comes back as the results
+     * that are on screen now plus a spinner, which swaps in the new ones by itself once the
+     * query has run.
+     *
+     * @param markupId the id the replacement must take, i.e. that of the component it replaces
+     * @return the replacement component
+     */
+    public Component rebuild(String markupId) {
+        // The part id is only set when it differs from the context; otherwise the view is
+        // shown for the context resource itself.
+        String id = partId != null ? partId : contextId;
+        Component rebuilt = QueryResultComponentFactory.build(markupId, queryRef, viewDisplay,
+                resourceWithProfile, id, contextId, refRoot);
+        if (rebuilt != null) rebuilt.setOutputMarkupId(true);
+        return rebuilt;
     }
 
     @Override

--- a/src/main/java/com/knowledgepixels/nanodash/Utils.java
+++ b/src/main/java/com/knowledgepixels/nanodash/Utils.java
@@ -5,10 +5,15 @@ import com.knowledgepixels.nanodash.domain.User;
 import net.trustyuri.TrustyUriUtils;
 import org.apache.commons.codec.Charsets;
 import org.apache.commons.lang.StringUtils;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.wicket.markup.html.link.ExternalLink;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.request.Url;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import org.apache.wicket.request.cycle.RequestCycle;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
 import org.apache.wicket.util.string.StringValue;
@@ -52,6 +57,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -118,8 +124,45 @@ public class Utils {
         return TrustyUriUtils.getArtifactCode(npId.toString()).substring(0, 10);
     }
 
-    // Concurrent, as retrieval also happens on background threads (see NanopubLookup):
-    private static Map<String, Nanopub> nanopubs = new ConcurrentHashMap<>();
+    // Nanopublications are immutable, so a cached one never goes out of date and the only
+    // reason to drop one is to keep the cache from growing without end — which it used to,
+    // being a plain map that never evicted. Bounded like the query caches in ApiCache, and
+    // concurrent, as retrieval also happens on background threads (see NanopubLookup).
+    private static final int MAX_CACHED_NANOPUBS = 10_000;
+
+    private static final Cache<String, Nanopub> nanopubs = CacheBuilder.newBuilder()
+            .maximumSize(MAX_CACHED_NANOPUBS)
+            .expireAfterAccess(24, TimeUnit.HOURS)
+            .build();
+
+    // Registry fetches go through our own client rather than the library's shared one
+    // (NanopubUtils.getHttpClient), which allows 10 seconds for each of connecting, reading
+    // and waiting for a pooled connection — up to 30 seconds for a single fetch, on a thread
+    // that may be rendering a page. These bounds are tighter, and in particular a saturated
+    // pool fails fast here instead of queueing threads up behind it.
+    private static final int REGISTRY_CONNECT_TIMEOUT_MS = 5_000;
+    private static final int REGISTRY_SOCKET_TIMEOUT_MS = 10_000;
+    private static final int REGISTRY_CONNECTION_REQUEST_TIMEOUT_MS = 2_000;
+
+    private static final CloseableHttpClient registryHttpClient = HttpClientBuilder.create()
+            .setDefaultRequestConfig(RequestConfig.custom()
+                    .setConnectTimeout(REGISTRY_CONNECT_TIMEOUT_MS)
+                    .setSocketTimeout(REGISTRY_SOCKET_TIMEOUT_MS)
+                    .setConnectionRequestTimeout(REGISTRY_CONNECTION_REQUEST_TIMEOUT_MS)
+                    .build())
+            .setMaxConnTotal(64)
+            .setMaxConnPerRoute(16)
+            .build();
+
+    /**
+     * The HTTP client to use for registry requests: same behaviour as the library's shared
+     * one, but with tighter timeouts (see {@link #getNanopub(String)}).
+     *
+     * @return the shared registry HTTP client
+     */
+    public static CloseableHttpClient getRegistryHttpClient() {
+        return registryHttpClient;
+    }
 
     /**
      * Adds a nanopublication to the local cache so it can be retrieved immediately
@@ -140,16 +183,20 @@ public class Utils {
      */
     public static Nanopub getNanopub(String uriOrArtifactCode) {
         String artifactCode = GetNanopub.getArtifactCode(uriOrArtifactCode).toString();
-        if (!nanopubs.containsKey(artifactCode)) {
-            for (int i = 0; i < 3; i++) {  // Try 3 times to get nanopub
-                Nanopub np = GetNanopub.get(artifactCode);
-                if (np != null) {
-                    nanopubs.put(artifactCode, np);
-                    break;
-                }
+        Nanopub cached = nanopubs.getIfPresent(artifactCode);
+        if (cached != null) return cached;
+        // A request thread gets one attempt: the retries are there to ride out a flaky
+        // registry, and doing that while a user waits only multiplies the time they spend
+        // looking at nothing. Background threads keep the full three.
+        int attempts = RequestCycle.get() != null ? 1 : 3;
+        for (int i = 0; i < attempts; i++) {
+            Nanopub np = GetNanopub.get(artifactCode, registryHttpClient);
+            if (np != null) {
+                nanopubs.put(artifactCode, np);
+                return np;
             }
         }
-        return nanopubs.get(artifactCode);
+        return null;
     }
 
     /**

--- a/src/main/java/com/knowledgepixels/nanodash/component/AboutPartPanel.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/AboutPartPanel.java
@@ -38,6 +38,20 @@ public class AboutPartPanel extends Panel {
     public static final String PART_VIEW_DISPLAYS_VIEW = "https://w3id.org/np/RAkvLDMWg1GCSY2RUpvVA0P3th3gzjUcoaXTzqMeFi5OY/part-view-displays-view";
 
     /**
+     * Every view this panel resolves through {@link View#get(String)} when it is built.
+     * The page gates on these: while any of them is unresolved the panel is built in a
+     * follow-up Ajax request, so that resolving them cannot block the page render. Keeping
+     * the list here, next to the constants it names, is what keeps it from drifting out of
+     * step with the panel — a page that gates on the wrong ids either blocks on a view it
+     * did not wait for, or waits forever for one this panel never resolves and so reloads
+     * the tab on every visit.
+     */
+    public static final String[] REQUIRED_VIEWS = {
+            PART_INFO_VIEW,
+            PART_VIEW_DISPLAYS_VIEW,
+    };
+
+    /**
      * @param id          the Wicket markup id
      * @param context     the part's owning resource (maintained resource, space, or user)
      * @param partId      the part IRI

--- a/src/main/java/com/knowledgepixels/nanodash/component/AboutResourcePanel.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/AboutResourcePanel.java
@@ -37,6 +37,21 @@ public class AboutResourcePanel extends Panel {
     public static final String MAINTAINED_RESOURCE_PRESET_ASSIGNMENTS_VIEW = "https://w3id.org/np/RA-CRSYJrYf-uaw1fip7hr_kdPqVb7_6dENwTPYQpikRY/preset-assignments-view";
 
     /**
+     * Every view this panel resolves through {@link View#get(String)} when it is built.
+     * The page gates on these: while any of them is unresolved the panel is built in a
+     * follow-up Ajax request, so that resolving them cannot block the page render. Keeping
+     * the list here, next to the constants it names, is what keeps it from drifting out of
+     * step with the panel — a page that gates on the wrong ids either blocks on a view it
+     * did not wait for, or waits forever for one this panel never resolves and so reloads
+     * the tab on every visit.
+     */
+    public static final String[] REQUIRED_VIEWS = {
+            MAINTAINED_RESOURCE_INFO_VIEW,
+            MAINTAINED_RESOURCE_PRESET_ASSIGNMENTS_VIEW,
+            MAINTAINED_RESOURCE_VIEW_DISPLAYS_VIEW,
+    };
+
+    /**
      * @param id       the Wicket markup id
      * @param resource the maintained resource whose About listings to render
      */

--- a/src/main/java/com/knowledgepixels/nanodash/component/AboutSpacePanel.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/AboutSpacePanel.java
@@ -83,6 +83,27 @@ public class AboutSpacePanel extends Panel {
     public static final String MAINTAINED_RESOURCES_VIEW = "https://w3id.org/np/RAPUs5_CXMs_13QpU0RQch8LB28MN61p-j0945_STg8BE/maintained-resources-view";
 
     /**
+     * Every view this panel resolves through {@link View#get(String)} when it is built.
+     * The page gates on these: while any of them is unresolved the panel is built in a
+     * follow-up Ajax request, so that resolving them cannot block the page render. Keeping
+     * the list here, next to the constants it names, is what keeps it from drifting out of
+     * step with the panel — a page that gates on the wrong ids either blocks on a view it
+     * did not wait for, or waits forever for one this panel never resolves and so reloads
+     * the tab on every visit.
+     */
+    public static final String[] REQUIRED_VIEWS = {
+            SPACE_INFO_VIEW,
+            PRESET_ASSIGNMENTS_VIEW,
+            SPACE_ROLES_VIEW,
+            VIEW_DISPLAYS_VIEW,
+            MEMBERS_VIEW,
+            NON_APPROVED_VIEW,
+            OBSERVERS_VIEW,
+            SUB_SPACES_VIEW,
+            MAINTAINED_RESOURCES_VIEW,
+    };
+
+    /**
      * @param id    the Wicket markup id
      * @param space the space whose About listings to render
      */

--- a/src/main/java/com/knowledgepixels/nanodash/component/AboutUserPanel.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/AboutUserPanel.java
@@ -41,6 +41,22 @@ public class AboutUserPanel extends Panel {
     public static final String USER_PRESET_ASSIGNMENTS_VIEW = "https://w3id.org/np/RAd0UM_ll5a7Ewpg2VT5azZ7lh3S-K2ASCOIk2AgKfAJY/preset-assignments-view";
 
     /**
+     * Every view this panel resolves through {@link View#get(String)} when it is built.
+     * The page gates on these: while any of them is unresolved the panel is built in a
+     * follow-up Ajax request, so that resolving them cannot block the page render. Keeping
+     * the list here, next to the constants it names, is what keeps it from drifting out of
+     * step with the panel — a page that gates on the wrong ids either blocks on a view it
+     * did not wait for, or waits forever for one this panel never resolves and so reloads
+     * the tab on every visit.
+     */
+    public static final String[] REQUIRED_VIEWS = {
+            PROFILE_VIEW,
+            INTRODUCTIONS_VIEW,
+            USER_PRESET_ASSIGNMENTS_VIEW,
+            USER_VIEW_DISPLAYS_VIEW,
+    };
+
+    /**
      * @param id            the Wicket markup id
      * @param userIriString the user IRI
      */

--- a/src/main/java/com/knowledgepixels/nanodash/component/ApiResultComponent.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/ApiResultComponent.java
@@ -86,30 +86,23 @@ public abstract class ApiResultComponent extends ResultComponent {
         return comp;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    // How long to keep waiting for a first result before giving up on it.
     private static final long LAZY_LOAD_TIMEOUT_MS = 60_000;
 
+    private final long deadline = System.currentTimeMillis() + LAZY_LOAD_TIMEOUT_MS;
+    private boolean queryFailed = false;
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Only builds the component; the waiting is done by the polling in
+     * {@link #isContentReady()}, which returns true exactly when there is something to build
+     * from — or to report.
+     */
     @Override
     public Component getLazyLoadComponent(String markupId) {
-        long deadline = System.currentTimeMillis() + LAZY_LOAD_TIMEOUT_MS;
-        while (System.currentTimeMillis() < deadline) {
-            if (!ApiCache.isRunning(queryRef)) {
-                try {
-                    response = ApiCache.retrieveResponseAsync(queryRef);
-                    if (response != null) break;
-                } catch (Exception ex) {
-                    return new Label(markupId, "<span class=\"negative\">API call failed.</span>").setEscapeModelStrings(false);
-                }
-            }
-            try {
-                Thread.sleep(100);
-            } catch (InterruptedException ex) {
-                Thread.currentThread().interrupt();
-                logger.error("Interrupted while waiting for API response", ex);
-                break;
-            }
+        if (queryFailed) {
+            return new Label(markupId, "<span class=\"negative\">API call failed.</span>").setEscapeModelStrings(false);
         }
         if (response == null) {
             logger.error("Timed out waiting for API response for {}", queryRef);
@@ -120,10 +113,24 @@ public abstract class ApiResultComponent extends ResultComponent {
 
     /**
      * {@inheritDoc}
+     * <p>
+     * Asks the cache — which answers without going to the network — and reports "ready" once
+     * it has the results, the query has failed, or the wait has gone on long enough. The
+     * panel's timer calls this about once a second, so waiting costs nothing while it lasts:
+     * this used to be a sleep loop inside {@link #getLazyLoadComponent(String)}, which held a
+     * request thread for up to a minute per view still loading.
      */
     @Override
     protected boolean isContentReady() {
-        return response != null || !ApiCache.isRunning(queryRef);
+        if (response != null || queryFailed) return true;
+        try {
+            response = ApiCache.retrieveResponseAsync(queryRef);
+        } catch (Exception ex) {
+            logger.error("Query failed for {}: {}", queryRef.getAsUrlString(), ex.getMessage());
+            queryFailed = true;
+            return true;
+        }
+        return response != null || System.currentTimeMillis() > deadline;
     }
 
     /**

--- a/src/main/java/com/knowledgepixels/nanodash/component/ApiResultComponent.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/ApiResultComponent.java
@@ -17,6 +17,7 @@ public abstract class ApiResultComponent extends ResultComponent {
 
     private final QueryRef queryRef;
     private ApiResponse response = null;
+    private String loadingTitle = null;
     private static final Logger logger = LoggerFactory.getLogger(ApiResultComponent.class);
 
     /**
@@ -31,18 +32,43 @@ public abstract class ApiResultComponent extends ResultComponent {
     }
 
     /**
+     * Sets the title to show while waiting, so the loading state looks like the loaded one
+     * with the spinner beside its title (see {@link LoadingResultPanel}). Without one, only
+     * the spinner is shown.
+     *
+     * @param loadingTitle the view's title, or null
+     */
+    public final void setLoadingTitle(String loadingTitle) {
+        this.loadingTitle = loadingTitle;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected Component getDefaultLoadingComponent(String id) {
+        if (loadingTitle == null || loadingTitle.isBlank()) {
+            return super.getDefaultLoadingComponent(id);
+        }
+        return new LoadingResultPanel(id, loadingTitle);
+    }
+
+    /**
      * Builds the component for a query's results in whichever state its cache is in: the
      * results themselves when they are current, the previous ones plus a spinner while a
-     * refresh runs (see {@link RefreshingResultPanel}), and only a spinner when nothing is
-     * cached yet. The returned component is the one to style and add, whichever state it is.
+     * refresh runs (see {@link RefreshingResultPanel}), and the title plus a spinner when
+     * nothing is cached yet. The returned component is the one to style and add, whichever
+     * state it is.
      *
-     * @param markupId the markup ID for the component
-     * @param queryRef the query reference the response belongs to
-     * @param response the current results, or null if the cache has none to serve
-     * @param renderer builds the component showing a set of results
+     * @param markupId     the markup ID for the component
+     * @param queryRef     the query reference the response belongs to
+     * @param response     the current results, or null if the cache has none to serve
+     * @param loadingTitle the view's title, shown beside the spinner while waiting for a
+     *                     first result; null for views that carry no title
+     * @param renderer     builds the component showing a set of results
      * @return the component to show
      */
-    public static Component create(String markupId, QueryRef queryRef, ApiResponse response, ApiResultRenderer renderer) {
+    public static Component create(String markupId, QueryRef queryRef, ApiResponse response, String loadingTitle, ApiResultRenderer renderer) {
         if (response != null) {
             return renderer.render(markupId, response);
         }
@@ -50,12 +76,14 @@ public abstract class ApiResultComponent extends ResultComponent {
         if (staleResponse != null) {
             return new RefreshingResultPanel(markupId, queryRef, staleResponse, renderer);
         }
-        return new ApiResultComponent(markupId, queryRef) {
+        ApiResultComponent comp = new ApiResultComponent(markupId, queryRef) {
             @Override
             public Component getApiResultComponent(String id, ApiResponse r) {
                 return renderer.render(id, r);
             }
         };
+        comp.setLoadingTitle(loadingTitle);
+        return comp;
     }
 
     /**

--- a/src/main/java/com/knowledgepixels/nanodash/component/ApiResultComponent.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/ApiResultComponent.java
@@ -31,6 +31,34 @@ public abstract class ApiResultComponent extends ResultComponent {
     }
 
     /**
+     * Builds the component for a query's results in whichever state its cache is in: the
+     * results themselves when they are current, the previous ones plus a spinner while a
+     * refresh runs (see {@link RefreshingResultPanel}), and only a spinner when nothing is
+     * cached yet. The returned component is the one to style and add, whichever state it is.
+     *
+     * @param markupId the markup ID for the component
+     * @param queryRef the query reference the response belongs to
+     * @param response the current results, or null if the cache has none to serve
+     * @param renderer builds the component showing a set of results
+     * @return the component to show
+     */
+    public static Component create(String markupId, QueryRef queryRef, ApiResponse response, ApiResultRenderer renderer) {
+        if (response != null) {
+            return renderer.render(markupId, response);
+        }
+        ApiResponse staleResponse = ApiCache.retrieveStaleResponse(queryRef);
+        if (staleResponse != null) {
+            return new RefreshingResultPanel(markupId, queryRef, staleResponse, renderer);
+        }
+        return new ApiResultComponent(markupId, queryRef) {
+            @Override
+            public Component getApiResultComponent(String id, ApiResponse r) {
+                return renderer.render(id, r);
+            }
+        };
+    }
+
+    /**
      * {@inheritDoc}
      */
     private static final long LAZY_LOAD_TIMEOUT_MS = 60_000;

--- a/src/main/java/com/knowledgepixels/nanodash/component/ApiResultRenderer.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/ApiResultRenderer.java
@@ -1,0 +1,27 @@
+package com.knowledgepixels.nanodash.component;
+
+import org.apache.wicket.Component;
+import org.nanopub.extra.services.ApiResponse;
+
+import java.io.Serializable;
+
+/**
+ * Builds the component that shows a query's results. Passed to
+ * {@link ApiResultComponent#create(String, org.nanopub.extra.services.QueryRef, ApiResponse, ApiResultRenderer)}
+ * so the same rendering code serves all three states a view display can be in: results
+ * that are current, outdated results shown while a refresh runs (see
+ * {@link RefreshingResultPanel}), and nothing cached yet.
+ * <p>
+ * Implementations become part of the page tree and must be serializable — the builders
+ * implement them as lambdas over their own (serializable) fields.
+ */
+public interface ApiResultRenderer extends Serializable {
+
+    /**
+     * @param markupId the Wicket markup id the created component must use
+     * @param response the query results to render
+     * @return the component showing those results
+     */
+    Component render(String markupId, ApiResponse response);
+
+}

--- a/src/main/java/com/knowledgepixels/nanodash/component/LazyContentPanel.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/LazyContentPanel.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html xmlns:wicket="http://wicket.apache.org">
+<body>
+
+<!-- As in ResultComponent: a container rather than an element, so a tab body that arrived
+     over Ajax sits in the page exactly where the directly rendered one does. -->
+<wicket:panel><wicket:container wicket:id="content"></wicket:container></wicket:panel>
+
+</body>
+</html>

--- a/src/main/java/com/knowledgepixels/nanodash/component/LazyContentPanel.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/LazyContentPanel.java
@@ -80,7 +80,7 @@ public class LazyContentPanel extends AjaxLazyLoadPanel<Component> {
      */
     @Override
     public Component getLoadingComponent(String id) {
-        return new Label(id, "<div class=\"row-section\"><div class=\"col-12\">" + ResultComponent.getWaitIconHtml() + "</div></div>").setEscapeModelStrings(false);
+        return new Label(id, ResultComponent.getSectionWaitHtml()).setEscapeModelStrings(false);
     }
 
 }

--- a/src/main/java/com/knowledgepixels/nanodash/component/LoadingResultPanel.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/LoadingResultPanel.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html xmlns:wicket="http://wicket.apache.org">
+
+<head>
+  <link rel="stylesheet" href="../../../../../webapp/style.css?for-local-testing-only" type="text/css" media="screen"
+        title="Stylesheet"/>
+</head>
+<body style="margin-left: auto; margin-right: auto; max-width: 1420px">
+
+<wicket:panel>
+  <div class="paneltitlerow listpanel">
+    <h4 wicket:id="label">Title</h4>
+    <span class="refresh-spinner" title="Loading..."></span>
+  </div>
+</wicket:panel>
+
+</body>
+
+</html>

--- a/src/main/java/com/knowledgepixels/nanodash/component/LoadingResultPanel.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/LoadingResultPanel.java
@@ -1,15 +1,14 @@
 package com.knowledgepixels.nanodash.component;
 
-import org.apache.wicket.markup.ComponentTag;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.panel.Panel;
 
 /**
  * The loading state of a view display whose results are not there yet: the view's title
- * with the spinner beside it, in the same gutter position {@link RefreshingResultPanel}
- * uses for a refresh. So a view that is loading for the first time and one that is being
- * brought up to date look alike, and the page's section titles are in place from the first
- * paint instead of appearing only once the queries return.
+ * with the spinner beside it, in the same place {@link RefreshingResultPanel} shows one for
+ * a refresh. So a view that is loading for the first time and one that is being brought up
+ * to date look alike, and the page's section titles are in place from the first paint
+ * instead of appearing only once the queries return.
  */
 public class LoadingResultPanel extends Panel {
 
@@ -21,17 +20,6 @@ public class LoadingResultPanel extends Panel {
     public LoadingResultPanel(String id, String title) {
         super(id);
         add(new Label("label", title));
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    protected void onComponentTag(ComponentTag tag) {
-        super.onComponentTag(tag);
-        // Marks the panel as updating, so the client-side indicator in nanodash.js leaves it
-        // alone rather than adding a second spinner.
-        tag.append("class", "view-refreshing", " ");
     }
 
 }

--- a/src/main/java/com/knowledgepixels/nanodash/component/LoadingResultPanel.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/LoadingResultPanel.java
@@ -1,0 +1,37 @@
+package com.knowledgepixels.nanodash.component;
+
+import org.apache.wicket.markup.ComponentTag;
+import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.panel.Panel;
+
+/**
+ * The loading state of a view display whose results are not there yet: the view's title
+ * with the spinner beside it, in the same gutter position {@link RefreshingResultPanel}
+ * uses for a refresh. So a view that is loading for the first time and one that is being
+ * brought up to date look alike, and the page's section titles are in place from the first
+ * paint instead of appearing only once the queries return.
+ */
+public class LoadingResultPanel extends Panel {
+
+    /**
+     * @param id    the Wicket markup id
+     * @param title the view's title (not null or blank — without one there is nothing for
+     *              the spinner to sit beside, and callers should show the bare icon)
+     */
+    public LoadingResultPanel(String id, String title) {
+        super(id);
+        add(new Label("label", title));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void onComponentTag(ComponentTag tag) {
+        super.onComponentTag(tag);
+        // Marks the panel as updating, so the client-side indicator in nanodash.js leaves it
+        // alone rather than adding a second spinner.
+        tag.append("class", "view-refreshing", " ");
+    }
+
+}

--- a/src/main/java/com/knowledgepixels/nanodash/component/PublishForm.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/PublishForm.html
@@ -140,7 +140,7 @@ I understand that published data cannot be fully removed (only retracted or supe
 </p>
 
 <p wicket:id="button-section" class="center">
-<input type="submit" class="button" value="Publish" onclick="this.value='Publishing\u2026'; this.disabled=true; this.form.submit();" />
+<button type="submit" class="button" onclick="return startPublishing(this);">Publish</button>
 <button wicket:id="preview-button" type="submit" class="button light">Preview</button>
 </p>
 

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultItemList.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultItemList.html
@@ -10,6 +10,7 @@
 <wicket:panel>
   <div class="paneltitlerow listpanel">
     <h4 wicket:id="label">Query</h4>
+    <span wicket:id="refresh-indicator" class="refresh-spinner" title="Updating..."></span>
     <input type="text" wicket:id="filter" class="panelfilter" placeholder="Filter..."/>
     <span class="buttons"><wicket:container wicket:id="np">[np]</wicket:container></span>
     <span wicket:id="buttons" class="buttons"></span>

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultItemListBuilder.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultItemListBuilder.java
@@ -71,7 +71,7 @@ public class QueryResultItemListBuilder implements Serializable {
 
     public Component build() {
         ApiResponse response = ApiCache.retrieveResponseAsync(queryRef);
-        Component comp = ApiResultComponent.create(markupId, queryRef, response, this::buildItemList);
+        Component comp = ApiResultComponent.create(markupId, queryRef, response, viewDisplay.getTitle(), this::buildItemList);
         comp.add(new AttributeAppender("class", " col-" + viewDisplay.getDisplayWidth()));
         return comp;
     }

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultItemListBuilder.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultItemListBuilder.java
@@ -71,21 +71,9 @@ public class QueryResultItemListBuilder implements Serializable {
 
     public Component build() {
         ApiResponse response = ApiCache.retrieveResponseAsync(queryRef);
-        String colClass = " col-" + viewDisplay.getDisplayWidth();
-        if (response != null) {
-            Component result = buildItemList(markupId, response);
-            result.add(new AttributeAppender("class", colClass));
-            return result;
-        } else {
-            ApiResultComponent comp = new ApiResultComponent(markupId, queryRef) {
-                @Override
-                public Component getApiResultComponent(String id, ApiResponse r) {
-                    return buildItemList(id, r);
-                }
-            };
-            comp.add(new AttributeAppender("class", colClass));
-            return comp;
-        }
+        Component comp = ApiResultComponent.create(markupId, queryRef, response, this::buildItemList);
+        comp.add(new AttributeAppender("class", " col-" + viewDisplay.getDisplayWidth()));
+        return comp;
     }
 
     private QueryResultItemList buildItemList(String markupId, ApiResponse response) {

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultList.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultList.html
@@ -10,6 +10,7 @@
 <wicket:panel>
   <div class="paneltitlerow listpanel">
     <h4 wicket:id="label">Query</h4>
+    <span wicket:id="refresh-indicator" class="refresh-spinner" title="Updating..."></span>
     <input type="text" wicket:id="filter" class="panelfilter" placeholder="Filter..."/>
     <span class="buttons"><wicket:container wicket:id="np">[np]</wicket:container></span>
     <span wicket:id="buttons" class="buttons"></span>

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultListBuilder.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultListBuilder.java
@@ -110,7 +110,7 @@ public class QueryResultListBuilder implements Serializable {
      */
     public Component build() {
         ApiResponse response = ApiCache.retrieveResponseAsync(queryRef);
-        Component comp = ApiResultComponent.create(markupId, queryRef, response, this::buildList);
+        Component comp = ApiResultComponent.create(markupId, queryRef, response, viewDisplay.getTitle(), this::buildList);
         comp.add(new AttributeAppender("class", " col-" + viewDisplay.getDisplayWidth()));
         return comp;
     }

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultListBuilder.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultListBuilder.java
@@ -110,150 +110,74 @@ public class QueryResultListBuilder implements Serializable {
      */
     public Component build() {
         ApiResponse response = ApiCache.retrieveResponseAsync(queryRef);
-        String colClass = " col-" + viewDisplay.getDisplayWidth();
-        if (resourceWithProfile != null) {
-            if (response != null) {
-                QueryResultList resultList = new QueryResultList(markupId, queryRef, response, viewDisplay);
-                resultList.setResourceWithProfile(resourceWithProfile);
-                resultList.setPageResource(pageResource);
-                resultList.setContextId(contextId);
-                resultList.setPostPublishTab(postPublishTab);
-                resultList.setRefRoot(refRoot);
-                View view = viewDisplay.getView();
-                if (view != null) {
-                    for (IRI actionIri : view.getViewResultActionList()) {
-                        if (!SpaceMemberRole.isViewerEntitled(view.getActionVisibleTo(actionIri), resourceWithProfile, refRoot)) continue;
-                        Template t = view.getTemplateForAction(actionIri);
-                        if (t == null) continue;
-                        String targetField = view.getTemplateTargetFieldForAction(actionIri);
-                        if (targetField == null) targetField = "resource";
-                        String label = view.getLabelForAction(actionIri);
-                        if (label == null) label = "action...";
-                        if (!label.endsWith("...")) label += "...";
-                        PageParameters params = new PageParameters().set("template", t.getId())
-                                .set("param_" + targetField, id)
-                                .set("context", contextId)
-                                .set("template-version", "latest");
-                        if (id != null && contextId != null && !id.equals(contextId)) {
-                            params.set("part", id);
-                        }
-                        String partField = view.getTemplatePartFieldForAction(actionIri);
-                        if (partField != null && contextId != null) {
-                            // The part field pre-fills a namespaced child IRI (the user fills the suffix).
-                            // TODO Find a better way to pass the MaintainedResource object to this method:
-                            MaintainedResource r = MaintainedResourceRepository.get().findById(contextId);
-                            String namespace = null;
-                            if (r != null) {
-                                namespace = r.getNamespace();
-                            } else if (resourceWithProfile instanceof Space) {
-                                // The Space-creation templates' `space` placeholder has a fixed
-                                // `https://w3id.org/spaces/` prefix, so the pre-fill is relative to it.
-                                // Nesting the new space's IRI under this space's path makes it a
-                                // sub-space via the prefix match.
-                                namespace = contextId.replaceFirst("https://w3id.org/spaces/", "") + "/";
-                            }
-                            if (namespace != null) {
-                                params.set("param_" + partField, namespace + "<SET-SUFFIX>");
-                            }
-                        }
-                        String queryMapping = view.getTemplateQueryMapping(actionIri);
-                        if (queryMapping != null && queryMapping.contains(":")) {
-                            params.set("values-from-query", queryRef.getAsUrlString());
-                            params.set("values-from-query-mapping", queryMapping);
-                        }
-                        params.set("refresh-upon-publish", queryRef.getAsUrlString());
-                        if (postPublishTab != null) params.set("postpub-tab", postPublishTab);
-                        resultList.addButton(label, PublishPage.class, params);
+        Component comp = ApiResultComponent.create(markupId, queryRef, response, this::buildList);
+        comp.add(new AttributeAppender("class", " col-" + viewDisplay.getDisplayWidth()));
+        return comp;
+    }
+
+    private QueryResultList buildList(String markupId, ApiResponse response) {
+        if (resourceWithProfile == null) {
+            QueryResultList resultList = new QueryResultList(markupId, queryRef, response, viewDisplay);
+            resultList.setPageResource(pageResource);
+            resultList.setContextId(contextId);
+            ViewActionMappings.addResultActions(resultList, viewDisplay, queryRef, id, contextId, null, refRoot);
+            return resultList;
+        }
+        QueryResultList resultList = new QueryResultList(markupId, queryRef, response, viewDisplay);
+        resultList.setResourceWithProfile(resourceWithProfile);
+        resultList.setPageResource(pageResource);
+        resultList.setContextId(contextId);
+        resultList.setPostPublishTab(postPublishTab);
+        resultList.setRefRoot(refRoot);
+        View view = viewDisplay.getView();
+        if (view != null) {
+            for (IRI actionIri : view.getViewResultActionList()) {
+                if (!SpaceMemberRole.isViewerEntitled(view.getActionVisibleTo(actionIri), resourceWithProfile, refRoot)) continue;
+                Template t = view.getTemplateForAction(actionIri);
+                if (t == null) continue;
+                String targetField = view.getTemplateTargetFieldForAction(actionIri);
+                if (targetField == null) targetField = "resource";
+                String label = view.getLabelForAction(actionIri);
+                if (label == null) label = "action...";
+                if (!label.endsWith("...")) label += "...";
+                PageParameters params = new PageParameters().set("template", t.getId())
+                        .set("param_" + targetField, id)
+                        .set("context", contextId)
+                        .set("template-version", "latest");
+                if (id != null && contextId != null && !id.equals(contextId)) {
+                    params.set("part", id);
+                }
+                String partField = view.getTemplatePartFieldForAction(actionIri);
+                if (partField != null && contextId != null) {
+                    // The part field pre-fills a namespaced child IRI (the user fills the suffix).
+                    // TODO Find a better way to pass the MaintainedResource object to this method:
+                    MaintainedResource r = MaintainedResourceRepository.get().findById(contextId);
+                    String namespace = null;
+                    if (r != null) {
+                        namespace = r.getNamespace();
+                    } else if (resourceWithProfile instanceof Space) {
+                        // The Space-creation templates' `space` placeholder has a fixed
+                        // `https://w3id.org/spaces/` prefix, so the pre-fill is relative to it.
+                        // Nesting the new space's IRI under this space's path makes it a
+                        // sub-space via the prefix match.
+                        namespace = contextId.replaceFirst("https://w3id.org/spaces/", "") + "/";
+                    }
+                    if (namespace != null) {
+                        params.set("param_" + partField, namespace + "<SET-SUFFIX>");
                     }
                 }
-                resultList.add(new AttributeAppender("class", colClass));
-                return resultList;
-            } else {
-                ApiResultComponent comp = new ApiResultComponent(markupId, queryRef) {
-                    @Override
-                    public Component getApiResultComponent(String markupId, ApiResponse response) {
-                        QueryResultList resultList = new QueryResultList(markupId, queryRef, response, viewDisplay);
-                        resultList.setResourceWithProfile(resourceWithProfile);
-                        resultList.setPageResource(pageResource);
-                        resultList.setContextId(contextId);
-                        resultList.setPostPublishTab(postPublishTab);
-                        resultList.setRefRoot(refRoot);
-                        View view = viewDisplay.getView();
-                        if (view != null) {
-                            for (IRI actionIri : view.getViewResultActionList()) {
-                                if (!SpaceMemberRole.isViewerEntitled(view.getActionVisibleTo(actionIri), resourceWithProfile, refRoot)) continue;
-                                Template t = view.getTemplateForAction(actionIri);
-                                if (t == null) continue;
-                                String targetField = view.getTemplateTargetFieldForAction(actionIri);
-                                if (targetField == null) targetField = "resource";
-                                String label = view.getLabelForAction(actionIri);
-                                if (label == null) label = "action...";
-                                if (!label.endsWith("...")) label += "...";
-                                PageParameters params = new PageParameters().set("template", t.getId())
-                                        .set("param_" + targetField, id)
-                                        .set("context", contextId)
-                                        .set("template-version", "latest");
-                                if (id != null && contextId != null && !id.equals(contextId)) {
-                                    params.set("part", id);
-                                }
-                                String partField = view.getTemplatePartFieldForAction(actionIri);
-                                if (partField != null && contextId != null) {
-                                    // The part field pre-fills a namespaced child IRI (the user fills the suffix).
-                                    // TODO Find a better way to pass the MaintainedResource object to this method:
-                                    MaintainedResource r = MaintainedResourceRepository.get().findById(contextId);
-                                    String namespace = null;
-                                    if (r != null) {
-                                        namespace = r.getNamespace();
-                                    } else if (resourceWithProfile instanceof Space) {
-                                        // The Space-creation templates' `space` placeholder has a fixed
-                                        // `https://w3id.org/spaces/` prefix, so the pre-fill is relative to it.
-                                        // Nesting the new space's IRI under this space's path makes it a
-                                        // sub-space via the prefix match.
-                                        namespace = contextId.replaceFirst("https://w3id.org/spaces/", "") + "/";
-                                    }
-                                    if (namespace != null) {
-                                        params.set("param_" + partField, namespace + "<SET-SUFFIX>");
-                                    }
-                                }
-                                String queryMapping = view.getTemplateQueryMapping(actionIri);
-                                if (queryMapping != null && queryMapping.contains(":")) {
-                                    params.set("values-from-query", queryRef.getAsUrlString());
-                                    params.set("values-from-query-mapping", queryMapping);
-                                }
-                                params.set("refresh-upon-publish", queryRef.getAsUrlString());
-                                if (postPublishTab != null) params.set("postpub-tab", postPublishTab);
-                                resultList.addButton(label, PublishPage.class, params);
-                            }
-                        }
-                        return resultList;
-                    }
-                };
-                comp.add(new AttributeAppender("class", colClass));
-                return comp;
-            }
-        } else {
-            if (response != null) {
-                QueryResultList resultList = new QueryResultList(markupId, queryRef, response, viewDisplay);
-                resultList.setPageResource(pageResource);
-                resultList.setContextId(contextId);
-                ViewActionMappings.addResultActions(resultList, viewDisplay, queryRef, id, contextId, null, refRoot);
-                resultList.add(new AttributeAppender("class", colClass));
-                return resultList;
-            } else {
-                ApiResultComponent comp = new ApiResultComponent(markupId, queryRef) {
-                    @Override
-                    public Component getApiResultComponent(String markupId, ApiResponse response) {
-                        QueryResultList resultList = new QueryResultList(markupId, queryRef, response, viewDisplay);
-                        resultList.setPageResource(pageResource);
-                        resultList.setContextId(contextId);
-                        ViewActionMappings.addResultActions(resultList, viewDisplay, queryRef, id, contextId, null, refRoot);
-                        return resultList;
-                    }
-                };
-                comp.add(new AttributeAppender("class", colClass));
-                return comp;
+                String queryMapping = view.getTemplateQueryMapping(actionIri);
+                if (queryMapping != null && queryMapping.contains(":")) {
+                    params.set("values-from-query", queryRef.getAsUrlString());
+                    params.set("values-from-query-mapping", queryMapping);
+                }
+                params.set("refresh-upon-publish", queryRef.getAsUrlString());
+                if (postPublishTab != null) params.set("postpub-tab", postPublishTab);
+                resultList.addButton(label, PublishPage.class, params);
             }
         }
+        return resultList;
     }
+
 
 }

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultNanopubSet.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultNanopubSet.html
@@ -5,6 +5,7 @@
 <wicket:panel>
   <div class="paneltitlerow listpanel">
     <h4 wicket:id="title">[View Title]</h4>
+    <span wicket:id="refresh-indicator" class="refresh-spinner" title="Updating..."></span>
     <div wicket:id="viewSelector" class="view-selector with-source">
       <input type="text" wicket:id="filter" placeholder="Filter..." style="margin: 2px 10px; padding: 2px 5px; font-size: 12px; width: 150px;"/>
       <span class="buttons">

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultNanopubSetBuilder.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultNanopubSetBuilder.java
@@ -107,22 +107,11 @@ public class QueryResultNanopubSetBuilder implements Serializable {
      */
     public Component build() {
         ApiResponse response = ApiCache.retrieveResponseAsync(queryRef);
-        String colClass = " col-" + viewDisplay.getDisplayWidth();
         long resolvedItemsPerPage = itemsPerPage != null ? itemsPerPage : viewDisplay.getPageSize();
-        if (response != null) {
-            QueryResultNanopubSet queryResultNanopubSet = buildNanopubSet(markupId, response, resolvedItemsPerPage);
-            queryResultNanopubSet.add(new AttributeAppender("class", colClass));
-            return queryResultNanopubSet;
-        } else {
-            ApiResultComponent comp = new ApiResultComponent(markupId, queryRef) {
-                @Override
-                public Component getApiResultComponent(String markupId, ApiResponse response) {
-                    return buildNanopubSet(markupId, response, resolvedItemsPerPage);
-                }
-            };
-            comp.add(new AttributeAppender("class", colClass));
-            return comp;
-        }
+        Component comp = ApiResultComponent.create(markupId, queryRef, response,
+                (id, r) -> buildNanopubSet(id, r, resolvedItemsPerPage));
+        comp.add(new AttributeAppender("class", " col-" + viewDisplay.getDisplayWidth()));
+        return comp;
     }
 
     private QueryResultNanopubSet buildNanopubSet(String markupId, ApiResponse response, long resolvedItemsPerPage) {

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultNanopubSetBuilder.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultNanopubSetBuilder.java
@@ -108,7 +108,7 @@ public class QueryResultNanopubSetBuilder implements Serializable {
     public Component build() {
         ApiResponse response = ApiCache.retrieveResponseAsync(queryRef);
         long resolvedItemsPerPage = itemsPerPage != null ? itemsPerPage : viewDisplay.getPageSize();
-        Component comp = ApiResultComponent.create(markupId, queryRef, response,
+        Component comp = ApiResultComponent.create(markupId, queryRef, response, hasTitle ? viewDisplay.getTitle() : null,
                 (id, r) -> buildNanopubSet(id, r, resolvedItemsPerPage));
         comp.add(new AttributeAppender("class", " col-" + viewDisplay.getDisplayWidth()));
         return comp;

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultPlainParagraph.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultPlainParagraph.html
@@ -10,6 +10,7 @@
 <wicket:panel>
   <div class="paneltitlerow listpanel">
     <h4 wicket:id="label">Paragraph</h4>
+    <span wicket:id="refresh-indicator" class="refresh-spinner" title="Updating..."></span>
     <input type="text" wicket:id="filter" class="panelfilter" placeholder="Filter..."/>
     <span class="buttons"><wicket:container wicket:id="np">[np]</wicket:container></span>
     <span wicket:id="buttons" class="buttons"></span>

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultPlainParagraphBuilder.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultPlainParagraphBuilder.java
@@ -135,54 +135,18 @@ public class QueryResultPlainParagraphBuilder implements Serializable {
      */
     public Component build() {
         ApiResponse response = ApiCache.retrieveResponseAsync(queryRef);
-        String colClass = " col-" + viewDisplay.getDisplayWidth();
-        if (space != null) {
-            if (response != null) {
-                QueryResultPlainParagraph resultPlainParagraph = new QueryResultPlainParagraph(markupId, queryRef, response, viewDisplay);
-                resultPlainParagraph.setResourceWithProfile(space);
-                resultPlainParagraph.setPageResource(pageResource);
-                resultPlainParagraph.setContextId(contextId);
-                addResultButtons(resultPlainParagraph);
-                resultPlainParagraph.add(new AttributeAppender("class", colClass));
-                return resultPlainParagraph;
-            } else {
-                ApiResultComponent comp = new ApiResultComponent(markupId, queryRef) {
-                    @Override
-                    public Component getApiResultComponent(String markupId, ApiResponse response) {
-                        QueryResultPlainParagraph resultPlainParagraph = new QueryResultPlainParagraph(markupId, queryRef, response, viewDisplay);
-                        resultPlainParagraph.setResourceWithProfile(space);
-                        resultPlainParagraph.setPageResource(pageResource);
-                        resultPlainParagraph.setContextId(contextId);
-                        addResultButtons(resultPlainParagraph);
-                        return resultPlainParagraph;
-                    }
-                };
-                comp.add(new AttributeAppender("class", colClass));
-                return comp;
-            }
-        } else {
-            if (response != null) {
-                QueryResultPlainParagraph resultPlainParagraph = new QueryResultPlainParagraph(markupId, queryRef, response, viewDisplay);
-                resultPlainParagraph.setPageResource(pageResource);
-                resultPlainParagraph.setContextId(contextId);
-                addResultButtons(resultPlainParagraph);
-                resultPlainParagraph.add(new AttributeAppender("class", colClass));
-                return resultPlainParagraph;
-            } else {
-                ApiResultComponent comp = new ApiResultComponent(markupId, queryRef) {
-                    @Override
-                    public Component getApiResultComponent(String markupId, ApiResponse response) {
-                        QueryResultPlainParagraph resultPlainParagraph = new QueryResultPlainParagraph(markupId, queryRef, response, viewDisplay);
-                        resultPlainParagraph.setPageResource(pageResource);
-                        resultPlainParagraph.setContextId(contextId);
-                        addResultButtons(resultPlainParagraph);
-                        return resultPlainParagraph;
-                    }
-                };
-                comp.add(new AttributeAppender("class", colClass));
-                return comp;
-            }
-        }
+        Component comp = ApiResultComponent.create(markupId, queryRef, response, this::buildPlainParagraph);
+        comp.add(new AttributeAppender("class", " col-" + viewDisplay.getDisplayWidth()));
+        return comp;
+    }
+
+    private QueryResultPlainParagraph buildPlainParagraph(String markupId, ApiResponse response) {
+        QueryResultPlainParagraph resultPlainParagraph = new QueryResultPlainParagraph(markupId, queryRef, response, viewDisplay);
+        if (space != null) resultPlainParagraph.setResourceWithProfile(space);
+        resultPlainParagraph.setPageResource(pageResource);
+        resultPlainParagraph.setContextId(contextId);
+        addResultButtons(resultPlainParagraph);
+        return resultPlainParagraph;
     }
 
 }

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultPlainParagraphBuilder.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultPlainParagraphBuilder.java
@@ -135,7 +135,7 @@ public class QueryResultPlainParagraphBuilder implements Serializable {
      */
     public Component build() {
         ApiResponse response = ApiCache.retrieveResponseAsync(queryRef);
-        Component comp = ApiResultComponent.create(markupId, queryRef, response, this::buildPlainParagraph);
+        Component comp = ApiResultComponent.create(markupId, queryRef, response, viewDisplay.getTitle(), this::buildPlainParagraph);
         comp.add(new AttributeAppender("class", " col-" + viewDisplay.getDisplayWidth()));
         return comp;
     }

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultSvg.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultSvg.html
@@ -10,6 +10,7 @@
 <wicket:panel>
   <div class="paneltitlerow listpanel">
     <h4 wicket:id="label">SVG</h4>
+    <span wicket:id="refresh-indicator" class="refresh-spinner" title="Updating..."></span>
     <span class="buttons"><wicket:container wicket:id="np">[np]</wicket:container></span>
     <span wicket:id="buttons" class="buttons"></span>
   </div>

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultSvgBuilder.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultSvgBuilder.java
@@ -130,28 +130,17 @@ public class QueryResultSvgBuilder implements Serializable {
      */
     public Component build() {
         ApiResponse response = ApiCache.retrieveResponseAsync(queryRef);
-        String colClass = " col-" + viewDisplay.getDisplayWidth();
-        if (response != null) {
-            QueryResultSvg resultSvg = new QueryResultSvg(markupId, queryRef, response, viewDisplay);
-            resultSvg.setPageResource(pageResource);
-            resultSvg.setContextId(contextId);
-            addResultButtons(resultSvg);
-            resultSvg.add(new AttributeAppender("class", colClass));
-            return resultSvg;
-        } else {
-            ApiResultComponent comp = new ApiResultComponent(markupId, queryRef) {
-                @Override
-                public Component getApiResultComponent(String markupId, ApiResponse response) {
-                    QueryResultSvg resultSvg = new QueryResultSvg(markupId, queryRef, response, viewDisplay);
-                    resultSvg.setPageResource(pageResource);
-                    resultSvg.setContextId(contextId);
-                    addResultButtons(resultSvg);
-                    return resultSvg;
-                }
-            };
-            comp.add(new AttributeAppender("class", colClass));
-            return comp;
-        }
+        Component comp = ApiResultComponent.create(markupId, queryRef, response, this::buildSvg);
+        comp.add(new AttributeAppender("class", " col-" + viewDisplay.getDisplayWidth()));
+        return comp;
+    }
+
+    private QueryResultSvg buildSvg(String markupId, ApiResponse response) {
+        QueryResultSvg resultSvg = new QueryResultSvg(markupId, queryRef, response, viewDisplay);
+        resultSvg.setPageResource(pageResource);
+        resultSvg.setContextId(contextId);
+        addResultButtons(resultSvg);
+        return resultSvg;
     }
 
 }

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultSvgBuilder.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultSvgBuilder.java
@@ -130,7 +130,7 @@ public class QueryResultSvgBuilder implements Serializable {
      */
     public Component build() {
         ApiResponse response = ApiCache.retrieveResponseAsync(queryRef);
-        Component comp = ApiResultComponent.create(markupId, queryRef, response, this::buildSvg);
+        Component comp = ApiResultComponent.create(markupId, queryRef, response, viewDisplay.getTitle(), this::buildSvg);
         comp.add(new AttributeAppender("class", " col-" + viewDisplay.getDisplayWidth()));
         return comp;
     }

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultTable.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultTable.html
@@ -10,6 +10,7 @@
 <wicket:panel>
   <div class="paneltitlerow tablepanel">
     <h4 wicket:id="label">Query</h4>
+    <span wicket:id="refresh-indicator" class="refresh-spinner" title="Updating..."></span>
     <input type="text" wicket:id="filter" class="panelfilter" placeholder="Filter..."/>
     <span class="buttons"><wicket:container wicket:id="np">[np]</wicket:container></span>
     <span wicket:id="buttons" class="buttons"></span>

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultTableBuilder.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultTableBuilder.java
@@ -121,7 +121,11 @@ public class QueryResultTableBuilder implements Serializable {
      */
     public Component build() {
         ApiResponse response = ApiCache.retrieveResponseAsync(queryRef);
-        Component comp = ApiResultComponent.create(markupId, queryRef, response, this::buildTable);
+        // A plain table (the standalone rendering) drops the title, so the loading state
+        // must not promise one that the loaded table then takes away.
+        boolean showsTitle = resourceWithProfile != null || !plain;
+        Component comp = ApiResultComponent.create(markupId, queryRef, response,
+                showsTitle ? viewDisplay.getTitle() : null, this::buildTable);
         comp.add(new AttributeAppender("class", " col-" + viewDisplay.getDisplayWidth()));
         return comp;
     }

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultTableBuilder.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultTableBuilder.java
@@ -121,66 +121,28 @@ public class QueryResultTableBuilder implements Serializable {
      */
     public Component build() {
         ApiResponse response = ApiCache.retrieveResponseAsync(queryRef);
-        String colClass = " col-" + viewDisplay.getDisplayWidth();
-        if (resourceWithProfile != null) {
-            if (response != null) {
-                QueryResultTable table = new QueryResultTable(markupId, queryRef, response, viewDisplay, false);
-                table.setContextId(contextId);
-                table.setPostPublishTab(postPublishTab);
-                table.setRefRoot(refRoot);
-                if (id != null && contextId != null && !id.equals(contextId)) {
-                    table.setPartId(id);
-                }
-                table.setResourceWithProfile(resourceWithProfile);
-                table.setPageResource(resourceWithProfile);
-                ViewActionMappings.addResultActions(table, viewDisplay, queryRef, id, contextId, resourceWithProfile, refRoot);
-                table.add(new AttributeAppender("class", colClass));
-                return table;
-            } else {
-                ApiResultComponent comp = new ApiResultComponent(markupId, queryRef) {
-                    @Override
-                    public Component getApiResultComponent(String markupId, ApiResponse response) {
-                        QueryResultTable table = new QueryResultTable(markupId, queryRef, response, viewDisplay, false);
-                        table.setContextId(contextId);
-                        table.setPostPublishTab(postPublishTab);
-                        table.setRefRoot(refRoot);
-                        if (id != null && contextId != null && !id.equals(contextId)) {
-                            table.setPartId(id);
-                        }
-                        table.setResourceWithProfile(resourceWithProfile);
-                        table.setPageResource(resourceWithProfile);
-                        ViewActionMappings.addResultActions(table, viewDisplay, queryRef, id, contextId, resourceWithProfile, refRoot);
-                        return table;
-                    }
-                };
-                comp.add(new AttributeAppender("class", colClass));
-                return comp;
+        Component comp = ApiResultComponent.create(markupId, queryRef, response, this::buildTable);
+        comp.add(new AttributeAppender("class", " col-" + viewDisplay.getDisplayWidth()));
+        return comp;
+    }
+
+    private QueryResultTable buildTable(String markupId, ApiResponse response) {
+        // A resource context brings the part id and the resource itself into the table
+        // (and rules out the plain rendering, which is for standalone tables).
+        boolean hasResource = resourceWithProfile != null;
+        QueryResultTable table = new QueryResultTable(markupId, queryRef, response, viewDisplay, hasResource ? false : plain);
+        table.setContextId(contextId);
+        table.setPostPublishTab(postPublishTab);
+        table.setRefRoot(refRoot);
+        if (hasResource) {
+            if (id != null && contextId != null && !id.equals(contextId)) {
+                table.setPartId(id);
             }
-        } else {
-            if (response != null) {
-                QueryResultTable table = new QueryResultTable(markupId, queryRef, response, viewDisplay, plain);
-                table.setContextId(contextId);
-                table.setPostPublishTab(postPublishTab);
-                table.setRefRoot(refRoot);
-                ViewActionMappings.addResultActions(table, viewDisplay, queryRef, id, contextId, resourceWithProfile, refRoot);
-                table.add(new AttributeAppender("class", colClass));
-                return table;
-            } else {
-                ApiResultComponent comp = new ApiResultComponent(markupId, queryRef) {
-                    @Override
-                    public Component getApiResultComponent(String markupId, ApiResponse response) {
-                        QueryResultTable table = new QueryResultTable(markupId, queryRef, response, viewDisplay, plain);
-                        table.setContextId(contextId);
-                        table.setPostPublishTab(postPublishTab);
-                        table.setRefRoot(refRoot);
-                        ViewActionMappings.addResultActions(table, viewDisplay, queryRef, id, contextId, resourceWithProfile, refRoot);
-                        return table;
-                    }
-                };
-                comp.add(new AttributeAppender("class", colClass));
-                return comp;
-            }
+            table.setResourceWithProfile(resourceWithProfile);
+            table.setPageResource(resourceWithProfile);
         }
+        ViewActionMappings.addResultActions(table, viewDisplay, queryRef, id, contextId, resourceWithProfile, refRoot);
+        return table;
     }
 
 }

--- a/src/main/java/com/knowledgepixels/nanodash/component/RefreshingResultPanel.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/RefreshingResultPanel.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html xmlns:wicket="http://wicket.apache.org">
+
+<head>
+  <link rel="stylesheet" href="../../../../../webapp/style.css?for-local-testing-only" type="text/css" media="screen"
+        title="Stylesheet"/>
+</head>
+<body style="margin-left: auto; margin-right: auto; max-width: 1420px">
+
+<wicket:panel>
+  <span class="refresh-spinner" wicket:id="spinner" title="Updating..."></span>
+  <div wicket:id="content">...</div>
+</wicket:panel>
+
+</body>
+
+</html>

--- a/src/main/java/com/knowledgepixels/nanodash/component/RefreshingResultPanel.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/RefreshingResultPanel.html
@@ -9,7 +9,10 @@
 
 <wicket:panel>
   <span class="refresh-spinner" wicket:id="spinner" title="Updating..."></span>
-  <div wicket:id="content">...</div>
+  <!-- A container rather than an element: the view renders exactly the markup it would
+       render without this panel around it, so wrapping a view for a refresh does not add a
+       level to the page and shift it about. -->
+  <wicket:container wicket:id="content">...</wicket:container>
 </wicket:panel>
 
 </body>

--- a/src/main/java/com/knowledgepixels/nanodash/component/RefreshingResultPanel.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/RefreshingResultPanel.java
@@ -1,6 +1,8 @@
 package com.knowledgepixels.nanodash.component;
 
 import com.knowledgepixels.nanodash.ApiCache;
+import com.knowledgepixels.nanodash.QueryResult;
+import org.apache.wicket.Component;
 import org.apache.wicket.Page;
 import org.apache.wicket.ajax.AbstractAjaxTimerBehavior;
 import org.apache.wicket.ajax.AjaxRequestTarget;
@@ -80,11 +82,26 @@ public class RefreshingResultPanel extends Panel {
         this.shownDigest = digest(staleResponse);
         this.deadline = System.currentTimeMillis() + REFRESH_TIMEOUT_MS;
         setOutputMarkupId(true);
-        add(renderer.render(CONTENT_ID, staleResponse));
+        add(showSpinnerOn(renderer.render(CONTENT_ID, staleResponse)));
+        // Fallback for content that has no title row of its own to put a spinner in. The
+        // view components all do, so this normally stays hidden.
         spinner = new WebMarkupContainer("spinner");
         spinner.setOutputMarkupPlaceholderTag(true);
+        spinner.setVisible(false);
         add(spinner);
     }
+
+    // Turns on the spinner the view shows beside its own title, and reports whether the
+    // content actually has one.
+    private Component showSpinnerOn(Component content) {
+        if (content instanceof QueryResult view) {
+            view.setRefreshing(true);
+            hasOwnIndicator = true;
+        }
+        return content;
+    }
+
+    private boolean hasOwnIndicator = false;
 
     /**
      * {@inheritDoc}
@@ -92,9 +109,20 @@ public class RefreshingResultPanel extends Panel {
     @Override
     protected void onComponentTag(ComponentTag tag) {
         super.onComponentTag(tag);
-        // Establishes the containing block the spinner is positioned against; dropped once
-        // the panel has settled and re-rendered.
+        // Marks the panel as updating, for the client-side indicator in nanodash.js (which
+        // then leaves this panel alone rather than adding a second spinner).
         if (refreshing) tag.append("class", "view-refreshing", " ");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void onConfigure() {
+        super.onConfigure();
+        // Only the fallback needs its own spinner: the view components show theirs in their
+        // title row.
+        spinner.setVisible(refreshing && !hasOwnIndicator);
     }
 
     /**
@@ -139,15 +167,21 @@ public class RefreshingResultPanel extends Panel {
         }
         refreshing = false;
         spinner.setVisible(false);
+        // The replacement renders without the spinner, since it is not refreshing anymore.
         addOrReplace(renderer.render(CONTENT_ID, fresh));
         target.add(this);
         return false;
     }
 
-    // Stops waiting without touching the content: hides the spinner (and with it the
-    // "refreshing" class on the panel) and repaints just that.
+    // Stops waiting without touching the content: turns the spinner off and repaints just
+    // that, so whatever the user is doing in the panel is left alone.
     private void settle(AjaxRequestTarget target) {
         refreshing = false;
+        Component content = get(CONTENT_ID);
+        if (content instanceof QueryResult view) {
+            view.setRefreshing(false);
+            target.add(view.getRefreshIndicator());
+        }
         spinner.setVisible(false);
         target.add(spinner);
     }

--- a/src/main/java/com/knowledgepixels/nanodash/component/RefreshingResultPanel.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/RefreshingResultPanel.java
@@ -1,0 +1,262 @@
+package com.knowledgepixels.nanodash.component;
+
+import com.knowledgepixels.nanodash.ApiCache;
+import org.apache.wicket.Page;
+import org.apache.wicket.ajax.AbstractAjaxTimerBehavior;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.markup.ComponentTag;
+import org.apache.wicket.markup.html.WebMarkupContainer;
+import org.apache.wicket.markup.html.panel.Panel;
+import org.apache.wicket.request.cycle.RequestCycle;
+import org.apache.wicket.util.visit.IVisit;
+import org.apache.wicket.util.visit.IVisitor;
+import org.nanopub.extra.services.ApiResponse;
+import org.nanopub.extra.services.ApiResponseEntry;
+import org.nanopub.extra.services.QueryRef;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Serial;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HexFormat;
+import java.util.List;
+
+/**
+ * Shows a query's previous, outdated results while a refresh for it is in flight, with a
+ * spinner next to them (issue #599). Beats the plain loading spinner whenever there is
+ * anything cached at all: a browser reload, a cache cleared after publishing, or a cached
+ * entry past its maximum age all leave the user looking at content that is merely a bit
+ * behind, so there is no reason to blank it out first.
+ * <p>
+ * When the refresh lands, the panel compares it to what is on screen and only swaps the
+ * content in if the results actually changed — an unchanged refresh just takes the spinner
+ * away, leaving whatever the user is doing in the panel (a typed filter, an open menu, the
+ * current table page) untouched.
+ * <p>
+ * Polling is done by a single {@link RefreshPollTimer} per page, in the manner of Wicket's
+ * own {@code AjaxLazyLoadPanel}: all panels on the page piggyback on it, and it stops as
+ * soon as none of them is waiting anymore.
+ */
+public class RefreshingResultPanel extends Panel {
+
+    private static final Logger logger = LoggerFactory.getLogger(RefreshingResultPanel.class);
+
+    private static final String CONTENT_ID = "content";
+
+    private static final Duration POLL_INTERVAL = Duration.ofSeconds(1);
+
+    // How long to wait for the refresh before settling on the outdated content: the same
+    // budget the cold-start spinner gets in ApiResultComponent.
+    private static final long REFRESH_TIMEOUT_MS = 60_000;
+
+    private final QueryRef queryRef;
+    private final ApiResultRenderer renderer;
+
+    // Fingerprint of the results currently on screen, to tell a refresh that changed
+    // something from one that did not. Null when it cannot be computed (RDF responses),
+    // which makes every refresh count as a change.
+    private final String shownDigest;
+
+    private final long deadline;
+    private final WebMarkupContainer spinner;
+
+    private boolean refreshing = true;
+
+    /**
+     * @param id            the Wicket markup id
+     * @param queryRef      the query being refreshed
+     * @param staleResponse the outdated results to show meanwhile (not null)
+     * @param renderer      builds the component showing a set of results
+     */
+    public RefreshingResultPanel(String id, QueryRef queryRef, ApiResponse staleResponse, ApiResultRenderer renderer) {
+        super(id);
+        this.queryRef = queryRef;
+        this.renderer = renderer;
+        this.shownDigest = digest(staleResponse);
+        this.deadline = System.currentTimeMillis() + REFRESH_TIMEOUT_MS;
+        setOutputMarkupId(true);
+        add(renderer.render(CONTENT_ID, staleResponse));
+        spinner = new WebMarkupContainer("spinner");
+        spinner.setOutputMarkupPlaceholderTag(true);
+        add(spinner);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void onComponentTag(ComponentTag tag) {
+        super.onComponentTag(tag);
+        // Establishes the containing block the spinner is positioned against; dropped once
+        // the panel has settled and re-rendered.
+        if (refreshing) tag.append("class", "view-refreshing", " ");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void onBeforeRender() {
+        super.onBeforeRender();
+        if (refreshing) {
+            RefreshPollTimer.install(getPage());
+        }
+    }
+
+    /**
+     * Checks whether this panel's refresh has landed, and acts on it. Called by the page's
+     * {@link RefreshPollTimer} once per tick.
+     *
+     * @param target the AJAX target of the polling request
+     * @return true if this panel is still waiting for its refresh
+     */
+    boolean poll(AjaxRequestTarget target) {
+        if (!refreshing) return false;
+        ApiResponse fresh;
+        try {
+            fresh = ApiCache.retrieveResponseAsync(queryRef);
+        } catch (Exception ex) {
+            // The query is failing; the outdated content is all we are going to get.
+            logger.error("Failed to refresh {}: {}", queryRef.getAsUrlString(), ex.getMessage());
+            settle(target);
+            return false;
+        }
+        if (fresh == null) {
+            if (System.currentTimeMillis() < deadline) return true;
+            logger.warn("Timed out refreshing {}; keeping the outdated content", queryRef.getAsUrlString());
+            settle(target);
+            return false;
+        }
+        if (shownDigest != null && shownDigest.equals(digest(fresh))) {
+            // Nothing changed, so nothing is worth interrupting the user for.
+            settle(target);
+            return false;
+        }
+        refreshing = false;
+        spinner.setVisible(false);
+        addOrReplace(renderer.render(CONTENT_ID, fresh));
+        target.add(this);
+        return false;
+    }
+
+    // Stops waiting without touching the content: hides the spinner (and with it the
+    // "refreshing" class on the panel) and repaints just that.
+    private void settle(AjaxRequestTarget target) {
+        refreshing = false;
+        spinner.setVisible(false);
+        target.add(spinner);
+    }
+
+    /**
+     * Fingerprints a response's contents, so two responses can be compared without keeping
+     * the older one around.
+     *
+     * @param response the response to fingerprint
+     * @return the fingerprint, or null if the response cannot be fingerprinted
+     */
+    private static String digest(ApiResponse response) {
+        if (response == null || response.isRdfResponse()) return null;
+        MessageDigest md;
+        try {
+            md = MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException ex) {
+            // SHA-256 is required of every Java platform, so this cannot happen; treating
+            // the response as unfingerprintable just means always swapping in the refresh.
+            logger.error("SHA-256 not available", ex);
+            return null;
+        }
+        if (response.getHeader() != null) {
+            for (String column : response.getHeader()) {
+                update(md, column);
+            }
+        }
+        List<ApiResponseEntry> data = response.getData();
+        if (data != null) {
+            for (ApiResponseEntry entry : data) {
+                // The keys come as a set, so fix an order before digesting them.
+                List<String> keys = new ArrayList<>(entry.getKeys());
+                Collections.sort(keys);
+                for (String key : keys) {
+                    update(md, key);
+                    update(md, entry.get(key));
+                }
+                md.update((byte) 2);
+            }
+        }
+        return HexFormat.of().formatHex(md.digest());
+    }
+
+    // Digests one value, keeping the boundary between values explicit so that neighbouring
+    // values cannot be shifted into each other without changing the digest.
+    private static void update(MessageDigest md, String value) {
+        if (value != null) md.update(value.getBytes(StandardCharsets.UTF_8));
+        md.update((byte) 1);
+    }
+
+    /**
+     * The page-wide timer polling every {@link RefreshingResultPanel} on the page, modelled
+     * on Wicket's {@code AjaxLazyLoadPanel.AjaxLazyLoadTimer}: one timer for all panels,
+     * removing itself once every panel has settled.
+     */
+    public static class RefreshPollTimer extends AbstractAjaxTimerBehavior {
+
+        @Serial
+        private static final long serialVersionUID = 1L;
+
+        /**
+         * Adds the timer to a page unless it already has one.
+         *
+         * @param page the page holding the refreshing panels
+         */
+        static void install(Page page) {
+            if (!page.getBehaviors(RefreshPollTimer.class).isEmpty()) return;
+            RefreshPollTimer timer = new RefreshPollTimer();
+            page.add(timer);
+            RequestCycle rc = RequestCycle.get();
+            if (rc != null) {
+                // Panels appearing within an AJAX response (e.g. a lazily loaded tab body)
+                // do not render the page, so the timer has to be started on the target.
+                rc.find(AjaxRequestTarget.class).ifPresent(timer::restart);
+            }
+        }
+
+        /**
+         * Constructor.
+         */
+        public RefreshPollTimer() {
+            super(POLL_INTERVAL);
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        protected void onTimer(AjaxRequestTarget target) {
+            // Collected first and polled after: polling swaps components in, and the
+            // component tree should not be rewritten while it is being walked.
+            final List<RefreshingResultPanel> panels = new ArrayList<>();
+            getComponent().getPage().visitChildren(RefreshingResultPanel.class,
+                    new IVisitor<RefreshingResultPanel, Void>() {
+                        @Override
+                        public void component(RefreshingResultPanel panel, IVisit<Void> visit) {
+                            if (panel.isVisibleInHierarchy()) panels.add(panel);
+                        }
+                    });
+            boolean pending = false;
+            for (RefreshingResultPanel panel : panels) {
+                if (panel.poll(target)) pending = true;
+            }
+            if (!pending) {
+                stop(target);
+                getComponent().remove(this);
+            }
+        }
+
+    }
+
+}

--- a/src/main/java/com/knowledgepixels/nanodash/component/ResultComponent.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/ResultComponent.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html xmlns:wicket="http://wicket.apache.org">
+<body>
+
+<!-- Wicket's own lazy-loading panel renders its content inside a div, which would put a
+     view that arrived over Ajax one level deeper in the page than the same view rendered
+     directly — and leave it there. A container instead of an element keeps the two
+     identical. The panel is repainted through its own tag, so nothing needs the div. -->
+<wicket:panel><wicket:container wicket:id="content"></wicket:container></wicket:panel>
+
+</body>
+</html>

--- a/src/main/java/com/knowledgepixels/nanodash/component/ResultComponent.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/ResultComponent.java
@@ -1,12 +1,8 @@
 package com.knowledgepixels.nanodash.component;
 
 import org.apache.wicket.Component;
-import org.apache.wicket.ajax.AbstractDefaultAjaxBehavior;
 import org.apache.wicket.extensions.ajax.markup.html.AjaxLazyLoadPanel;
 import org.apache.wicket.markup.html.basic.Label;
-import org.apache.wicket.request.IRequestHandler;
-import org.apache.wicket.request.cycle.RequestCycle;
-import org.apache.wicket.request.handler.resource.ResourceReferenceRequestHandler;
 
 /**
  * A base class for components that display results from an API call with a loading indicator.
@@ -66,18 +62,52 @@ public abstract class ResultComponent extends AjaxLazyLoadPanel<Component> {
         } else if (waitMessage != null) {
             return new Label(id, getWaitComponentHtml(waitMessage)).setEscapeModelStrings(false);
         } else {
-            return super.getLoadingComponent(id);
+            return getDefaultLoadingComponent(id);
         }
     }
 
     /**
-     * Returns the HTML for a loading icon.
+     * The loading state shown when neither a wait message nor custom markup was set: the
+     * bare spinner. Subclasses override this to show something more specific — see
+     * {@link ApiResultComponent}, which puts the view's title beside it.
+     *
+     * @param id the component id
+     * @return the component to show while waiting
+     */
+    protected Component getDefaultLoadingComponent(String id) {
+        return new Label(id, getStandaloneWaitIconHtml()).setEscapeModelStrings(false);
+    }
+
+    /**
+     * Returns the HTML for the loading icon at the size it takes when it sits next to
+     * something — a wait message, a panel title — where the neighbouring text carries the
+     * eye and the spinner only has to confirm that something is happening.
      *
      * @return a string containing the HTML for the loading icon
      */
     public static String getWaitIconHtml() {
-        IRequestHandler handler = new ResourceReferenceRequestHandler(AbstractDefaultAjaxBehavior.INDICATOR);
-        return "<img alt=\"Loading...\" src=\"" + RequestCycle.get().urlFor(handler) + "\"/>";
+        return "<span class=\"refresh-spinner\" title=\"Updating...\"></span>";
+    }
+
+    /**
+     * Returns the HTML for the loading icon when it stands alone — a whole page section or
+     * panel body with nothing in it yet. Same spinner, drawn larger, because here it is the
+     * only thing on that stretch of the page and a small one is easy to miss.
+     *
+     * @return a string containing the HTML for the loading icon
+     */
+    public static String getStandaloneWaitIconHtml() {
+        return "<span class=\"refresh-spinner standalone\" title=\"Loading...\"></span>";
+    }
+
+    /**
+     * Returns the HTML for a whole page section that is still loading, as the pages' own
+     * lazy-loading panels show it.
+     *
+     * @return a string containing the HTML for the loading section
+     */
+    public static String getSectionWaitHtml() {
+        return "<div class=\"row-section\"><div class=\"col-12\">" + getStandaloneWaitIconHtml() + "</div></div>";
     }
 
     /**
@@ -88,7 +118,7 @@ public abstract class ResultComponent extends AjaxLazyLoadPanel<Component> {
      */
     public static String getWaitComponentHtml(String waitMessage) {
         if (waitMessage == null || waitMessage.isBlank()) {
-            return "<p class=\"waiting nomessage\">" + getWaitIconHtml() + "</p>";
+            return "<p class=\"waiting nomessage\">" + getStandaloneWaitIconHtml() + "</p>";
         }
         return "<p class=\"waiting\">" + waitMessage + " " + getWaitIconHtml() + "</p>";
     }

--- a/src/main/java/com/knowledgepixels/nanodash/component/menu/ViewDisplayMenu.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/menu/ViewDisplayMenu.java
@@ -9,6 +9,7 @@ import com.knowledgepixels.nanodash.QueryResult;
 import com.knowledgepixels.nanodash.Utils;
 import com.knowledgepixels.nanodash.ViewDisplay;
 import com.knowledgepixels.nanodash.component.GuidedChoiceItem;
+import com.knowledgepixels.nanodash.component.RefreshingResultPanel;
 import com.knowledgepixels.nanodash.domain.AbstractResourceWithProfile;
 import com.knowledgepixels.nanodash.domain.IndividualAgent;
 import com.knowledgepixels.nanodash.domain.Space;
@@ -17,6 +18,11 @@ import com.knowledgepixels.nanodash.page.PublishPage;
 import com.knowledgepixels.nanodash.page.QueryPage;
 import com.knowledgepixels.nanodash.page.ViewResultsPage;
 import com.knowledgepixels.nanodash.template.TemplateData;
+import org.apache.wicket.Component;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.ajax.attributes.AjaxCallListener;
+import org.apache.wicket.ajax.attributes.AjaxRequestAttributes;
+import org.apache.wicket.ajax.markup.html.AjaxFallbackLink;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.link.BookmarkablePageLink;
 import org.apache.wicket.markup.html.link.ExternalLink;
@@ -30,6 +36,7 @@ import org.eclipse.rdf4j.model.IRI;
 import org.nanopub.extra.services.QueryRef;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * A dropdown menu panel for view displays, replacing the "^" source link.
@@ -190,12 +197,35 @@ public class ViewDisplayMenu extends BaseDisplayMenu {
         addToOwnLink.setVisible(showAddToOwn);
         addEntry("addToOwn", addToOwnLink);
 
-        Link<Void> refreshLink = new Link<>("refreshNow") {
+        // Refreshes this one view where it stands. Re-rendering the whole page would work too,
+        // but it takes the reader back to the top of it, away from the view they were looking
+        // at — and re-runs everything else on the page for a refresh they asked of one view.
+        AjaxFallbackLink<Void> refreshLink = new AjaxFallbackLink<>("refreshNow") {
             @Override
-            public void onClick() {
+            public void onClick(Optional<AjaxRequestTarget> target) {
                 ApiCache.clearCache(queryRef, 0);
-                setResponsePage(getPage().getClass(), getPage().getPageParameters());
+                QueryResult view = findParent(QueryResult.class);
+                // The view sits inside a wrapper while it is being refreshed; that wrapper is
+                // then the piece to replace, so wrappers do not nest.
+                Component replaceable = view;
+                if (view != null && view.getParent() instanceof RefreshingResultPanel) {
+                    replaceable = view.getParent();
+                }
+                Component rebuilt = (view == null ? null : view.rebuild(replaceable.getId()));
+                if (target.isEmpty() || rebuilt == null || !replaceable.getOutputMarkupId()) {
+                    // No Ajax, nothing to rebuild, or nothing in the page to replace: fall
+                    // back to re-rendering the page.
+                    setResponsePage(getPage().getClass(), getPage().getPageParameters());
+                    return;
+                }
+                // The replacement has to answer to the id the browser already has, or the
+                // Ajax response would update an element that is not there and leave the old
+                // markup — and its links, by then removed from the page — on screen.
+                rebuilt.setMarkupId(replaceable.getMarkupId());
+                replaceable.replaceWith(rebuilt);
+                target.get().add(rebuilt);
             }
+
         };
         refreshLink.setVisible(session.getUserIri() != null && queryRef != null);
         addEntry("refreshNow", refreshLink);

--- a/src/main/java/com/knowledgepixels/nanodash/component/menu/ViewDisplayMenu.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/menu/ViewDisplayMenu.java
@@ -23,6 +23,7 @@ import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.attributes.AjaxCallListener;
 import org.apache.wicket.ajax.attributes.AjaxRequestAttributes;
 import org.apache.wicket.ajax.markup.html.AjaxFallbackLink;
+import org.apache.wicket.extensions.ajax.markup.html.AjaxLazyLoadPanel;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.link.BookmarkablePageLink;
 import org.apache.wicket.markup.html.link.ExternalLink;
@@ -205,11 +206,18 @@ public class ViewDisplayMenu extends BaseDisplayMenu {
             public void onClick(Optional<AjaxRequestTarget> target) {
                 ApiCache.clearCache(queryRef, 0);
                 QueryResult view = findParent(QueryResult.class);
-                // The view sits inside a wrapper while it is being refreshed; that wrapper is
-                // then the piece to replace, so wrappers do not nest.
+                // A view is not always what stands in the page: while it waits for its first
+                // results it is inside Wicket's lazy-loading panel, and while it is being
+                // brought up to date inside a RefreshingResultPanel. Either way the wrapper
+                // is the piece that has to be replaced — replacing what is inside it would
+                // leave the wrapper around it and address an element the browser does not
+                // have, so nothing would change on screen and the markup left behind would
+                // keep linking to components that are no longer there.
                 Component replaceable = view;
-                if (view != null && view.getParent() instanceof RefreshingResultPanel) {
-                    replaceable = view.getParent();
+                while (replaceable != null && "content".equals(replaceable.getId())
+                        && (replaceable.getParent() instanceof RefreshingResultPanel
+                            || replaceable.getParent() instanceof AjaxLazyLoadPanel)) {
+                    replaceable = replaceable.getParent();
                 }
                 Component rebuilt = (view == null ? null : view.rebuild(replaceable.getId()));
                 if (target.isEmpty() || rebuilt == null || !replaceable.getOutputMarkupId()) {

--- a/src/main/java/com/knowledgepixels/nanodash/domain/UserData.java
+++ b/src/main/java/com/knowledgepixels/nanodash/domain/UserData.java
@@ -58,7 +58,7 @@ public class UserData implements Serializable {
         // TODO Make nanopublication setting configurable:
         NanopubSetting setting;
         if (pref.getSettingUri() != null) {
-            setting = new NanopubSetting(GetNanopub.get(pref.getSettingUri()));
+            setting = new NanopubSetting(GetNanopub.get(pref.getSettingUri(), Utils.getRegistryHttpClient()));
         } else {
             try {
                 setting = NanopubSetting.getLocalSetting();
@@ -69,7 +69,7 @@ public class UserData implements Serializable {
         String settingId = setting.getNanopub().getUri().stringValue();
         if (setting.getUpdateStrategy().equals(NPX.UPDATES_BY_CREATOR)) {
             settingId = QueryApiAccess.getLatestVersionId(settingId);
-            setting = new NanopubSetting(GetNanopub.get(settingId));
+            setting = new NanopubSetting(GetNanopub.get(settingId, Utils.getRegistryHttpClient()));
         }
         logger.info("Using nanopublication setting: {}", settingId);
 

--- a/src/main/java/com/knowledgepixels/nanodash/page/HomePage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/HomePage.java
@@ -156,7 +156,7 @@ public class HomePage extends NanodashPage {
 
             @Override
             public Component getLoadingComponent(String id) {
-                return new Label(id, "<div class=\"row-section\"><div class=\"col-12\">" + ResultComponent.getWaitIconHtml() + "</div></div>").setEscapeModelStrings(false);
+                return new Label(id, ResultComponent.getSectionWaitHtml()).setEscapeModelStrings(false);
             }
 
             @Override

--- a/src/main/java/com/knowledgepixels/nanodash/page/HomePage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/HomePage.java
@@ -4,6 +4,7 @@ import com.knowledgepixels.nanodash.NanodashPreferences;
 import com.knowledgepixels.nanodash.NanodashSession;
 import com.knowledgepixels.nanodash.Utils;
 import com.knowledgepixels.nanodash.WicketApplication;
+import com.knowledgepixels.nanodash.component.LazyContentPanel;
 import com.knowledgepixels.nanodash.component.ResultComponent;
 import com.knowledgepixels.nanodash.component.TitleBar;
 import com.knowledgepixels.nanodash.component.ViewList;
@@ -131,18 +132,15 @@ public class HomePage extends NanodashPage {
             }
         };
 
-        add(new AjaxLazyLoadPanel<Component>("views") {
-
-            @Override
-            public Component getLazyLoadComponent(String markupId) {
-                MaintainedResource r = homeResourceModel.getObject();
-                if (r == null) {
-                    return new Label(markupId, notFoundHtml).setEscapeModelStrings(false);
-                }
-                ViewList viewList = new ViewList(markupId, r);
-                viewList.setPageFooter(new Fragment("page-footer", "homeFooterFragment", HomePage.this));
-                return viewList;
+        add(new LazyContentPanel("views", markupId -> {
+            MaintainedResource r = homeResourceModel.getObject();
+            if (r == null) {
+                return new Label(markupId, notFoundHtml).setEscapeModelStrings(false);
             }
+            ViewList viewList = new ViewList(markupId, r);
+            viewList.setPageFooter(new Fragment("page-footer", "homeFooterFragment", HomePage.this));
+            return viewList;
+        }) {
 
             @Override
             protected boolean isContentReady() {

--- a/src/main/java/com/knowledgepixels/nanodash/page/MaintainedResourcePage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/MaintainedResourcePage.java
@@ -117,12 +117,7 @@ public class MaintainedResourcePage extends NanodashPage {
                 generalInfoView.setOutputMarkupPlaceholderTag(true);
                 contentContainer.add(generalInfoView);
 
-                contentContainer.add(new AjaxLazyLoadPanel<Component>("views") {
-
-                    @Override
-                    public Component getLazyLoadComponent(String markupId) {
-                        return new ViewList(markupId, resourceModel.getObject());
-                    }
+                contentContainer.add(new LazyContentPanel("views", markupId -> new ViewList(markupId, resourceModel.getObject())) {
 
                     @Override
                     protected boolean isContentReady() {

--- a/src/main/java/com/knowledgepixels/nanodash/page/MaintainedResourcePage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/MaintainedResourcePage.java
@@ -131,7 +131,7 @@ public class MaintainedResourcePage extends NanodashPage {
 
                     @Override
                     public Component getLoadingComponent(String id) {
-                        return new Label(id, "<div class=\"row-section\"><div class=\"col-12\">" + ResultComponent.getWaitIconHtml() + "</div></div>").setEscapeModelStrings(false);
+                        return new Label(id, ResultComponent.getSectionWaitHtml()).setEscapeModelStrings(false);
                     }
 
                     @Override

--- a/src/main/java/com/knowledgepixels/nanodash/page/MaintainedResourcePage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/MaintainedResourcePage.java
@@ -158,7 +158,7 @@ public class MaintainedResourcePage extends NanodashPage {
                 // they aren't freshly cached, which would block the initial page
                 // render; the view-id list must mirror the panel's View.get calls.
                 add(LazyContentPanel.of("otherTab", markupId -> new AboutResourcePanel(markupId, resourceModel.getObject()),
-                        AboutResourcePanel.MAINTAINED_RESOURCE_INFO_VIEW, AboutSpacePanel.PRESET_ASSIGNMENTS_VIEW, AboutSpacePanel.VIEW_DISPLAYS_VIEW));
+                        AboutResourcePanel.REQUIRED_VIEWS));
             } else if (activeTab == ResourceTabs.Tab.EXPLORE) {
                 add(LazyContentPanel.of("otherTab", markupId -> new ExplorePanel(markupId, resourceId),
                         ReferencesPage.REFERENCES_VIEW));

--- a/src/main/java/com/knowledgepixels/nanodash/page/NanodashPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/NanodashPage.java
@@ -19,6 +19,7 @@ import org.apache.wicket.markup.head.IHeaderResponse;
 import org.apache.wicket.markup.head.JavaScriptHeaderItem;
 import org.apache.wicket.markup.head.JavaScriptReferenceHeaderItem;
 import org.apache.wicket.markup.html.WebPage;
+import org.apache.wicket.protocol.http.WebApplication;
 import org.apache.wicket.request.cycle.RequestCycle;
 import org.apache.wicket.request.flow.RedirectToUrlException;
 import org.apache.wicket.request.http.WebRequest;
@@ -27,6 +28,7 @@ import org.apache.wicket.request.resource.JavaScriptResourceReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.time.Duration;
 import java.util.ResourceBundle;
 
@@ -216,6 +218,54 @@ public abstract class NanodashPage extends WebPage {
         super.onRender();
     }
 
+    // How long a stylesheet URL is reused before the file is checked again. Keeps the
+    // stat off every single render without making an edit wait noticeably to show up.
+    private static final long STYLESHEET_STAMP_TTL_MS = 5000;
+
+    private static volatile String stylesheetUrl;
+    private static volatile long stylesheetUrlStampedAt;
+
+    /**
+     * The URL to load style.css from, stamped so that a changed file is a changed URL.
+     * <p>
+     * The app version alone does not do that: it stays the same across every edit of a
+     * snapshot build (and across redeploys of the same release), while the file is served
+     * straight from the webapp directory with only a {@code Last-Modified} header — no
+     * {@code ETag}, no {@code Cache-Control}. Browsers are then free to keep serving their
+     * copy without revalidating, which is why CSS changes used to need a hard refresh.
+     * Stamping the file's own modification time into the query string makes each edit a new
+     * URL that no cache can answer from an old copy.
+     *
+     * @return the stylesheet URL including its cache-busting query string
+     */
+    private static String getStyleSheetUrl() {
+        long now = System.currentTimeMillis();
+        String url = stylesheetUrl;
+        if (url == null || now - stylesheetUrlStampedAt > STYLESHEET_STAMP_TTL_MS) {
+            String version = ResourceBundle.getBundle("nanodash").getString("nanodash.version");
+            long lastModified = getStyleSheetLastModified();
+            url = "style.css?v=" + version + (lastModified > 0 ? "-" + lastModified : "");
+            stylesheetUrl = url;
+            stylesheetUrlStampedAt = now;
+        }
+        return url;
+    }
+
+    /**
+     * @return style.css's last-modified time, or 0 when it cannot be determined (a packed
+     * war, where the file cannot change without a redeploy anyway)
+     */
+    private static long getStyleSheetLastModified() {
+        try {
+            String path = WebApplication.get().getServletContext().getRealPath("/style.css");
+            if (path == null) return 0;
+            return new File(path).lastModified();
+        } catch (Exception ex) {
+            logger.warn("Could not determine the stylesheet's modification time: {}", ex.getMessage());
+            return 0;
+        }
+    }
+
     /**
      * {@inheritDoc}
      * <p>
@@ -224,8 +274,7 @@ public abstract class NanodashPage extends WebPage {
     @Override
     public void renderHead(IHeaderResponse response) {
         super.renderHead(response);
-        String version = ResourceBundle.getBundle("nanodash").getString("nanodash.version");
-        response.render(CssHeaderItem.forUrl("style.css?v=" + version));
+        response.render(CssHeaderItem.forUrl(getStyleSheetUrl()));
         response.render(JavaScriptHeaderItem.forReference(getApplication().getJavaScriptLibrarySettings().getJQueryReference()));
         response.render(JavaScriptReferenceHeaderItem.forReference(nanodashJs));
         String umamiScriptUrl = NanodashPreferences.get().getUmamiScriptUrl();

--- a/src/main/java/com/knowledgepixels/nanodash/page/ResourcePartPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/ResourcePartPage.java
@@ -169,7 +169,7 @@ public class ResourcePartPage extends NanodashPage {
             // aren't freshly cached, which would block the initial page render; the
             // view-id list must mirror the panel's View.get calls.
             add(LazyContentPanel.of("otherTab", markupId -> new AboutPartPanel(markupId, resourceWithProfile, id, classes),
-                    AboutPartPanel.PART_INFO_VIEW, AboutResourcePanel.MAINTAINED_RESOURCE_PRESET_ASSIGNMENTS_VIEW, AboutPartPanel.PART_VIEW_DISPLAYS_VIEW));
+                    AboutPartPanel.REQUIRED_VIEWS));
         } else if (activeTab == ResourceTabs.Tab.EXPLORE) {
             contentContainer.setVisible(false);
             // The panel constructor resolves a view nanopub over the network when

--- a/src/main/java/com/knowledgepixels/nanodash/page/ResourcePartPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/ResourcePartPage.java
@@ -198,7 +198,7 @@ public class ResourcePartPage extends NanodashPage {
 
                     @Override
                     public Component getLoadingComponent(String id) {
-                        return new Label(id, "<div class=\"row-section\"><div class=\"col-12\">" + ResultComponent.getWaitIconHtml() + "</div></div>").setEscapeModelStrings(false);
+                        return new Label(id, ResultComponent.getSectionWaitHtml()).setEscapeModelStrings(false);
                     }
 
                 });

--- a/src/main/java/com/knowledgepixels/nanodash/page/ResourcePartPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/ResourcePartPage.java
@@ -184,12 +184,7 @@ public class ResourcePartPage extends NanodashPage {
             if (resourceWithProfile.isDataInitialized()) {
                 contentContainer.add(new ViewList("views", resourceWithProfile, id, nanopubRef, classes));
             } else {
-                contentContainer.add(new AjaxLazyLoadPanel<Component>("views") {
-
-                    @Override
-                    public Component getLazyLoadComponent(String markupId) {
-                        return new ViewList(markupId, resourceWithProfile, id, nanopubRef, classes);
-                    }
+                contentContainer.add(new LazyContentPanel("views", markupId -> new ViewList(markupId, resourceWithProfile, id, nanopubRef, classes)) {
 
                     @Override
                     protected boolean isContentReady() {

--- a/src/main/java/com/knowledgepixels/nanodash/page/SpacePage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/SpacePage.java
@@ -203,7 +203,7 @@ public class SpacePage extends NanodashPage {
 
                 @Override
                 public Component getLoadingComponent(String id) {
-                    return new Label(id, "<div class=\"row-section\"><div class=\"col-12\">" + ResultComponent.getWaitIconHtml() + "</div></div>").setEscapeModelStrings(false);
+                    return new Label(id, ResultComponent.getSectionWaitHtml()).setEscapeModelStrings(false);
                 }
 
                 @Override

--- a/src/main/java/com/knowledgepixels/nanodash/page/SpacePage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/SpacePage.java
@@ -144,8 +144,7 @@ public class SpacePage extends NanodashPage {
                 // they aren't freshly cached, which would block the initial page
                 // render; the view-id list must mirror the panel's View.get calls.
                 add(LazyContentPanel.of("otherTab", markupId -> new AboutSpacePanel(markupId, spaceModel.getObject(), effectiveRoot),
-                        AboutSpacePanel.SPACE_INFO_VIEW, AboutSpacePanel.PRESET_ASSIGNMENTS_VIEW, AboutSpacePanel.SPACE_ROLES_VIEW, AboutSpacePanel.VIEW_DISPLAYS_VIEW,
-                        AboutSpacePanel.MEMBERS_VIEW, AboutSpacePanel.OBSERVERS_VIEW));
+                        AboutSpacePanel.REQUIRED_VIEWS));
             } else if (activeTab == ResourceTabs.Tab.EXPLORE) {
                 add(LazyContentPanel.of("otherTab", markupId -> new ExplorePanel(markupId, spaceId),
                         ReferencesPage.REFERENCES_VIEW));

--- a/src/main/java/com/knowledgepixels/nanodash/page/SpacePage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/SpacePage.java
@@ -188,12 +188,7 @@ public class SpacePage extends NanodashPage {
             generalInfoView.setOutputMarkupPlaceholderTag(true);
             contentContainer.add(generalInfoView);
 
-            contentContainer.add(new AjaxLazyLoadPanel<Component>("views") {
-
-                @Override
-                public Component getLazyLoadComponent(String markupId) {
-                    return new ViewList(markupId, spaceModel.getObject());
-                }
+            contentContainer.add(new LazyContentPanel("views", markupId -> new ViewList(markupId, spaceModel.getObject())) {
 
                 @Override
                 protected boolean isContentReady() {

--- a/src/main/java/com/knowledgepixels/nanodash/page/UserPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/UserPage.java
@@ -202,12 +202,7 @@ public class UserPage extends NanodashPage {
                 latestNanopubsView.setOutputMarkupPlaceholderTag(true);
                 contentContainer.add(latestNanopubsView);
 
-                contentContainer.add(new AjaxLazyLoadPanel<Component>("views") {
-
-                    @Override
-                    public Component getLazyLoadComponent(String markupId) {
-                        return new ViewList(markupId, individualAgent);
-                    }
+                contentContainer.add(new LazyContentPanel("views", markupId -> new ViewList(markupId, individualAgent)) {
 
                     @Override
                     protected boolean isContentReady() {

--- a/src/main/java/com/knowledgepixels/nanodash/page/UserPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/UserPage.java
@@ -166,8 +166,7 @@ public class UserPage extends NanodashPage {
                 // they aren't freshly cached, which would block the initial page
                 // render; the view-id list must mirror the panel's View.get calls.
                 add(LazyContentPanel.of("otherTab", markupId -> new AboutUserPanel(markupId, userIriString),
-                        AboutUserPanel.INTRODUCTIONS_VIEW, AboutUserPanel.PROFILE_VIEW,
-                        AboutSpacePanel.PRESET_ASSIGNMENTS_VIEW, AboutSpacePanel.VIEW_DISPLAYS_VIEW));
+                        AboutUserPanel.REQUIRED_VIEWS));
             } else if (activeTab == ResourceTabs.Tab.EXPLORE) {
                 add(LazyContentPanel.of("otherTab", markupId -> new ExplorePanel(markupId, userIriString),
                         ReferencesPage.REFERENCES_VIEW));

--- a/src/main/java/com/knowledgepixels/nanodash/page/UserPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/UserPage.java
@@ -217,7 +217,7 @@ public class UserPage extends NanodashPage {
 
                     @Override
                     public Component getLoadingComponent(String id) {
-                        return new Label(id, "<div class=\"row-section\"><div class=\"col-12\">" + ResultComponent.getWaitIconHtml() + "</div></div>").setEscapeModelStrings(false);
+                        return new Label(id, ResultComponent.getSectionWaitHtml()).setEscapeModelStrings(false);
                     }
 
                     @Override

--- a/src/main/java/com/knowledgepixels/nanodash/script/nanodash.js
+++ b/src/main/java/com/knowledgepixels/nanodash/script/nanodash.js
@@ -146,6 +146,29 @@ function scrollToAnchor() {
 });
 window.addEventListener("hashchange", startAnchorTracking);
 
+/* Publishing takes a moment — the nanopublication is signed and sent to the registry — and
+   the form is submitted the plain way, so the page stays as it is until the server answers.
+   The button says what is going on for that while, and stops taking clicks: a second one
+   would submit the form again and publish twice. Returns false so the click itself does not
+   submit on top of the submit below. */
+function startPublishing(button) {
+  if (button.disabled) return false;
+  var form = button.form;
+  button.textContent = "Publishing";
+  button.insertBefore(makeSpinner(), button.firstChild);
+  button.classList.add("publishing");
+  // Every button of the form, so the preview button cannot be used to leave mid-publish.
+  form.querySelectorAll("button, input[type=submit]").forEach(function (b) { b.disabled = true; });
+  form.submit();
+  return false;
+}
+
+function makeSpinner() {
+  var spinner = document.createElement("span");
+  spinner.className = "refresh-spinner";
+  return spinner;
+}
+
 /* The client-side half of the "an update is happening" indicator. Ajax updates started
    from inside a view panel — filtering, paging, sorting — get the same spinner in the
    panel's left gutter that the server puts there while a view loads or refreshes
@@ -187,8 +210,7 @@ function showUpdateSpinner(panel) {
   var titleRow = panel.querySelector(".paneltitlerow");
   var title = titleRow ? titleRow.querySelector("h4") : null;
   if (!titleRow) return;
-  var spinner = document.createElement("span");
-  spinner.className = "refresh-spinner";
+  var spinner = makeSpinner();
   spinner.title = "Updating...";
   panel.classList.add("view-refreshing");
   titleRow.insertBefore(spinner, title ? title.nextSibling : titleRow.firstChild);

--- a/src/main/java/com/knowledgepixels/nanodash/script/nanodash.js
+++ b/src/main/java/com/knowledgepixels/nanodash/script/nanodash.js
@@ -146,12 +146,108 @@ function scrollToAnchor() {
 });
 window.addEventListener("hashchange", startAnchorTracking);
 
+/* The client-side half of the "an update is happening" indicator. Ajax updates started
+   from inside a view panel — filtering, paging, sorting — get the same spinner in the
+   panel's left gutter that the server puts there while a view loads or refreshes
+   (LoadingResultPanel / RefreshingResultPanel), so every kind of update looks alike.
+   Shown only after a delay: these round trips normally take tens of milliseconds, and a
+   spinner flashing on every keystroke would be worse than none. */
+var UPDATE_SPINNER_DELAY_MS = 250;
+/* Backstop for a call that never reports completion, so a spinner cannot get stuck. */
+var UPDATE_SPINNER_MAX_MS = 30000;
+var updatingPanels = new Map();
+
+function isVisible(el) {
+  return !!(el.offsetWidth || el.offsetHeight || el.getClientRects().length);
+}
+
+/* The view panel an Ajax call was triggered from, or null for calls that belong to no
+   single panel — the page-wide lazy-load and refresh-poll timers among them, which is
+   why they never light up every panel on the page. */
+function findUpdatingPanel(attributes) {
+  var id = attributes && attributes.c;
+  if (!id || typeof id !== "string") return null;
+  var el = document.getElementById(id);
+  if (!el) return null;
+  var panel = el.closest('[class*="col-"]');
+  // A view panel is a column with a title row; anything else (a page-level column, a
+  // form) is left alone, since the gutter position is meaningless there.
+  return panel && panel.querySelector(".paneltitlerow") ? panel : null;
+}
+
+function showUpdateSpinner(panel) {
+  var state = updatingPanels.get(panel);
+  if (!state || state.spinner || !panel.isConnected) return;
+  // A spinner the server already put there (the view is loading or refreshing) says the
+  // same thing; a second one would only be noise, and removing it later is not ours to do.
+  var existing = panel.querySelector(".refresh-spinner");
+  if (existing && isVisible(existing)) return;
+  // Right after the title, where the view's own spinner goes; the title row's layout keeps
+  // it clear of the title icon and of the filter and menu on the right.
+  var titleRow = panel.querySelector(".paneltitlerow");
+  var title = titleRow ? titleRow.querySelector("h4") : null;
+  if (!titleRow) return;
+  var spinner = document.createElement("span");
+  spinner.className = "refresh-spinner";
+  spinner.title = "Updating...";
+  panel.classList.add("view-refreshing");
+  titleRow.insertBefore(spinner, title ? title.nextSibling : titleRow.firstChild);
+  state.spinner = spinner;
+}
+
+function hideUpdateSpinner(panel) {
+  var state = updatingPanels.get(panel);
+  updatingPanels.delete(panel);
+  if (!state) return;
+  if (state.showTimer) clearTimeout(state.showTimer);
+  if (state.maxTimer) clearTimeout(state.maxTimer);
+  if (!state.spinner) return;
+  state.spinner.remove();
+  // Only ours to take back: the class may equally have come from the server-rendered
+  // loading state, which removes it itself.
+  if (!panel.querySelector(".refresh-spinner")) {
+    panel.classList.remove("view-refreshing");
+  }
+}
+
+function onUpdateStart(panel) {
+  var state = updatingPanels.get(panel);
+  if (state) {
+    state.count++;
+    return;
+  }
+  state = {count: 1, spinner: null, showTimer: null, maxTimer: null};
+  updatingPanels.set(panel, state);
+  state.showTimer = setTimeout(function () { showUpdateSpinner(panel); }, UPDATE_SPINNER_DELAY_MS);
+  state.maxTimer = setTimeout(function () { hideUpdateSpinner(panel); }, UPDATE_SPINNER_MAX_MS);
+}
+
+function onUpdateEnd(panel) {
+  var state = updatingPanels.get(panel);
+  if (!state) return;
+  state.count--;
+  if (state.count <= 0) hideUpdateSpinner(panel);
+}
+
+function trackAjaxUpdates() {
+  if (typeof Wicket === "undefined" || !Wicket.Event) return;
+  Wicket.Event.subscribe("/ajax/call/before", function (jqEvent, attributes) {
+    var panel = findUpdatingPanel(attributes);
+    if (panel) onUpdateStart(panel);
+  });
+  Wicket.Event.subscribe("/ajax/call/complete", function (jqEvent, attributes) {
+    var panel = findUpdatingPanel(attributes);
+    if (panel) onUpdateEnd(panel);
+  });
+}
+
 document.addEventListener("DOMContentLoaded", function() {
   wrapLeadingEmoji();
   wrapCellEmoji();
   renderFriendlyDates();
   addSectionAnchors();
   startAnchorTracking();
+  trackAjaxUpdates();
   // Re-run after Wicket AJAX calls complete (dynamically loaded content)
   if (typeof Wicket !== "undefined" && Wicket.Event) {
     Wicket.Event.subscribe("/ajax/call/complete", function() {

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -2432,6 +2432,15 @@ p.waiting {
   flex: 0 1 auto;
 }
 
+/* With the spinner there, its auto right margin is what pushes the rest of the row to the
+   end. The auto left margins that normally do that job have to give way: two auto margins
+   share the free space between them, which would strand the filter field halfway across the
+   row for as long as the spinner shows. */
+.paneltitlerow:has(> .refresh-spinner) > span.buttons,
+.paneltitlerow:not(:has(> h4)):has(> .refresh-spinner) > input.panelfilter {
+  margin-left: 0;
+}
+
 /* Standing on its own — a whole page section or panel body with nothing in it yet — the
    same spinner is drawn larger: there is no title or message beside it to carry the eye,
    and none of the gutter's width limit applies. */

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -2388,6 +2388,40 @@ p.waiting {
   padding: 15px;
 }
 
+/* Views whose results are outdated show them right away with this small spinner beside
+   them until the refresh lands (issue #599). It sits in the column's left padding, level
+   with the panel title, so it neither displaces nor covers any of the content; the
+   "view-refreshing" class on the column is what it is positioned against, and both are
+   gone once the panel has settled. */
+.view-refreshing {
+  position: relative;
+}
+
+.refresh-spinner {
+  position: absolute;
+  left: 3px;
+  top: 30px;
+  width: 11px;
+  height: 11px;
+  border: 2px solid #ddd;
+  border-top-color: #888;
+  border-radius: 50%;
+  animation: refresh-spin 0.9s linear infinite;
+  pointer-events: none;
+}
+
+@keyframes refresh-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .refresh-spinner {
+    animation-duration: 3s;
+  }
+}
+
 span.usertext {
   background: #ffb;
   padding: 3px;

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -2384,23 +2384,17 @@ p.waiting {
   color: #ccc;
 }
 
-.listview img:not(.user-icon):not(.bot-icon) { /* for wait icon */
+.listview img:not(.user-icon):not(.bot-icon) {
   padding: 15px;
 }
 
-/* Views whose results are outdated show them right away with this small spinner beside
-   them until the refresh lands (issue #599). It sits in the column's left padding, level
-   with the panel title, so it neither displaces nor covers any of the content; the
-   "view-refreshing" class on the column is what it is positioned against, and both are
-   gone once the panel has settled. */
-.view-refreshing {
-  position: relative;
-}
-
+/* The one indicator for "an update is happening", used for every such state: a view
+   waiting for its first results, outdated results being re-queried (issue #599), and any
+   Ajax update inside a view panel (filtering, paging, sorting — see nanodash.js). Keeping
+   a single icon means the user learns one shape rather than three. */
 .refresh-spinner {
-  position: absolute;
-  left: 3px;
-  top: 30px;
+  display: inline-block;
+  box-sizing: border-box;
   width: 11px;
   height: 11px;
   border: 2px solid #ddd;
@@ -2408,6 +2402,44 @@ p.waiting {
   border-radius: 50%;
   animation: refresh-spin 0.9s linear infinite;
   pointer-events: none;
+  vertical-align: middle;
+}
+
+/* Its place on a view panel: in the title row, right after the title. Earlier attempts put
+   it in the column's 15px left padding, but nothing big enough to notice fits there without
+   getting close to the title's leading icon — and how close that looks depends on the emoji
+   font's own side bearings. In the row it takes part in the layout instead of hovering over
+   it, so it cannot collide with anything at any size.
+
+   The auto right margin is what keeps the row from moving when it appears: the title stops
+   growing to fill the row and the spinner absorbs that space instead, so the title stays
+   where it is and the filter field and menu stay where they are. */
+.paneltitlerow > .refresh-spinner {
+  width: 16px;
+  height: 16px;
+  border-width: 2px;
+  margin-left: 10px;
+  margin-right: auto;
+  /* Level with the title's text and icon rather than with the row, which reaches lower
+     because of the filter field and the menu: the title's own 22px top margin plus half
+     the difference in height between it and the spinner. */
+  align-self: flex-start;
+  margin-top: 25px;
+  flex: none;
+}
+
+.paneltitlerow:has(> .refresh-spinner) > h4 {
+  flex: 0 1 auto;
+}
+
+/* Standing on its own — a whole page section or panel body with nothing in it yet — the
+   same spinner is drawn larger: there is no title or message beside it to carry the eye,
+   and none of the gutter's width limit applies. */
+.refresh-spinner.standalone {
+  width: 22px;
+  height: 22px;
+  border-width: 3px;
+  margin: 15px 4px;
 }
 
 @keyframes refresh-spin {

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -787,6 +787,39 @@ span.prelink {
   border: 1px solid #0B73DA;
 }
 
+/* A button that has been pressed and is now waiting on the server — publishing, which
+   signs the nanopublication and sends it to the registry. Grey and no longer a pointer,
+   since it does not take another click, with the same spinner the rest of the app uses
+   for "this is happening" sitting inside it. */
+.button.publishing,
+.button:disabled {
+  background-color: #999;
+  color: #fff;
+  cursor: default;
+}
+
+/* The pointer is still on the button after the click that started it, so this has to
+   outrank the ordinary hover colour below. */
+.button.publishing:hover,
+.button:disabled:hover {
+  background-color: #999;
+}
+
+/* A secondary button stays secondary when it is disabled: an outline that has gone grey,
+   rather than the solid grey of the button actually doing something. */
+.button.light:disabled,
+.button.light:disabled:hover {
+  background-color: transparent;
+  color: #999;
+  border-color: #999;
+}
+
+.button.publishing > .refresh-spinner {
+  border-color: rgba(255, 255, 255, 0.4);
+  border-top-color: #fff;
+  margin-right: 8px;
+}
+
 .button.big {
   /* Same height as a regular/.light button (matching vertical padding + a
      transparent border to offset .light's 1px border); stands out via the solid

--- a/src/test/java/com/knowledgepixels/nanodash/ApiCacheTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/ApiCacheTest.java
@@ -14,6 +14,7 @@ import org.nanopub.extra.services.QueryRef;
 import com.google.common.cache.Cache;
 
 import java.lang.reflect.Field;
+import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -34,6 +35,7 @@ class ApiCacheTest {
         resetMap("lastRefresh");
         resetMap("refreshStart");
         resetMap("runAfter");
+        resetMap("forcedRefresh");
 
         lenient().when(mockQueryRef.getAsUrlString()).thenReturn(MOCK_CACHE_ID);
     }
@@ -46,7 +48,16 @@ class ApiCacheTest {
             cache.invalidateAll();
         } else if (obj instanceof ConcurrentMap<?, ?> map) {
             map.clear();
+        } else if (obj instanceof Set<?> set) {
+            set.clear();
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Set<String> getSet(String fieldName) throws Exception {
+        Field f = ApiCache.class.getDeclaredField(fieldName);
+        f.setAccessible(true);
+        return (Set<String>) f.get(null);
     }
 
     @SuppressWarnings("unchecked")
@@ -176,18 +187,65 @@ class ApiCacheTest {
     }
 
     @Test
-    @DisplayName("clearCache should remove cached response for the given QueryRef")
-    void clearCacheRemovesCachedResponse() throws Exception {
+    @DisplayName("clearCache should mark the cached response as outdated, keeping it for the stale-content display")
+    void clearCacheMarksCachedResponseAsOutdated() throws Exception {
         ApiResponse mockResponse = mock(ApiResponse.class);
         ConcurrentMap<String, ApiResponse> cachedResponses = getMap("cachedResponses");
         cachedResponses.put(MOCK_CACHE_ID, mockResponse);
 
-        assertTrue(cachedResponses.containsKey(MOCK_CACHE_ID));
+        ApiCache.clearCache(mockQueryRef, 1000L);
 
-        final long waitTime = 1000L;
-        ApiCache.clearCache(mockQueryRef, waitTime);
+        assertTrue(getSet("forcedRefresh").contains(MOCK_CACHE_ID));
+        assertSame(mockResponse, ApiCache.retrieveStaleResponse(mockQueryRef));
+    }
 
-        assertFalse(cachedResponses.containsKey(MOCK_CACHE_ID));
+    @Test
+    @DisplayName("retrieveStaleResponse should return the cached response however outdated, and null when nothing is cached")
+    void retrieveStaleResponseReturnsAnyCachedResponse() throws Exception {
+        assertNull(ApiCache.retrieveStaleResponse(mockQueryRef));
+
+        ApiResponse cached = mock(ApiResponse.class);
+        putCachedResponse(cached, 48 * 60 * 60 * 1000L);
+
+        assertSame(cached, ApiCache.retrieveStaleResponse(mockQueryRef));
+    }
+
+    @Test
+    @DisplayName("retrieveResponseSync should re-fetch a cache marked by clearCache instead of serving the kept response")
+    void retrieveResponseSync_refreshesResponseMarkedByClearCache() throws Exception {
+        ApiResponse stale = mock(ApiResponse.class);
+        ApiResponse fresh = mock(ApiResponse.class);
+        // Young enough to be served without the marking.
+        putCachedResponse(stale, 5000L);
+        ApiCache.clearCache(mockQueryRef, 0L);
+
+        try (MockedStatic<QueryApiAccess> queryApiAccess = mockStatic(QueryApiAccess.class)) {
+            queryApiAccess.when(() -> QueryApiAccess.get(mockQueryRef)).thenReturn(fresh);
+
+            ApiResponse result = ApiCache.retrieveResponseSync(mockQueryRef, false);
+
+            assertSame(fresh, result);
+            assertFalse(getSet("forcedRefresh").contains(MOCK_CACHE_ID), "the marking should be gone once the refresh has run");
+        }
+    }
+
+    @Test
+    @DisplayName("retrieveResponseSync should drop the clearCache marking even when the refresh fails")
+    void retrieveResponseSync_dropsMarkingWhenRefreshFails() throws Exception {
+        ApiResponse stale = mock(ApiResponse.class);
+        putCachedResponse(stale, 5000L);
+        ApiCache.clearCache(mockQueryRef, 0L);
+
+        try (MockedStatic<QueryApiAccess> queryApiAccess = mockStatic(QueryApiAccess.class)) {
+            queryApiAccess.when(() -> QueryApiAccess.get(mockQueryRef)).thenThrow(new FailedApiCallException(new Exception("API call failed")));
+
+            ApiResponse result = ApiCache.retrieveResponseSync(mockQueryRef, false);
+
+            // The kept response is the outage fallback, but the marking must not survive:
+            // otherwise every later call would re-run the failing query.
+            assertSame(stale, result);
+            assertFalse(getSet("forcedRefresh").contains(MOCK_CACHE_ID));
+        }
     }
 
     @Test

--- a/src/test/java/com/knowledgepixels/nanodash/ApiCacheTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/ApiCacheTest.java
@@ -1,5 +1,7 @@
 package com.knowledgepixels.nanodash;
 
+import org.apache.wicket.ThreadContext;
+import org.apache.wicket.util.tester.WicketTester;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -226,6 +228,33 @@ class ApiCacheTest {
 
             assertSame(fresh, result);
             assertFalse(getSet("forcedRefresh").contains(MOCK_CACHE_ID), "the marking should be gone once the refresh has run");
+        }
+    }
+
+    @Test
+    @DisplayName("retrieveResponseSync should not wait out an ingest delay on a request thread")
+    void retrieveResponseSync_doesNotWaitOutIngestDelayOnRequestThread() throws Exception {
+        ApiResponse cached = mock(ApiResponse.class);
+        putCachedResponse(cached, 90000L);
+        // A refresh is already in flight, so nothing new is submitted while the test runs.
+        getMap("refreshStart").put(MOCK_CACHE_ID, System.currentTimeMillis());
+        // ...and a publication has just asked for a long pause before the next fetch.
+        ApiCache.clearCache(mockQueryRef, 60000L);
+
+        // A WicketTester binds a request cycle to this thread, which is what marks it as a
+        // thread serving a user rather than a background one.
+        WicketTester tester = new WicketTester();
+        try (MockedStatic<QueryApiAccess> queryApiAccess = mockStatic(QueryApiAccess.class)) {
+            long start = System.currentTimeMillis();
+            ApiResponse result = ApiCache.retrieveResponseSync(mockQueryRef, false);
+            long elapsed = System.currentTimeMillis() - start;
+
+            assertSame(cached, result, "the outdated response should be served straight away");
+            assertTrue(elapsed < 1000, "should not have waited for the ingest delay, but took " + elapsed + "ms");
+            queryApiAccess.verify(() -> QueryApiAccess.get(any()), never());
+        } finally {
+            tester.destroy();
+            ThreadContext.detach();
         }
     }
 

--- a/src/test/java/com/knowledgepixels/nanodash/component/AboutPanelRequiredViewsTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/component/AboutPanelRequiredViewsTest.java
@@ -1,0 +1,67 @@
+package com.knowledgepixels.nanodash.component;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * An About panel is built in a follow-up Ajax request while any of the views it resolves is
+ * still unresolved, and directly once they are all in hand. The page decides that from the
+ * panel's {@code REQUIRED_VIEWS}, so a list that does not match the panel's actual
+ * {@code View.get} calls breaks the tab in one of two ways: a view it forgot to list can
+ * block the page render, and a view listed that the panel never resolves never becomes
+ * cached, so the tab reloads over Ajax on every single visit.
+ * <p>
+ * That is not something the compiler can check, and all four pages had drifted, so it is
+ * checked here: the panel's source is read and its {@code View.get(CONSTANT)} calls are
+ * compared with what {@code REQUIRED_VIEWS} names.
+ */
+class AboutPanelRequiredViewsTest {
+
+    private static final Path SOURCE_DIR = Path.of("src/main/java/com/knowledgepixels/nanodash/component");
+
+    private static final Pattern VIEW_GET = Pattern.compile("View\\.get\\(([A-Z][A-Z0-9_]*)\\)");
+    private static final Pattern REQUIRED = Pattern.compile(
+            "REQUIRED_VIEWS\\s*=\\s*\\{(.*?)}", Pattern.DOTALL);
+
+    private void assertListsMatch(String panel) throws IOException {
+        Path source = SOURCE_DIR.resolve(panel + ".java");
+        assertTrue(Files.exists(source), "cannot find " + source.toAbsolutePath());
+        String code = Files.readString(source);
+
+        Set<String> resolved = new TreeSet<>();
+        Matcher m = VIEW_GET.matcher(code);
+        while (m.find()) resolved.add(m.group(1));
+
+        Matcher r = REQUIRED.matcher(code);
+        assertTrue(r.find(), panel + " should declare REQUIRED_VIEWS");
+        Set<String> declared = new TreeSet<>();
+        for (String entry : r.group(1).split(",")) {
+            String name = entry.trim();
+            if (!name.isEmpty()) declared.add(name);
+        }
+
+        assertEquals(resolved, declared,
+                panel + "'s REQUIRED_VIEWS must name exactly the views it resolves with View.get");
+    }
+
+    @Test
+    @DisplayName("every About panel's REQUIRED_VIEWS matches the views it actually resolves")
+    void requiredViewsMatchTheResolvedOnes() throws IOException {
+        assertListsMatch("AboutSpacePanel");
+        assertListsMatch("AboutUserPanel");
+        assertListsMatch("AboutResourcePanel");
+        assertListsMatch("AboutPartPanel");
+    }
+
+}

--- a/src/test/java/com/knowledgepixels/nanodash/component/PublishFormTemplateErrorTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/component/PublishFormTemplateErrorTest.java
@@ -97,7 +97,7 @@ class PublishFormTemplateErrorTest {
         // The default provenance and publication-info templates are loaded too, so this also
         // guards against the standard set of templates reporting errors:
         assertFalse(html.contains("based on an invalid template"), html);
-        assertTrue(html.contains("value=\"Publish\""), html);
+        assertTrue(html.contains(">Publish</button>"), html);
         assertTrue(html.contains(">Preview</button>"), html);
         assertTrue(html.contains("I understand that published data"), html);
         assertFalse(html.contains("Publishing is disabled"), html);

--- a/src/test/java/com/knowledgepixels/nanodash/component/RefreshingResultPanelTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/component/RefreshingResultPanelTest.java
@@ -148,8 +148,9 @@ class RefreshingResultPanelTest {
 
         String markup = tester.getLastResponseAsString();
         assertTrue(markup.contains("Relevant resources"), markup);
+        // Beside the title, in the title row, exactly as a loaded view shows it.
+        assertTrue(markup.contains("paneltitlerow"), markup);
         assertTrue(markup.contains("refresh-spinner"), markup);
-        assertTrue(markup.contains("view-refreshing"), markup);
     }
 
     @Test

--- a/src/test/java/com/knowledgepixels/nanodash/component/RefreshingResultPanelTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/component/RefreshingResultPanelTest.java
@@ -140,6 +140,28 @@ class RefreshingResultPanelTest {
     }
 
     @Test
+    @DisplayName("with nothing cached, the view's title is shown with the spinner beside it")
+    void coldLoadShowsTitleWithSpinner() {
+        tester.startComponentInPage(
+                ApiResultComponent.create("panel", queryRef, null, "📌 Relevant resources", RENDERER));
+
+        String markup = tester.getLastResponseAsString();
+        assertTrue(markup.contains("Relevant resources"), markup);
+        assertTrue(markup.contains("refresh-spinner"), markup);
+        assertTrue(markup.contains("view-refreshing"), markup);
+    }
+
+    @Test
+    @DisplayName("a view without a title falls back to the bare spinner, the same icon")
+    void coldLoadWithoutTitleShowsBareSpinner() {
+        tester.startComponentInPage(ApiResultComponent.create("panel", queryRef, null, null, RENDERER));
+
+        String markup = tester.getLastResponseAsString();
+        assertTrue(markup.contains("refresh-spinner"), markup);
+        assertFalse(markup.contains("paneltitlerow"), markup);
+    }
+
+    @Test
     @DisplayName("the poll timer stops once every panel has settled")
     void timerStopsWhenNothingIsWaiting() throws Exception {
         startPanel(response("alpha"));

--- a/src/test/java/com/knowledgepixels/nanodash/component/RefreshingResultPanelTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/component/RefreshingResultPanelTest.java
@@ -17,6 +17,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -159,6 +160,27 @@ class RefreshingResultPanelTest {
         String markup = tester.getLastResponseAsString();
         assertTrue(markup.contains("refresh-spinner"), markup);
         assertFalse(markup.contains("paneltitlerow"), markup);
+    }
+
+    @Test
+    @DisplayName("a view still waiting for its first results does not hold the thread")
+    void lazyLoadDoesNotBlockOnTheResponse() throws Exception {
+        // A fetch is in flight elsewhere and nothing is cached yet: the state in which the
+        // panel used to sit in a sleep loop, holding a request thread for up to a minute.
+        Field refreshStart = ApiCache.class.getDeclaredField("refreshStart");
+        refreshStart.setAccessible(true);
+        ((ConcurrentMap<String, Long>) refreshStart.get(null)).put(queryRef.getAsUrlString(), System.currentTimeMillis());
+
+        Component panel = ApiResultComponent.create("panel", queryRef, null, "A title", RENDERER);
+        tester.startComponentInPage(panel);
+
+        long start = System.currentTimeMillis();
+        assertFalse(((ApiResultComponent) panel).isContentReady(), "nothing to show yet");
+        Component built = ((ApiResultComponent) panel).getLazyLoadComponent("content");
+        long elapsed = System.currentTimeMillis() - start;
+
+        assertTrue(elapsed < 1000, "must not wait for the response, but took " + elapsed + "ms");
+        assertNotNull(built);
     }
 
     @Test

--- a/src/test/java/com/knowledgepixels/nanodash/component/RefreshingResultPanelTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/component/RefreshingResultPanelTest.java
@@ -1,0 +1,154 @@
+package com.knowledgepixels.nanodash.component;
+
+import com.google.common.cache.Cache;
+import com.knowledgepixels.nanodash.ApiCache;
+import org.apache.wicket.Component;
+import org.apache.wicket.util.tester.WicketTester;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.nanopub.extra.services.ApiResponse;
+import org.nanopub.extra.services.ApiResponseEntry;
+import org.nanopub.extra.services.QueryRef;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentMap;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Outdated results are shown right away with a spinner beside them; when the refresh lands,
+ * the content is only swapped if the results actually changed (issue #599).
+ */
+class RefreshingResultPanelTest {
+
+    private static final String QUERY_ID = "RAe-oA5eSmkCXCALZ99-0k4imnlI74KPqURfhHOmnzo6A/get-latest-nanopubs-from-pubkeys";
+
+    private WicketTester tester;
+    private QueryRef queryRef;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        tester = new WicketTester();
+        queryRef = new QueryRef(QUERY_ID);
+        clearCacheField("cachedResponses");
+        clearCacheField("lastRefresh");
+        clearCacheField("refreshStart");
+        clearCacheField("runAfter");
+        clearCacheField("failed");
+        clearCacheField("forcedRefresh");
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void clearCacheField(String fieldName) throws Exception {
+        Field f = ApiCache.class.getDeclaredField(fieldName);
+        f.setAccessible(true);
+        Object obj = f.get(null);
+        if (obj instanceof Cache<?, ?> cache) {
+            cache.invalidateAll();
+        } else if (obj instanceof ConcurrentMap<?, ?> map) {
+            map.clear();
+        } else if (obj instanceof Set<?> set) {
+            set.clear();
+        }
+    }
+
+    /** Puts a response into the cache as freshly refreshed, so no API call is made. */
+    @SuppressWarnings("unchecked")
+    private void cacheAsCurrent(ApiResponse response) throws Exception {
+        Field responses = ApiCache.class.getDeclaredField("cachedResponses");
+        responses.setAccessible(true);
+        ((Cache<String, ApiResponse>) responses.get(null)).put(queryRef.getAsUrlString(), response);
+        Field lastRefresh = ApiCache.class.getDeclaredField("lastRefresh");
+        lastRefresh.setAccessible(true);
+        ((ConcurrentMap<String, Long>) lastRefresh.get(null)).put(queryRef.getAsUrlString(), System.currentTimeMillis());
+    }
+
+    private static ApiResponse response(String... labels) {
+        ApiResponse response = new ApiResponse();
+        response.setHeader(new String[]{"label"});
+        for (String label : labels) {
+            ApiResponseEntry entry = new ApiResponseEntry();
+            entry.add("label", label);
+            response.add(entry);
+        }
+        return response;
+    }
+
+    private static final ApiResultRenderer RENDERER = (markupId, response) -> {
+        StringBuilder sb = new StringBuilder();
+        for (ApiResponseEntry entry : response.getData()) {
+            sb.append(entry.get("label")).append(" ");
+        }
+        return new org.apache.wicket.markup.html.basic.Label(markupId, sb.toString().trim());
+    };
+
+    private RefreshingResultPanel startPanel(ApiResponse staleResponse) {
+        tester.startComponentInPage(new RefreshingResultPanel("panel", queryRef, staleResponse, RENDERER));
+        return (RefreshingResultPanel) tester.getComponentFromLastRenderedPage("panel");
+    }
+
+    private void runTimer() {
+        List<RefreshingResultPanel.RefreshPollTimer> timers =
+                tester.getLastRenderedPage().getBehaviors(RefreshingResultPanel.RefreshPollTimer.class);
+        assertFalse(timers.isEmpty(), "the panel should have installed a poll timer on the page");
+        tester.executeBehavior(timers.getFirst());
+    }
+
+    @Test
+    @DisplayName("the outdated results are on the page from the first render, with the spinner beside them")
+    void outdatedResultsAreShownImmediately() {
+        startPanel(response("alpha", "beta"));
+
+        String markup = tester.getLastResponseAsString();
+        assertTrue(markup.contains("alpha beta"), markup);
+        assertTrue(markup.contains("refresh-spinner"), markup);
+        assertTrue(markup.contains("view-refreshing"), markup);
+    }
+
+    @Test
+    @DisplayName("a refresh that changed nothing takes the spinner away without touching the content")
+    void unchangedRefreshLeavesContentAlone() throws Exception {
+        RefreshingResultPanel panel = startPanel(response("alpha", "beta"));
+        Component shownContent = panel.get("content");
+
+        // Same results, different object: what a re-run of an unchanged query returns.
+        cacheAsCurrent(response("alpha", "beta"));
+        runTimer();
+
+        assertSame(shownContent, panel.get("content"), "the content component should not have been rebuilt");
+        assertFalse(panel.get("spinner").isVisible(), "the spinner should be gone");
+    }
+
+    @Test
+    @DisplayName("a refresh with changed results swaps the content in")
+    void changedRefreshSwapsInTheNewResults() throws Exception {
+        RefreshingResultPanel panel = startPanel(response("alpha", "beta"));
+        Component shownContent = panel.get("content");
+
+        cacheAsCurrent(response("alpha", "beta", "gamma"));
+        runTimer();
+
+        assertNotSame(shownContent, panel.get("content"));
+        assertTrue(panel.get("content").getDefaultModelObjectAsString().contains("gamma"));
+        assertFalse(panel.get("spinner").isVisible());
+    }
+
+    @Test
+    @DisplayName("the poll timer stops once every panel has settled")
+    void timerStopsWhenNothingIsWaiting() throws Exception {
+        startPanel(response("alpha"));
+        cacheAsCurrent(response("alpha"));
+
+        runTimer();
+
+        assertTrue(tester.getLastRenderedPage().getBehaviors(RefreshingResultPanel.RefreshPollTimer.class).isEmpty(),
+                "the timer should have removed itself");
+    }
+
+}


### PR DESCRIPTION
Closes #599.

## Problem

When a view display's cached query results were outdated, the panel blanked out to a loading spinner — the user lost sight of content that was merely a bit behind. Every view display goes through the same two-branch pattern, so this hit whenever `ApiCache.retrieveResponseAsync` returned null:

- **a browser reload**, which invalidated each of the page's query caches outright (so a warm page turned into a field of spinners for 1–3 s);
- **after publishing**, where `clearCache()` invalidated the entry;
- **entries past `MAX_CACHE_AGE_MS`**, still cached but treated as absent.

## Approach

**`ApiCache` keeps the data on a forced refresh.** A browser reload and `clearCache()` now add the cache id to a `forcedRefresh` set instead of invalidating the entry; `retrieveResponseAsync` returns null while it is set (the data is not current) and the new `retrieveStaleResponse()` hands the kept entry to the UI. The marking counts as stale for `retrieveResponseSync`, which also waits out an in-flight refresh, so repositories never memoise pre-publish data. The flag is dropped when a refresh attempt completes — success *or* failure, so a query that cannot be reached does not pin every later render to the stale path and re-submit a refresh each time. Same marking for the RDF/CONSTRUCT cache, which gains the previous model as an outage fallback.

**`RefreshingResultPanel`** renders the outdated results immediately with a small spinner in the column's left gutter, level with the panel title, and the content stays fully interactive. When the refresh lands, the panel fingerprints it (SHA-256 over header + rows) against what is on screen:

- **unchanged → no swap at all**, only the spinner goes away, so a typed filter, an open menu or the current table page survive untouched;
- changed → the content is rebuilt and repainted.

Panels share one page-wide `RefreshPollTimer`, following Wicket's own `AjaxLazyLoadPanel`/`AjaxLazyLoadTimer` idiom: it removes itself once every panel has settled, and gives up after 60 s by keeping the outdated content rather than showing a timeout message. Panels are collected before polling so the component tree is not rewritten mid-visit.

**Builder cleanup.** The three states (current / outdated / nothing cached) now go through one `ApiResultComponent.create(markupId, queryRef, response, ApiResultRenderer)` call, which removes the duplicated construction code from all six `QueryResult*Builder`s — including the two 60-line copies of the action-button block in `QueryResultListBuilder`.

## Verification

- 1063 unit tests pass. New `RefreshingResultPanelTest` covers the immediate outdated render, no-swap-when-unchanged, swap-when-changed, and timer self-removal; `ApiCacheTest` gained coverage for the new `clearCache` / stale contract (its old "removes the entry" assertion now asserts the new one).
- Driven in a local instance with forced reloads of the home, space, resource and user pages: every panel renders its content at load with a spinner (home: 14 panels, 13 refreshing, full markup) and all spinners clear within a few seconds. No 500s, no JS errors, no Wicket markup or page-store deserialization errors.

## Not covered

`ItemListPanel` and the connector pages (`GenOverviewPage`, `GenNanopubPage`, `ChannelPage`) still show a bare spinner — `ItemListPanel`'s lazy branch replaces its own filter container as a side effect, so it does not drop into the wrapper cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up: one indicator for every kind of update

Four different ways a view could be updating looked four different ways — a first load showed a spinner where the content would go, an outdated result being re-queried showed one in the column's gutter, and filtering, paging or sorting showed nothing at all.

All of them now show **the same spinner beside the view's title**, rendered as part of the title row (`QueryResult` owns it; the six view panels declare it in their markup). Being in the row's flow rather than positioned over it, it cannot collide with the title's icon at any size — earlier attempts placed it in the column's 15px left padding, where nothing big enough to notice fits without crowding the icon. Its `margin-right: auto` absorbs exactly the space the title used to grow into, so nothing moves when it appears or goes (verified: title and right-hand controls at identical x in both states), and it is aligned to the title's own box rather than to the row, which reaches lower because of the filter field and menu.

- **Waiting for first results** → the view's title with the spinner beside it (`LoadingResultPanel`), so a page's section titles are in place from the first paint instead of appearing only when queries return.
- **Filter / paging / sorting** → the same spinner, via a hook on Wicket's `/ajax/call/before` and `/ajax/call/complete` in `nanodash.js`, delayed by 250 ms: those round trips normally take tens of milliseconds, and a spinner flashing on every keystroke is worse than none. Page-level calls (the lazy-load and refresh-poll timers) light up nothing; concurrent calls share one spinner; a server-rendered spinner is never doubled; a 30 s backstop prevents a stuck one.
- **A whole page section still empty** → the same spinner drawn larger (22px), having no title beside it to carry the eye. The six page-level wait states that each built the same markup now share `ResultComponent.getSectionWaitHtml()`.

Views without a title (plain tables, `noTitle()` nanopub sets) have no title row to host it and keep the panel-level fallback.

## Also: style.css cache busting

The stylesheet was loaded as `style.css?v=<app version>` — constant across every edit of a snapshot build — while the file is served from the webapp directory with only a `Last-Modified` header (no `ETag`, no `Cache-Control`), so browsers could keep serving a stale copy without revalidating and CSS changes needed a hard refresh. The URL now carries the file's own modification time (checked at most once every 5 s, omitted when it cannot be read, as in a packed war).

## Verification

- 1065 unit tests pass; `RefreshingResultPanelTest` also covers the loading states.
- A standalone harness drives the `nanodash.js` hook against a fake Wicket event bus: 13 checks (no flash on fast calls, one spinner on slow ones, correct placement, other panels untouched, concurrent calls, page-level calls ignored, no double spinner, no JS errors).
- Measured in the running app across pages and viewport widths: every spinner clear of all panel content, and no layout shift between the settled and updating states.
