### PR TITLE
fix: apply auto Local Resource treatment to introduced/embedded resources

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/template/Template.java
+++ b/src/main/java/com/knowledgepixels/nanodash/template/Template.java
@@ -975,10 +975,14 @@ public class Template implements Serializable {
         }
     }
 
-    // Local IRIs in used statement positions that carry no identity type (no placeholder
-    // type, not a Local/Introduced/Embedded Resource) are automatically treated as Local
+    // Local IRIs in used statement positions that carry no minting-relevant type (no
+    // placeholder type, not a Local Resource) are automatically treated as Local
     // Resources, so every produced nanopub mints them under its own namespace instead of
-    // copying the template-local IRI verbatim (see issue #551).
+    // copying the template-local IRI verbatim (see issue #551). Introduced/Embedded
+    // Resource tags do not exempt an IRI: they only record the resulting IRI for pubinfo
+    // (npx:introduces / npx:embeds) and say nothing about minting; a template-local IRI
+    // tagged only nt:IntroducedResource would otherwise be shared by all produced
+    // nanopubs (see issue #602).
     private void tagUntypedLocalIrisAsLocalResources(Nanopub templateNp) {
         List<IRI> topIris = statementMap.get(templateIri);
         if (topIris == null) return;
@@ -1008,7 +1012,7 @@ public class Template implements Serializable {
         if (iri.equals(templateIri)) return;
         // Statement/group identifiers referenced as values stay untouched:
         if (statementMap.containsKey(iri) || statementSubjects.containsKey(iri)) return;
-        if (isPlaceholder(iri) || isLocalResource(iri) || isIntroducedResource(iri) || isEmbeddedResource(iri)) return;
+        if (isPlaceholder(iri) || isLocalResource(iri)) return;
         addType(iri, NTEMPLATE.LOCAL_RESOURCE);
     }
 

--- a/src/test/java/com/knowledgepixels/nanodash/template/AutoLocalResourceTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/template/AutoLocalResourceTest.java
@@ -69,12 +69,35 @@ public class AutoLocalResourceTest {
     }
 
     @Test
-    void introducedResourcesStayUntouched() throws Exception {
+    void introducedResourcesGetTaggedToo() throws Exception {
+        // Introduced/Embedded Resource tags only record the resulting IRI for pubinfo
+        // and say nothing about minting, so they must not exempt an otherwise untyped
+        // local IRI from the Local Resource treatment (issue #602).
         NanopubCreator creator = templateCreator();
         creator.addAssertionStatement(LOCAL_SUBJ, RDF.TYPE, NTEMPLATE.INTRODUCED_RESOURCE);
         Template t = new Template(creator.finalizeNanopub());
-        assertFalse(t.isLocalResource(LOCAL_SUBJ), "an introduced resource must not be auto-tagged as Local Resource");
+        assertTrue(t.isLocalResource(LOCAL_SUBJ), "a bare introduced resource must still be auto-tagged as Local Resource");
         assertTrue(t.isIntroducedResource(LOCAL_SUBJ));
+    }
+
+    @Test
+    void embeddedResourcesGetTaggedToo() throws Exception {
+        NanopubCreator creator = templateCreator();
+        creator.addAssertionStatement(LOCAL_SUBJ, RDF.TYPE, NTEMPLATE.EMBEDDED_RESOURCE);
+        Template t = new Template(creator.finalizeNanopub());
+        assertTrue(t.isLocalResource(LOCAL_SUBJ), "a bare embedded resource must still be auto-tagged as Local Resource");
+        assertTrue(t.isEmbeddedResource(LOCAL_SUBJ));
+    }
+
+    @Test
+    void introducedPlaceholdersStayUntouched() throws Exception {
+        // e.g. "Question" template: nt:IntroducedResource, nt:UriPlaceholder
+        NanopubCreator creator = templateCreator();
+        creator.addAssertionStatement(LOCAL_SUBJ, RDF.TYPE, NTEMPLATE.INTRODUCED_RESOURCE);
+        creator.addAssertionStatement(LOCAL_SUBJ, RDF.TYPE, NTEMPLATE.URI_PLACEHOLDER);
+        Template t = new Template(creator.finalizeNanopub());
+        assertFalse(t.isLocalResource(LOCAL_SUBJ), "an introduced placeholder must not be auto-tagged as Local Resource");
+        assertTrue(t.isPlaceholder(LOCAL_SUBJ));
     }
 
     @Test


### PR DESCRIPTION
Fixes #602.

The guard in `Template.tagIfUntypedLocal` exempted `nt:IntroducedResource` and `nt:EmbeddedResource` from the auto Local Resource treatment introduced in #551. Neither tag has anything to do with minting — both only record the resulting IRI so it can be written to pubinfo as `npx:introduces` / `npx:embeds`. As a result, a template-local sub-IRI tagged only `nt:IntroducedResource` was still copied verbatim, and every nanopub created from such a template shared one IRI (78 nanopubs across 15 templates network-wide; worst live case: 13 nanopubs on one `/paragraph` IRI).

Changes:

- The guard now checks only the two conditions that actually govern minting: `isPlaceholder(iri) || isLocalResource(iri)`. The already-handled cases stay handled: `nt:IntroducedResource, nt:UriPlaceholder` is caught by `isPlaceholder`, `nt:IntroducedResource, nt:LocalResource` by `isLocalResource`, and genuinely external introduced IRIs never reach this line.
- `AutoLocalResourceTest.introducedResourcesStayUntouched` inverted to `introducedResourcesGetTaggedToo` (also asserting the IRI remains an Introduced Resource, so pubinfo recording is unaffected), plus new tests for the embedded counterpart and for the `nt:IntroducedResource, nt:UriPlaceholder` combination remaining exempt.

Full test suite passes (1079 tests). With this fix, the 8 live template heads that still declare a bare `nt:IntroducedResource` stop producing collisions without needing to be republished. Already-published nanopubs keep their colliding IRIs permanently, as noted in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)