### PR TITLE
fix: offer the pending-members approve action for every tier, not only admins

### DIFF
--- a/docs/queries/list-space-non-approved-ref-v7.trig
+++ b/docs/queries/list-space-non-approved-ref-v7.trig
@@ -1,0 +1,117 @@
+@prefix this: <http://purl.org/nanopub/temp/np001/> .
+@prefix sub: <http://purl.org/nanopub/temp/np001/> .
+@prefix np: <http://www.nanopub.org/nschema#> .
+@prefix grlc: <https://w3id.org/kpxl/grlc/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix nt: <https://w3id.org/np/o/ntemplate/> .
+@prefix npx: <http://purl.org/nanopub/x/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix orcid: <https://orcid.org/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+sub:Head {
+  this: a np:Nanopublication;
+    np:hasAssertion sub:assertion;
+    np:hasProvenance sub:provenance;
+    np:hasPublicationInfo sub:pubinfo .
+}
+
+sub:assertion {
+  sub:list-space-non-approved a grlc:grlc-query;
+    dct:description "Lists the non-approved role claims of a given space ref (space IRI + root definition): agents who hold a higher-tier role instantiation (admin/maintainer/member) that is NOT in the trust-validated current state, i.e. a self-assigned or otherwise ungranted claim awaiting approval by an equal-or-higher-tier member. Pass the ref's root nanopub (root_np). Observer-tier roles are excluded: they are self-assignable, so a self-declared observer needs no approval and is shown by list-space-observers instead. The higher-tier test is generic — the built-in admin property (gen:hasAdmin) OR a RoleDeclaration whose npa:hasRoleType is gen:AdminRole/gen:MaintainerRole/gen:MemberRole. Per (member, role) only the latest role-instantiation nanopub is considered (by dct:created). Returns one row per member with the claimed tier, the grant nanopub(s) with the claimed role's label (role_assignments_multi_iri + role_assignments_label_multi), and a consistent (approve_np, grant_template) pair for the approve action: the granting nanopublication to derive from and the template to open it with. v2: adds the role_assignments columns. v3: resolves owl:sameAs space aliases (via the ref's validated npa:sameAsSpace edges in the current-state graph), so a higher-tier claim made against an alias IRI of the space is detected. v4: the invalidation filter honours an npx:invalidates edge only when the invalidating nanopub shares a signing pubkey (npa:hasValidSignatureForPublicKeyHash) with the grant it targets, so a foreign-key retraction can no longer suppress another agent's claim (issue #487 / same gate as the materializer's #112). v5: BUGFIX — the v3/v4 space-alias resolution used a BIND-in-UNION pattern that RDF4J leaves unbound, so the query returned ZERO rows for every space; replaced with a non-union filter/exists that restores detection while keeping alias resolution. v6: adds an approve_np column holding the granting nanopublication for each pending row. v7 (nanodash issue #603): replaces the admin-only roleAssignmentTemplate and agent_iri columns with a per-row (approve_np, grant_template) pair so the approve action works for EVERY tier, not only for admin grants: grant_template is the grant's own nt:wasCreatedFromTemplate (falling back to the free-form template), letting the approve action open the pending grant in derive mode (approve_np:@derive-a grant_template:@template) so the approver re-publishes the same assertion under their own key — which is exactly what tier validation requires. The tier column is DETERMINISTIC: the highest tier among the member's pending claims (rank-keyed min, not a sample), and the approve pair is computed from the SAME grant via a rank-prefixed concatenated min — preferring the grant of that highest tier — so the displayed tier, the derive target, and the template can never mismatch when a member has pending claims under several role properties. A grant whose assertion defines a Space itself (a root definition, detected via '?s a gen:Space' since gen:hasRootDefinition is absent on older definitions) is not offered for derivation, as deriving it would publish a competing root definition; for admin-tier claims such rows instead pair with the built-in admin-assignment template, so the approve button keeps working as a space-ref-conflict remedy (the hasAdmin triple unifies with that template, the definition's other statements show as unfillable). Rows whose grant is not loaded in this repo, or whose grant is a space definition claiming a non-admin tier, get no pair and hence no approve button.";
+    dct:license <http://www.apache.org/licenses/LICENSE-2.0>;
+    rdfs:label "List space non-approved role claims (ref-scoped)";
+    grlc:endpoint <https://w3id.org/np/l/nanopub-query-1.1/repo/spaces>;
+    grlc:sparql """prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix dct: <http://purl.org/dc/terms/>
+prefix np: <http://www.nanopub.org/nschema#>
+prefix npa: <http://purl.org/nanopub/admin/>
+prefix npx: <http://purl.org/nanopub/x/>
+prefix nt: <https://w3id.org/np/o/ntemplate/>
+prefix gen: <https://w3id.org/kpxl/gen/terms/>
+prefix schema: <http://schema.org/>
+
+select ?member
+       (strafter(min(?tierKey), \" \") as ?tier)
+       (group_concat(distinct ?latestNp; separator=\" \") as ?role_assignments_multi_iri)
+       (group_concat(distinct ?roleLabel; separator=\"\\n\") as ?role_assignments_label_multi)
+       (strbefore(strafter(min(?pair), \" \"), \" \") as ?approve_np)
+       (strafter(strafter(min(?pair), \" \"), \" \") as ?grant_template)
+where {
+  {
+    select ?member ?roleProp
+           (max(?val0) as ?val)
+           (strafter(max(concat(coalesce(str(?dateNp),\"\"), \" \", str(?grantNp))), \" \") as ?latestNp)
+           (sample(?tier0) as ?tierX)
+           (sample(?rl) as ?rlRaw)
+    where {
+      values ?_root_np_multi_iri {}
+      graph npa:spacesGraph { ?ref npa:rootNanopub ?_root_np_multi_iri ; npa:spaceIri ?spaceIri . }
+      graph npa:graph { npa:thisRepo npa:hasCurrentSpaceState ?g . }
+      graph npa:spacesGraph {
+        ?ri a gen:RoleInstantiation ; npa:forSpace ?inSpace ; npa:forAgent ?member ; npa:viaNanopub ?grantNp ;
+            (npa:regularProperty|npa:inverseProperty) ?roleProp .
+      }
+      filter( ?inSpace = ?spaceIri || exists { graph ?g { ?inSpace npa:sameAsSpace ?ref } } )
+      bind(?roleProp = gen:hasAdmin as ?isAdminProp)
+      bind(exists { graph npa:spacesGraph { ?rdA a npa:RoleDeclaration ; npa:hasRoleType gen:AdminRole ; (gen:hasRegularProperty|gen:hasInverseProperty) ?roleProp } } as ?isAdminDecl)
+      bind(exists { graph npa:spacesGraph { ?rdM a npa:RoleDeclaration ; npa:hasRoleType gen:MaintainerRole ; (gen:hasRegularProperty|gen:hasInverseProperty) ?roleProp } } as ?isMaint)
+      bind(exists { graph npa:spacesGraph { ?rdMe a npa:RoleDeclaration ; npa:hasRoleType gen:MemberRole ; (gen:hasRegularProperty|gen:hasInverseProperty) ?roleProp } } as ?isMemb)
+      filter(?isAdminProp || ?isAdminDecl || ?isMaint || ?isMemb)
+      filter not exists { graph npa:graph { ?invNp npx:invalidates ?grantNp ; npa:hasValidSignatureForPublicKeyHash ?invpk . ?grantNp npa:hasValidSignatureForPublicKeyHash ?invpk . } }
+      bind(if(exists { graph ?g { ?vri npa:forSpaceRef ?ref ; npa:forAgent ?member ; (npa:regularProperty|npa:inverseProperty) ?roleProp } }, 1, 0) as ?val0)
+      optional { graph npa:graph { ?grantNp dct:created ?dateNp } }
+      bind(if(?isAdminProp || ?isAdminDecl, \"Admin\", if(?isMaint, \"Maintainer\", \"Member\")) as ?tier0)
+      optional {
+        graph ?g { ?raRole a gen:RoleAssignment ; npa:forSpaceRef ?ref ; gen:hasRole ?role . }
+        graph npa:spacesGraph { ?rd2 a npa:RoleDeclaration ; npa:role ?role ; (gen:hasRegularProperty|gen:hasInverseProperty) ?roleProp ; npa:viaNanopub ?roleNp . }
+        graph npa:graph { ?roleNp np:hasAssertion ?role_a . }
+        optional { graph ?role_a { ?role schema:name ?rlS } }
+        optional { graph ?role_a { ?role rdfs:label ?rlA } }
+        optional { graph ?role_a { ?role dct:title ?rlB } }
+        bind(coalesce(?rlS, ?rlA, ?rlB) as ?rlResolved)
+      }
+      bind(if(?isAdminProp, \"admin\", ?rlResolved) as ?rl)
+    }
+    group by ?member ?roleProp
+    having (max(?val0) = 0)
+  }
+  bind(coalesce(?rlRaw, \"role\") as ?roleLabel)
+  bind(iri(?latestNp) as ?latestNpIri)
+  optional { graph npa:graph { ?latestNpIri np:hasAssertion ?la . } }
+  bind(exists { graph ?la { ?anySpace a gen:Space . } } as ?isSpaceDef)
+  optional {
+    graph npa:graph { ?latestNpIri np:hasPublicationInfo ?pi . }
+    graph ?pi { ?latestNpIri nt:wasCreatedFromTemplate ?gtmplRaw . }
+  }
+  bind(if(?tierX = \"Admin\", \"1 Admin\", if(?tierX = \"Maintainer\", \"2 Maintainer\", \"3 Member\")) as ?tierKey)
+  bind(if(bound(?la) && !?isSpaceDef,
+          concat(strbefore(?tierKey, \" \"), \" \", ?latestNp, \" \", coalesce(str(?gtmplRaw), \"http://purl.org/np/RACyK2NjqFgezYLiE8FQu7JI0xY1M1aNQbykeCW8oqXkA\")),
+          if(?isSpaceDef && ?tierX = \"Admin\",
+             concat(\"1 \", ?latestNp, \" https://w3id.org/np/RAsOQ7k3GNnuUqZuLm57PWwWopQJR_4onnCpNR457CZg8\"),
+             ?undefPair)) as ?pair)
+}
+group by ?member
+order by ?member""" .
+}
+
+sub:provenance {
+  sub:assertion prov:wasAttributedTo orcid:0000-0002-1267-0234 .
+}
+
+sub:pubinfo {
+  orcid:0000-0002-1267-0234 foaf:name "Tobias Kuhn" .
+
+  this: dct:created "2026-08-19T06:58:30Z"^^xsd:dateTime;
+    dct:creator orcid:0000-0002-1267-0234;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    npx:embeds sub:list-space-non-approved;
+    npx:supersedes <https://w3id.org/np/RAhSqdJ6w_dpbVwlCLQyp5rqOWGSnG47EL_hULHkspehQ>;
+    rdfs:label "List space non-approved role claims (ref-scoped)";
+    nt:wasCreatedFromProvenanceTemplate <https://w3id.org/np/RA7lSq6MuK_TIC6JMSHvLtee3lpLoZDOqLJCLXevnrPoU>;
+    nt:wasCreatedFromPubinfoTemplate <https://w3id.org/np/RACJ58Gvyn91LqCKIO9zu1eijDQIeEff28iyDrJgjSJF8>,
+      <https://w3id.org/np/RAukAcWHRDlkqxk7H2XNSegc1WnHI569INvNr-xdptDGI>;
+    nt:wasCreatedFromTemplate <https://w3id.org/np/RAEFAt-QcFK0ZhqfvlsmS10BnzGJA0xwOICZXkO-ai87k> .
+}

--- a/docs/queries/pending-members-derive-view.trig
+++ b/docs/queries/pending-members-derive-view.trig
@@ -1,0 +1,59 @@
+@prefix this: <http://purl.org/nanopub/temp/np001/> .
+@prefix sub: <http://purl.org/nanopub/temp/np001/> .
+@prefix gen: <https://w3id.org/kpxl/gen/terms/> .
+@prefix np: <http://www.nanopub.org/nschema#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix nt: <https://w3id.org/np/o/ntemplate/> .
+@prefix npx: <http://purl.org/nanopub/x/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix orcid: <https://orcid.org/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+sub:Head {
+  this: a np:Nanopublication;
+    np:hasAssertion sub:assertion;
+    np:hasProvenance sub:provenance;
+    np:hasPublicationInfo sub:pubinfo .
+}
+
+sub:assertion {
+  sub:approve-action a gen:ViewEntryAction;
+    rdfs:label "✅ approve...";
+    gen:hasActionTemplate <https://w3id.org/np/RAsOQ7k3GNnuUqZuLm57PWwWopQJR_4onnCpNR457CZg8>;
+    gen:hasActionTemplatePartField "void";
+    gen:hasActionTemplateQueryMapping "approve_np:@derive-a grant_template:@template";
+    gen:hasActionTemplateTargetField "void";
+    gen:isVisibleTo gen:MemberRole .
+
+  sub:pending-members-view a gen:ResourceView, gen:TabularView;
+    dct:isVersionOf sub:pending-members-view-kind;
+    dct:title "❓ Pending Admins/Maintainers/Members";
+    rdfs:label "Space pending members view";
+    gen:appliesToInstancesOf gen:Space;
+    gen:hasDisplayWidth gen:ColumnWidth06of12;
+    gen:hasStructuralPosition "5.8.pendingMembers";
+    gen:hasViewAction sub:approve-action;
+    gen:hasViewQuery <https://w3id.org/np/RAVsaIwAWFk9NekiVx-pGN6c1p-CK9ozishyvXcjUtTLc/list-space-non-approved>;
+    gen:hasViewQueryTargetField "space" .
+}
+
+sub:provenance {
+  sub:assertion prov:wasAttributedTo orcid:0000-0002-1267-0234 .
+}
+
+sub:pubinfo {
+  orcid:0000-0002-1267-0234 foaf:name "Tobias Kuhn" .
+
+  this: dct:created "2026-08-19T06:59:26Z"^^xsd:dateTime;
+    dct:creator orcid:0000-0002-1267-0234;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    npx:embeds sub:pending-members-view;
+    npx:introduces sub:pending-members-view-kind;
+    rdfs:label "Space pending members view";
+    nt:wasCreatedFromProvenanceTemplate <https://w3id.org/np/RA7lSq6MuK_TIC6JMSHvLtee3lpLoZDOqLJCLXevnrPoU>;
+    nt:wasCreatedFromPubinfoTemplate <https://w3id.org/np/RACJ58Gvyn91LqCKIO9zu1eijDQIeEff28iyDrJgjSJF8>,
+      <https://w3id.org/np/RAoTD7udB2KtUuOuAe74tJi1t3VzK0DyWS7rYVAq1GRvw>, <https://w3id.org/np/RAukAcWHRDlkqxk7H2XNSegc1WnHI569INvNr-xdptDGI>;
+    nt:wasCreatedFromTemplate <https://w3id.org/np/RARLsTlqbTesu1b0WJZ-zL1z96xumOiqbK3l_vV6iZoww> .
+}

--- a/src/main/java/com/knowledgepixels/nanodash/QueryApiAccess.java
+++ b/src/main/java/com/knowledgepixels/nanodash/QueryApiAccess.java
@@ -217,8 +217,7 @@ public class QueryApiAccess {
     // instantiation (admin/maintainer/member) that is NOT in the validated state — a
     // self-assigned or otherwise ungranted claim awaiting approval by an equal-or-higher-tier
     // member. Observer-tier roles are excluded (self-assignable, so they need no approval and
-    // are listed by LIST_SPACE_OBSERVERS_REF). Only admin claims are detectable today (the live
-    // repo materialises every declaration as ObserverRole). Drives the "❓ Pending
+    // are listed by LIST_SPACE_OBSERVERS_REF). Drives the "❓ Pending
     // Admins/Maintainers/Members" view. v3 (RA2BnCGv, supersedes RAZMAChi) resolves owl:sameAs
     // space aliases via the ref's validated npa:sameAsSpace edges, so a higher-tier claim made
     // against an alias IRI of the space is detected. v4 (RAwv7GRc, supersedes RA2BnCGv) gates the
@@ -229,9 +228,22 @@ public class QueryApiAccess {
     // sameAsSpace ... }` alias pattern left ?inSpace unbound on RDF4J (BIND in a UNION branch does
     // not see the outer ?spaceIri), so the query returned ZERO rows for every space (no pending
     // claim could ever surface). Replaced with a non-union
-    // `filter( ?inSpace = ?spaceIri || exists { ... sameAsSpace ... } )`. Source at
-    // docs/queries/list-space-non-approved-ref-v5.trig.
-    public static final String LIST_SPACE_NON_APPROVED_REF = "RAtSaYBHpb2iG6dwlHRHVfUpygNAKS-3bUa1iV5YNqk3w/list-space-non-approved";
+    // `filter( ?inSpace = ?spaceIri || exists { ... sameAsSpace ... } )`. v6 (RAhSqdJ6, supersedes
+    // RAtSaYBH via the RAPo1zp2 intermediate) adds an approve_np column with the granting
+    // nanopub. Latest (RAVsaIwA, supersedes RAhSqdJ6; issue #603): the admin-only
+    // roleAssignmentTemplate and agent_iri columns are replaced by a per-row
+    // (approve_np, grant_template) pair — the grant nanopub and its own creation template
+    // (nt:wasCreatedFromTemplate, free-form template as fallback) — so the view's approve
+    // action can open the pending grant in derive mode for EVERY tier, not only for admin
+    // grants. The tier column is deterministic (the highest tier among the member's pending
+    // claims, rank-keyed min instead of a flapping sample), and the pair is computed from
+    // the SAME grant via a rank-prefixed concatenated min preferring that highest tier, so
+    // tier, derive target, and template always agree. A grant whose assertion defines a
+    // Space itself (a competing root definition) is not offered for derivation; admin-tier
+    // claims from such definitions pair with the built-in admin-assignment template instead
+    // (the hasAdmin triple unifies), keeping the space-ref-conflict remedy.
+    // Source at docs/queries/list-space-non-approved-ref-v7.trig.
+    public static final String LIST_SPACE_NON_APPROVED_REF = "RAVsaIwAWFk9NekiVx-pGN6c1p-CK9ozishyvXcjUtTLc/list-space-non-approved";
 
     // Ref-scoped variants of the four About-tab *view* display queries (distinct from the
     // GET_SPACE_*_REF client-authority queries above). Each takes the ref's root nanopub

--- a/src/main/java/com/knowledgepixels/nanodash/component/AboutSpacePanel.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/AboutSpacePanel.java
@@ -58,10 +58,17 @@ public class AboutSpacePanel extends Panel {
      * admin/maintainer/member-tier role instantiation that is not in the
      * validated state — a self-assigned or otherwise ungranted claim awaiting
      * approval), built on the list-space-non-approved query. Carries a per-row
-     * "approve" action (visible to members and above) that re-asserts the same
-     * role triple, signed by the approver.
+     * "approve" action (visible to members and above) that opens the pending
+     * grant nanopub in derive mode under its own creation template
+     * (approve_np:@derive-a grant_template:@template), so the approver
+     * re-publishes the same assertion under their own key — for every tier,
+     * not only admin grants (issue #603). Deliberately a FRESH view identity
+     * (own kind, no npx:supersedes): views resolve to the latest version of
+     * their chain, so continuing the old pending-members-view chain would
+     * change behavior on deployed instances that still pin the old query;
+     * this way they keep working with what they have.
      */
-    public static final String NON_APPROVED_VIEW = "https://w3id.org/np/RAk5nU4XXK1-CzrE2mcSLcRmJXnANVWgkQ2dNUQzDVR64/pending-members-view";
+    public static final String NON_APPROVED_VIEW = "https://w3id.org/np/RA1eynkJJ4d3QVzThyuSWW8qSihyWFq5Gi8pOVREu3cHQ/pending-members-view";
 
     /**
      * View listing a space's observers (members whose highest tier is observer,
@@ -192,10 +199,12 @@ public class AboutSpacePanel extends Panel {
         // Non-approved (pending) higher-tier role claims, between members and observers.
         // Ref-scoped (root_np), like the observers table below; there is no IRI-keyed
         // fallback query, so when the ref root is unknown (pre-v3 data) the table is driven
-        // by the param-less query, which yields no rows. The space is passed as
-        // resource/context so the per-row "approve" action pre-fills param_space; the agent
-        // and role template come from the row via the view's query mappings. postPublishTab
-        // returns the approver to the About tab, where the approved member now shows.
+        // by the param-less query, which yields no rows. The per-row "approve" action opens
+        // the pending grant in derive mode under its own creation template (the row's
+        // approve_np/grant_template pair via the view's query mappings), so the approver
+        // re-publishes the same assertion under their own key — which works for every tier
+        // (issue #603). postPublishTab returns the approver to the About tab, where the
+        // approved member now shows.
         View nonApprovedView = View.get(NON_APPROVED_VIEW);
         QueryRef nonApprovedQuery = (refRoot != null && !refRoot.isEmpty())
                 ? new QueryRef(QueryApiAccess.LIST_SPACE_NON_APPROVED_REF, "root_np", refRoot)


### PR DESCRIPTION
Fixes #603.

The "❓ Pending Admins/Maintainers/Members" table on a space's About tab could *list* maintainer- and member-tier pending role claims but structurally could not offer the per-row approve button for them: the pinned `list-space-non-approved` query bound the assignment template only for `gen:hasAdmin` grants, and an empty `@`-mapped value hides the action.

## Approach

Approval now works by **deriving the pending grant nanopub under its own creation template** (`approve_np:@derive-a grant_template:@template`): the approver re-publishes the same assertion under their own key, which is exactly what tier validation requires — and it works for every tier without a per-tier template table.

Beyond the fix sketched in the issue, three things surfaced during implementation:

- **Per-row template.** Derive-a fills against the URL `template` key, and the admin template's predicate is fixed, so member/maintainer grants could not fill into it. The query now returns each grant's own `nt:wasCreatedFromTemplate` (free-form template as fallback), mapped over `@template` — the same pattern `DeriveAction` uses.
- **Deterministic, consistent aggregates.** The `tier` column previously came from a `sample()` over a member's mixed-tier claims and could flap between runs; `approve_np`/`grant_template` as independent aggregates could even mismatch. Now: tier = highest pending tier (rank-keyed `min`), and the pair is a rank-prefixed concatenated `min` preferring that same tier — tier, derive target, and template always agree.
- **Space-definition guard.** Some pending "grants" are full space root definitions (detected via `?s a gen:Space`, since `gen:hasRootDefinition` is absent on older definitions). Deriving one would publish a competing root definition, so those rows are not offered for derivation; admin-tier claims from such definitions pair with the built-in admin-assignment template instead, preserving the existing space-ref-conflict remedy. Net: no case behaves worse than before, maintainer/member rows gain the button.

## Published artifacts (live)

- Query `RAVsaIwAWFk9NekiVx-pGN6c1p-CK9ozishyvXcjUtTLc/list-space-non-approved` (supersedes `RAhSqdJ6…`; safe, queries are pinned by exact IRI everywhere).
- View `RA1eynkJJ4d3QVzThyuSWW8qSihyWFq5Gi8pOVREu3cHQ/pending-members-view` — deliberately a **fresh view identity** (own kind, no `npx:supersedes`): views resolve to their chain's latest version, so continuing the old chain would have changed behavior on deployed instances that still pin the old query. The old chain stays frozen at `RAD9zXW…` and keeps working as-is; instances only switch behavior when this code deploys. The old lineage can be retired once all instances run the new code.

## Testing

Verified against the live spaces repo (raw SPARQL, `_nanopub_trig`, and the published query): the issue's five pending `ff:has-participant` members each pair with the participation template; mixed-tier members on the knowledgepixels space show a stable "Admin" tier targeting the admin claim; the pending-admin case on test/group keeps its button; a space with no pending claims returns zero rows. `mvn compile` passes; render-verification on a running instance is the remaining step after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)