### PR TITLE
fix(explore): show "use this template..." only for full template definitions

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/page/ExplorePage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/ExplorePage.java
@@ -9,6 +9,7 @@ import com.knowledgepixels.nanodash.domain.IndividualAgent;
 import com.knowledgepixels.nanodash.domain.User;
 import com.knowledgepixels.nanodash.repository.MaintainedResourceRepository;
 import com.knowledgepixels.nanodash.repository.SpaceRepository;
+import com.knowledgepixels.nanodash.template.Template;
 import jakarta.servlet.http.HttpServletRequest;
 import net.trustyuri.TrustyUriUtils;
 import org.apache.wicket.RestartResponseException;
@@ -305,7 +306,9 @@ public class ExplorePage extends NanodashPage {
             raw.add(createAssertionLink("a-rdfxml", npUri, "rdfxml", false));
             raw.add(createAssertionLink("a-rdfxml-txt", npUri, "rdfxml", true));
             nanopubSection.add(raw);
-            if (Utils.isNanopubOfClass(np, NTEMPLATE.ASSERTION_TEMPLATE)) {
+            // The type check alone also matches nanopubs that merely introduce a resource typed as a
+            // template (e.g. the registration of a template kind), which have no form to fill in:
+            if (Utils.isNanopubOfClass(np, NTEMPLATE.ASSERTION_TEMPLATE) && Template.hasFullTemplateDefinition(np)) {
                 nanopubSection.add(new WebMarkupContainer("use-template").add(new BookmarkablePageLink<Void>("template-link", PublishPage.class,
                         NavigationContext.withContext(new PageParameters().set("template", np.getUri()), getContextId()))));
             } else {

--- a/src/main/java/com/knowledgepixels/nanodash/template/Template.java
+++ b/src/main/java/com/knowledgepixels/nanodash/template/Template.java
@@ -886,16 +886,59 @@ public class Template implements Serializable {
         return tag;
     }
 
-    private void processTemplate(Nanopub templateNp) throws MalformedTemplateException {
-        IRI assertionUri = templateNp.getAssertionUri();
+    /**
+     * Checks whether the given nanopublication contains a full template definition,
+     * i.e. whether it can serve as the source of a fill-in form. Nanopublications
+     * that merely refer to a template - most notably the registration of a template
+     * kind as a maintained resource of a space, which types the kind IRI as a
+     * template but carries no template body - do not qualify.
+     *
+     * @param np the nanopublication to check
+     * @return true if the nanopublication defines a template, false otherwise
+     */
+    public static boolean hasFullTemplateDefinition(Nanopub np) {
+        if (np == null) return false;
+        Set<IRI> templateNodes = getTemplateNodes(np);
+        IRI node;
+        if (templateNodes.contains(np.getAssertionUri())) {
+            node = np.getAssertionUri();
+        } else if (templateNodes.size() == 1) {
+            node = templateNodes.iterator().next();
+            // A template node outside the nanopub's namespace is a reference to a
+            // template defined elsewhere, not a definition (see issue #597):
+            if (!node.stringValue().startsWith(np.getUri().stringValue())) return false;
+        } else if (templateNodes.size() > 1) {
+            return false;
+        } else {
+            // Experimental SHACL-based template: the base node shape carries the definition.
+            for (Statement st : np.getAssertion()) {
+                if (st.getPredicate().equals(SHACL.TARGET_CLASS)) return true;
+            }
+            return false;
+        }
+        // A definition has a body; a bare declaration of the template node does not:
+        for (Statement st : np.getAssertion()) {
+            if (st.getSubject().equals(node) && st.getPredicate().equals(NTEMPLATE.HAS_STATEMENT)) return true;
+        }
+        return false;
+    }
+
+    // The nodes of the assertion that are typed as templates, in the order encountered.
+    private static Set<IRI> getTemplateNodes(Nanopub np) {
         Set<IRI> templateNodes = new LinkedHashSet<>();
-        for (Statement st : templateNp.getAssertion()) {
+        for (Statement st : np.getAssertion()) {
             if (!st.getPredicate().equals(RDF.TYPE)) continue;
             if (!(st.getSubject() instanceof IRI subjIri)) continue;
             if (st.getObject().equals(NTEMPLATE.ASSERTION_TEMPLATE) || st.getObject().equals(NTEMPLATE.PROVENANCE_TEMPLATE) || st.getObject().equals(NTEMPLATE.PUBINFO_TEMPLATE)) {
                 templateNodes.add(subjIri);
             }
         }
+        return templateNodes;
+    }
+
+    private void processTemplate(Nanopub templateNp) throws MalformedTemplateException {
+        IRI assertionUri = templateNp.getAssertionUri();
+        Set<IRI> templateNodes = getTemplateNodes(templateNp);
 
         if (templateNodes.contains(assertionUri)) {
             // Legacy shape (template node = assertion graph URI) takes precedence

--- a/src/test/java/com/knowledgepixels/nanodash/template/FullTemplateDefinitionTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/template/FullTemplateDefinitionTest.java
@@ -1,0 +1,144 @@
+package com.knowledgepixels.nanodash.template;
+
+import com.knowledgepixels.nanodash.Utils;
+import com.knowledgepixels.nanodash.vocabulary.KPXL_TERMS;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.DCTERMS;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.eclipse.rdf4j.model.vocabulary.SHACL;
+import org.junit.jupiter.api.Test;
+import org.nanopub.Nanopub;
+import org.nanopub.NanopubCreator;
+import org.nanopub.vocabulary.NPX;
+import org.nanopub.vocabulary.NTEMPLATE;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link Template#hasFullTemplateDefinition(Nanopub)}, which decides
+ * whether a nanopublication can be offered as a form to fill in ("use this
+ * template..."). Nanopublications that only refer to a template - in particular
+ * the registration of a template kind as a maintained resource - must not
+ * qualify, even though their type set contains {@code nt:AssertionTemplate}
+ * (see issue #597).
+ */
+public class FullTemplateDefinitionTest {
+
+    private static final ValueFactory vf = SimpleValueFactory.getInstance();
+
+    // A syntactically valid trusty URI shape (RA + 43 chars), so sub-IRIs strip correctly:
+    private static final String NP_URI = "https://w3id.org/np/RAAbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_AbCdE";
+    private static final String OTHER_NP_URI = "https://w3id.org/np/RAZyXwVuTsRqPoNmLkJiHgFeDcBa9876543210_-ZyXwV";
+    private static final IRI TEMPLATE_NODE = vf.createIRI(NP_URI + "/template");
+    private static final IRI KIND_IRI = vf.createIRI(OTHER_NP_URI + "/templateKind");
+    private static final IRI SPACE = vf.createIRI("https://w3id.org/spaces/knowledgepixels/nanodash");
+
+    private static NanopubCreator newCreator() throws Exception {
+        NanopubCreator creator = new NanopubCreator(NP_URI);
+        creator.addProvenanceStatement(vf.createStatement(creator.getAssertionUri(), RDFS.SEEALSO, creator.getAssertionUri()));
+        creator.addPubinfoStatement(vf.createStatement(creator.getNanopubUri(), RDFS.SEEALSO, creator.getNanopubUri()));
+        return creator;
+    }
+
+    private static void addTemplateBody(NanopubCreator creator, IRI templateNode) throws Exception {
+        IRI st1 = vf.createIRI(NP_URI + "/st1");
+        IRI namePlaceholder = vf.createIRI(NP_URI + "/name");
+        creator.addAssertionStatement(templateNode, RDF.TYPE, NTEMPLATE.ASSERTION_TEMPLATE);
+        creator.addAssertionStatement(templateNode, RDFS.LABEL, vf.createLiteral("Test template"));
+        creator.addAssertionStatement(templateNode, NTEMPLATE.HAS_STATEMENT, st1);
+        creator.addAssertionStatement(st1, RDF.SUBJECT, vf.createIRI("http://example.com/subject"));
+        creator.addAssertionStatement(st1, RDF.PREDICATE, RDFS.LABEL);
+        creator.addAssertionStatement(st1, RDF.OBJECT, namePlaceholder);
+        creator.addAssertionStatement(namePlaceholder, RDF.TYPE, NTEMPLATE.LITERAL_PLACEHOLDER);
+        creator.addAssertionStatement(namePlaceholder, RDFS.LABEL, vf.createLiteral("name"));
+    }
+
+    /**
+     * The shape of a template-kind registration: the kind IRI, which lives in the
+     * namespace of the nanopub that minted it, is typed as an assertion template and
+     * declared a maintained resource of a space. There is no template body here.
+     */
+    private static Nanopub kindRegistrationNanopub() throws Exception {
+        NanopubCreator creator = newCreator();
+        creator.addAssertionStatement(KIND_IRI, RDF.TYPE, KPXL_TERMS.MAINTAINED_RESOURCE);
+        creator.addAssertionStatement(KIND_IRI, RDF.TYPE, NTEMPLATE.ASSERTION_TEMPLATE);
+        creator.addAssertionStatement(KIND_IRI, RDFS.LABEL, vf.createLiteral("Commenting on Something Template"));
+        creator.addAssertionStatement(KIND_IRI, DCTERMS.DESCRIPTION, vf.createLiteral("Template for commenting on something."));
+        creator.addAssertionStatement(KIND_IRI, KPXL_TERMS.IS_MAINTAINED_BY, SPACE);
+        creator.addPubinfoStatement(vf.createStatement(creator.getNanopubUri(), NPX.INTRODUCES, KIND_IRI));
+        return creator.finalizeNanopub();
+    }
+
+    @Test
+    void legacyTemplateIsFullDefinition() throws Exception {
+        NanopubCreator creator = newCreator();
+        addTemplateBody(creator, creator.getAssertionUri());
+        assertTrue(Template.hasFullTemplateDefinition(creator.finalizeNanopub()));
+    }
+
+    @Test
+    void embeddedIdentityTemplateIsFullDefinition() throws Exception {
+        NanopubCreator creator = newCreator();
+        addTemplateBody(creator, TEMPLATE_NODE);
+        creator.addAssertionStatement(TEMPLATE_NODE, DCTERMS.IS_VERSION_OF, KIND_IRI);
+        creator.addAssertionStatement(TEMPLATE_NODE, KPXL_TERMS.GOVERNED_BY, SPACE);
+        creator.addPubinfoStatement(vf.createStatement(creator.getNanopubUri(), NPX.EMBEDS, TEMPLATE_NODE));
+        assertTrue(Template.hasFullTemplateDefinition(creator.finalizeNanopub()));
+    }
+
+    @Test
+    void kindRegistrationIsNotFullDefinition() throws Exception {
+        assertFalse(Template.hasFullTemplateDefinition(kindRegistrationNanopub()));
+    }
+
+    /**
+     * The type-based check alone is what made the button appear on kind registrations:
+     * the type of the introduced resource counts as a type of the nanopub itself.
+     */
+    @Test
+    void kindRegistrationStillCountsAsAssertionTemplateByType() throws Exception {
+        assertTrue(Utils.isNanopubOfClass(kindRegistrationNanopub(), NTEMPLATE.ASSERTION_TEMPLATE));
+    }
+
+    @Test
+    void templateNodeWithoutStatementsIsNotFullDefinition() throws Exception {
+        NanopubCreator creator = newCreator();
+        creator.addAssertionStatement(TEMPLATE_NODE, RDF.TYPE, NTEMPLATE.ASSERTION_TEMPLATE);
+        creator.addAssertionStatement(TEMPLATE_NODE, RDFS.LABEL, vf.createLiteral("Test template"));
+        assertFalse(Template.hasFullTemplateDefinition(creator.finalizeNanopub()));
+    }
+
+    @Test
+    void multipleTemplateNodesAreNotFullDefinition() throws Exception {
+        NanopubCreator creator = newCreator();
+        addTemplateBody(creator, TEMPLATE_NODE);
+        creator.addAssertionStatement(vf.createIRI(NP_URI + "/template2"), RDF.TYPE, NTEMPLATE.ASSERTION_TEMPLATE);
+        assertFalse(Template.hasFullTemplateDefinition(creator.finalizeNanopub()));
+    }
+
+    @Test
+    void plainNanopubIsNotFullDefinition() throws Exception {
+        NanopubCreator creator = newCreator();
+        creator.addAssertionStatement(vf.createIRI("http://example.com/thing"), RDFS.LABEL, vf.createLiteral("A thing"));
+        assertFalse(Template.hasFullTemplateDefinition(creator.finalizeNanopub()));
+    }
+
+    @Test
+    void shaclTemplateIsFullDefinition() throws Exception {
+        NanopubCreator creator = newCreator();
+        IRI shape = vf.createIRI(NP_URI + "/shape");
+        creator.addAssertionStatement(shape, RDF.TYPE, SHACL.NODE_SHAPE);
+        creator.addAssertionStatement(shape, SHACL.TARGET_CLASS, vf.createIRI("http://example.com/Thing"));
+        assertTrue(Template.hasFullTemplateDefinition(creator.finalizeNanopub()));
+    }
+
+    @Test
+    void nullIsNotFullDefinition() {
+        assertFalse(Template.hasFullTemplateDefinition(null));
+    }
+
+}


### PR DESCRIPTION
Closes #597

## Problem

Nanopubs that merely *register a template kind* showed a "use this template..." button on the Explore page, and following it landed on *"Error: This template could not be loaded. It might be invalid or temporarily unavailable."*

Example: https://w3id.org/np/RAiiCQE9mACzVH_GH2nUowud6193SzqKHhPn7zpBhmw6Y

```turtle
sub:assertion {
  <…/RAaqrSEat…/templateKind> a gen:MaintainedResource, nt:AssertionTemplate ;
    rdfs:label "Commenting on Something Template" ;
    gen:isMaintainedBy <…/spaces/knowledgepixels/nanodash> .
}
sub:pubinfo { this: npx:introduces <…/RAaqrSEat…/templateKind> . }
```

The button was gated on `Utils.isNanopubOfClass(np, NTEMPLATE.ASSERTION_TEMPLATE)`, i.e. on `NanopubUtils.getTypes(np)`, which folds in the types of any `npx:introduces` object — so the registration looks like a template even though it carries no template body. `Template.processTemplate` then rejects it, because the template node lives in the namespace of the nanopub that minted the kind, not of the registration, and `TemplateData.getTemplate` returns null.

## Fix

New `Template.hasFullTemplateDefinition(Nanopub)`, used alongside the existing type check. It mirrors the parser's branches — legacy (template node = assertion graph URI), embedded (exactly one typed node, which must sit in this nanopub's namespace), SHACL (`sh:targetClass`) — and additionally requires a body (at least one `nt:hasStatement` on the template node), so a bare declaration doesn't qualify. The node-collection loop is factored out of `processTemplate` into a shared static helper so the gate and the parser can't drift apart. Assertion-only, no network access.

## Tests

New `FullTemplateDefinitionTest` (9 tests): legacy and embedded templates qualify; a kind registration built to the exact shape above does not; also covered are a template node without statements, multiple typed nodes, a plain nanopub, a SHACL template, and null. One test pins *why* the extra guard is needed, by asserting the registration still counts as an assertion template by type.

Full `template` package green: 334 tests, 0 failures — including `AllAssertionTemplatesLoadingTest`, which confirms all 196 published templates still parse and would still show the button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
