### PR TITLE
feat: persist caches across restarts for a warm start (#570)

### DIFF
--- a/docker-compose.override.yml.template
+++ b/docker-compose.override.yml.template
@@ -13,6 +13,10 @@ services:
       # The maintained resource whose view displays are shown on the home page.
       # Default: https://w3id.org/spaces/knowledgepixels/nanodash/r/home
       #- NANODASH_HOME_RESOURCE=https://w3id.org/spaces/your/resource/r/home
+      # Where the query and nanopub caches are snapshotted so restarts/upgrades come
+      # back up warm. Default: ~/.nanopub/nanodash-api-cache.ser (inside the mounted
+      # volume); set to 'none' to disable persistence.
+      #- NANODASH_API_CACHE_FILE=none
 
   backup-keys:
     build: ./backup-keys

--- a/src/main/java/com/knowledgepixels/nanodash/ApiCache.java
+++ b/src/main/java/com/knowledgepixels/nanodash/ApiCache.java
@@ -11,6 +11,7 @@ import org.nanopub.extra.services.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -201,6 +202,23 @@ public class ApiCache {
             logger.debug("Not waiting out the ingest delay for {} on a request thread", cacheId);
             // Hand the refresh to the background, where waiting out the delay costs nobody
             // anything, and answer with what we have meanwhile.
+            retrieveResponseAsync(queryRef);
+            return cachedResponses.getIfPresent(cacheId);
+        }
+        // A merely outdated entry is served right away on any thread, with the re-fetch
+        // handed to the background, instead of running the query inline: a synchronous
+        // caller that is fine with data from the last refresh cycle must not block on the
+        // network for it, whether it serves a user directly (a request thread) or builds
+        // the state pages are gated on (the repository and resource-data threads). This is
+        // also what lets a restart come back up warm from the persisted snapshot (issue
+        // #570) — every restored entry is older than the refresh threshold, and re-fetching
+        // them synchronously would stall the first page render on the very queries the
+        // snapshot was meant to cover. Callers that genuinely need current data say so, and
+        // keep their blocking fetch: a forced call, or an entry marked by clearCache (e.g.
+        // just after publishing).
+        if (needsRefresh && !forced && !forcedRefresh.contains(cacheId)
+                && cachedResponses.getIfPresent(cacheId) != null) {
+            logger.debug("Serving outdated response for {}, refreshing in the background", cacheId);
             retrieveResponseAsync(queryRef);
             return cachedResponses.getIfPresent(cacheId);
         }
@@ -508,6 +526,98 @@ public class ApiCache {
      */
     public static ApiResponse retrieveStaleResponse(QueryRef queryRef) {
         return cachedResponses.getIfPresent(queryRef.getAsUrlString());
+    }
+
+    /**
+     * The cache content worth carrying across restarts: the query responses and maps together
+     * with when each was last refreshed. The transient bookkeeping (running refreshes, failure
+     * counts, ingest delays, forced-refresh markings) is process-local by nature and stays out.
+     * The cached RDF models are also left out for now: they would need a text serialization of
+     * their own, and their queries re-fetch quickly enough.
+     */
+    static class Snapshot implements Serializable {
+
+        private static final long serialVersionUID = 1L;
+
+        private final Map<String, ApiResponse> responses;
+        private final Map<String, Map<String, String>> maps;
+        private final Map<String, Long> refreshTimes;
+
+        private Snapshot(Map<String, ApiResponse> responses, Map<String, Map<String, String>> maps, Map<String, Long> refreshTimes) {
+            this.responses = responses;
+            this.maps = maps;
+            this.refreshTimes = refreshTimes;
+        }
+
+        boolean isEmpty() {
+            return responses.isEmpty() && maps.isEmpty();
+        }
+
+        int size() {
+            return responses.size() + maps.size();
+        }
+
+    }
+
+    /**
+     * Captures the persistable cache content (see {@link Snapshot}). Entries whose refresh
+     * timestamp is missing — typically because their first fetch is still in flight — are
+     * left out, since without a timestamp the importer could not tell how stale they are.
+     *
+     * @return a snapshot of the current cache content
+     */
+    static Snapshot exportSnapshot() {
+        Map<String, ApiResponse> responses = new HashMap<>(cachedResponses.asMap());
+        Map<String, Map<String, String>> maps = new HashMap<>(cachedMaps.asMap());
+        Map<String, Long> refreshTimes = new HashMap<>();
+        for (String cacheId : responses.keySet()) {
+            Long t = lastRefresh.get(cacheId);
+            if (t != null) refreshTimes.put(cacheId, t);
+        }
+        for (String cacheId : maps.keySet()) {
+            Long t = lastRefresh.get(cacheId);
+            if (t != null) refreshTimes.put(cacheId, t);
+        }
+        responses.keySet().retainAll(refreshTimes.keySet());
+        maps.keySet().retainAll(refreshTimes.keySet());
+        return new Snapshot(responses, maps, refreshTimes);
+    }
+
+    /**
+     * Restores a snapshot into the cache, meant to run once at startup before the instance
+     * serves requests. Each entry keeps its original refresh timestamp, so the normal age
+     * logic takes over from there: anything older than {@link #REFRESH_AGE_THRESHOLD_MS} is
+     * re-fetched in the background on first access while the restored content is shown
+     * meanwhile — the same stale-but-displayable behavior as within a single run.
+     *
+     * <p>Entries already present in the cache are left alone, as are entries older than the
+     * given maximum age or carrying a timestamp from the future (a clock jump must not
+     * produce entries that would count as fresh indefinitely).</p>
+     *
+     * @param snapshot the snapshot to restore
+     * @param maxAgeMs entries whose last refresh lies further back than this are dropped
+     * @return the number of restored entries
+     */
+    static int importSnapshot(Snapshot snapshot, long maxAgeMs) {
+        long timeNow = System.currentTimeMillis();
+        int count = 0;
+        for (Map.Entry<String, ApiResponse> e : snapshot.responses.entrySet()) {
+            Long t = snapshot.refreshTimes.get(e.getKey());
+            if (t == null || t > timeNow || timeNow - t > maxAgeMs) continue;
+            if (e.getValue() == null || cachedResponses.getIfPresent(e.getKey()) != null) continue;
+            cachedResponses.put(e.getKey(), e.getValue());
+            lastRefresh.putIfAbsent(e.getKey(), t);
+            count++;
+        }
+        for (Map.Entry<String, Map<String, String>> e : snapshot.maps.entrySet()) {
+            Long t = snapshot.refreshTimes.get(e.getKey());
+            if (t == null || t > timeNow || timeNow - t > maxAgeMs) continue;
+            if (e.getValue() == null || cachedMaps.getIfPresent(e.getKey()) != null) continue;
+            cachedMaps.put(e.getKey(), e.getValue());
+            lastRefresh.putIfAbsent(e.getKey(), t);
+            count++;
+        }
+        return count;
     }
 
     /**

--- a/src/main/java/com/knowledgepixels/nanodash/ApiCachePersistence.java
+++ b/src/main/java/com/knowledgepixels/nanodash/ApiCachePersistence.java
@@ -1,0 +1,181 @@
+package com.knowledgepixels.nanodash;
+
+import org.nanopub.Nanopub;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Persists the {@link ApiCache} content and the nanopub cache (see {@link Utils#getNanopub})
+ * across restarts (issue #570): both are written to a snapshot file periodically and on
+ * shutdown, and read back at startup. A freshly restarted or upgraded instance thereby has
+ * content to show right away — the query responses re-fetch in the background while the
+ * restored ones are served — instead of starting cold and re-fetching everything from the
+ * query API and the registry at once.
+ *
+ * <p>The snapshot is a cache, not a store of record: a missing, corrupt, or (after a library
+ * upgrade) unreadable file only means starting cold, never failing startup. The default file
+ * location is inside {@code ~/.nanopub}, which the standard Docker setup already mounts as a
+ * volume, so deployments get persistence without any configuration.</p>
+ */
+public class ApiCachePersistence {
+
+    private ApiCachePersistence() {
+    } // no instances allowed
+
+    private static final Logger logger = LoggerFactory.getLogger(ApiCachePersistence.class);
+
+    // How often the cache is snapshotted to disk. Also the most that a hard crash (where the
+    // shutdown save never runs) can lose.
+    private static final long SAVE_INTERVAL_MINUTES = 5;
+
+    // Snapshot entries whose last refresh lies further back than this are dropped at load
+    // time, so a long-unused snapshot does not resurrect ancient content. Deliberately much
+    // longer than the in-memory 24h serving horizon: entries beyond that horizon are still
+    // valuable as the stale-content fallback when the query API is unreachable after a
+    // restart.
+    private static final long MAX_SNAPSHOT_AGE_MS = 7 * 24 * 60 * 60 * 1000L;
+
+    private static ScheduledExecutorService scheduler;
+    private static File snapshotFile;
+
+    /**
+     * The root object written to the snapshot file: the query cache content together with
+     * the cached nanopubs. The nanopubs matter as much as the query responses for a warm
+     * start — building the user data, for instance, means fetching an intro nanopub per
+     * user, serially, when they are not cached — and being immutable they can be restored
+     * without any staleness considerations.
+     */
+    private static class PersistedState implements Serializable {
+
+        private static final long serialVersionUID = 1L;
+
+        private final ApiCache.Snapshot queryCache;
+        private final Map<String, Nanopub> nanopubs;
+        // These two are null when reading a file from before the field existed.
+        private final Map<String, org.apache.commons.lang3.tuple.Pair<Long, View>> resolvedViews;
+        private final Map<String, View> views;
+
+        private PersistedState(ApiCache.Snapshot queryCache, Map<String, Nanopub> nanopubs,
+                Map<String, org.apache.commons.lang3.tuple.Pair<Long, View>> resolvedViews, Map<String, View> views) {
+            this.queryCache = queryCache;
+            this.nanopubs = nanopubs;
+            this.resolvedViews = resolvedViews;
+            this.views = views;
+        }
+
+    }
+
+    /**
+     * Loads the snapshot file into the {@link ApiCache} and starts the periodic saving. Meant
+     * to run once at application startup, before the instance serves requests. Does nothing
+     * when persistence is disabled (see {@link NanodashPreferences#getApiCacheFile()}).
+     */
+    public static synchronized void init() {
+        if (scheduler != null) return;
+        String path = NanodashPreferences.get().getApiCacheFile();
+        if (path == null) {
+            logger.info("API cache persistence is disabled");
+            return;
+        }
+        snapshotFile = new File(path);
+        load(snapshotFile);
+        scheduler = Executors.newSingleThreadScheduledExecutor((r) -> {
+            Thread t = new Thread(r, "nanodash-cache-persistence");
+            t.setDaemon(true);
+            return t;
+        });
+        scheduler.scheduleWithFixedDelay(() -> save(snapshotFile), SAVE_INTERVAL_MINUTES, SAVE_INTERVAL_MINUTES, TimeUnit.MINUTES);
+        logger.info("API cache persistence initialized with snapshot file {}", snapshotFile);
+    }
+
+    /**
+     * Stops the periodic saving and writes a final snapshot. Meant to run once at application
+     * shutdown.
+     */
+    public static synchronized void shutdown() {
+        if (scheduler == null) return;
+        scheduler.shutdown();
+        scheduler = null;
+        save(snapshotFile);
+    }
+
+    /**
+     * Restores the cache content from the given snapshot file, if there is one and it is
+     * readable. Any failure — including a snapshot written by an incompatible earlier version
+     * of the involved classes — is logged and otherwise ignored: the instance then simply
+     * starts with a cold cache, and the next periodic save replaces the unusable file.
+     *
+     * @param file the snapshot file to read
+     */
+    static void load(File file) {
+        if (!file.isFile()) return;
+        try (ObjectInputStream in = new ObjectInputStream(new BufferedInputStream(new FileInputStream(file)))) {
+            Object obj = in.readObject();
+            if (obj instanceof PersistedState state) {
+                int queryCount = ApiCache.importSnapshot(state.queryCache, MAX_SNAPSHOT_AGE_MS);
+                int npCount = Utils.importCachedNanopubs(state.nanopubs);
+                int resolvedCount = state.resolvedViews == null ? 0 : View.importResolvedViews(state.resolvedViews, MAX_SNAPSHOT_AGE_MS);
+                int viewCount = state.views == null ? 0 : View.importViews(state.views);
+                logger.info("Restored {} cached query results, {} cached nanopubs, {} views and {} view resolutions from {}",
+                        queryCount, npCount, viewCount, resolvedCount, file);
+            } else if (obj instanceof ApiCache.Snapshot snapshot) {
+                // A file from before the snapshot also carried the nanopub cache.
+                int count = ApiCache.importSnapshot(snapshot, MAX_SNAPSHOT_AGE_MS);
+                logger.info("Restored {} cached query results from {}", count, file);
+            } else {
+                logger.warn("Ignoring cache snapshot file {} with unexpected content", file);
+            }
+        } catch (Exception ex) {
+            logger.warn("Could not read cache snapshot file {}; starting with a cold cache: {}", file, ex.toString());
+        }
+    }
+
+    /**
+     * Writes the current cache content to the given snapshot file. The snapshot is written to
+     * a temporary file first and then moved into place, so a crash mid-write leaves the
+     * previous snapshot intact. An empty cache is not written out: an instance shutting down
+     * before it warmed up must not wipe the useful snapshot from the previous run.
+     *
+     * @param file the snapshot file to write
+     */
+    static void save(File file) {
+        try {
+            ApiCache.Snapshot snapshot = ApiCache.exportSnapshot();
+            Map<String, Nanopub> nanopubs = Utils.exportCachedNanopubs();
+            if (snapshot.isEmpty() && nanopubs.isEmpty()) return;
+            Map<String, org.apache.commons.lang3.tuple.Pair<Long, View>> resolvedViews = View.exportResolvedViews();
+            Map<String, View> views = View.exportViews();
+            File dir = file.getAbsoluteFile().getParentFile();
+            if (dir != null) dir.mkdirs();
+            File tmpFile = new File(file.getPath() + ".tmp");
+            try (ObjectOutputStream out = new ObjectOutputStream(new BufferedOutputStream(new FileOutputStream(tmpFile)))) {
+                out.writeObject(new PersistedState(snapshot, nanopubs, resolvedViews, views));
+            }
+            try {
+                Files.move(tmpFile.toPath(), file.toPath(), StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+            } catch (AtomicMoveNotSupportedException ex) {
+                Files.move(tmpFile.toPath(), file.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            }
+            logger.debug("Saved {} cached query results and {} cached nanopubs to {}", snapshot.size(), nanopubs.size(), file);
+        } catch (Exception ex) {
+            logger.warn("Could not write cache snapshot file {}: {}", file, ex.toString());
+        }
+    }
+
+}

--- a/src/main/java/com/knowledgepixels/nanodash/NanodashPreferences.java
+++ b/src/main/java/com/knowledgepixels/nanodash/NanodashPreferences.java
@@ -56,7 +56,20 @@ public class NanodashPreferences implements Serializable {
     private String claudeChatBinary = "claude";
     private String claudeChatModel;
     private boolean mcpRemoteEnabled = false;
+    private String apiCacheFile;
     public static final String DEFAULT_SETTING_PATH = "/.nanopub/nanodash-preferences.yml";
+
+    /**
+     * Default location of the API cache snapshot file, inside {@code ~/.nanopub} — the
+     * directory the standard Docker setup mounts as a volume, so the snapshot survives
+     * container restarts and upgrades without configuration.
+     */
+    public static final String DEFAULT_API_CACHE_PATH = "/.nanopub/nanodash-api-cache.ser";
+
+    /**
+     * Value for {@link #getApiCacheFile()} that disables API cache persistence.
+     */
+    public static final String API_CACHE_DISABLED = "none";
 
     /** Where an instance is assumed to be reachable when nothing says otherwise: a local run. */
     public static final String DEFAULT_WEBSITE_URL = "http://localhost:37373/";
@@ -366,6 +379,32 @@ public class NanodashPreferences implements Serializable {
      */
     public void setMcpRemoteEnabled(boolean mcpRemoteEnabled) {
         this.mcpRemoteEnabled = mcpRemoteEnabled;
+    }
+
+    /**
+     * Get the file where the API cache is persisted across restarts, from the
+     * {@code NANODASH_API_CACHE_FILE} environment variable or the preferences file, falling
+     * back to {@link #DEFAULT_API_CACHE_PATH} in the user's home directory.
+     *
+     * @return the snapshot file path, or null when persistence is disabled with the value
+     *         {@value #API_CACHE_DISABLED}
+     */
+    public String getApiCacheFile() {
+        String s = System.getenv("NANODASH_API_CACHE_FILE");
+        if (s == null || s.isBlank()) s = apiCacheFile;
+        if (s == null || s.isBlank()) s = System.getProperty("user.home") + DEFAULT_API_CACHE_PATH;
+        if (API_CACHE_DISABLED.equalsIgnoreCase(s.trim())) return null;
+        return s;
+    }
+
+    /**
+     * Set the file where the API cache is persisted across restarts.
+     *
+     * @param apiCacheFile the snapshot file path, or {@value #API_CACHE_DISABLED} to disable
+     *                     persistence
+     */
+    public void setApiCacheFile(String apiCacheFile) {
+        this.apiCacheFile = apiCacheFile;
     }
 
     public String getHomeResource() {

--- a/src/main/java/com/knowledgepixels/nanodash/Utils.java
+++ b/src/main/java/com/knowledgepixels/nanodash/Utils.java
@@ -165,6 +165,35 @@ public class Utils {
     }
 
     /**
+     * The current nanopub cache content, for persisting across restarts (issue #570; see
+     * {@link ApiCachePersistence}). Nanopubs are immutable, so unlike the query responses
+     * they carry no staleness concerns at all.
+     *
+     * @return a copy of the cached nanopubs, keyed by artifact code
+     */
+    static Map<String, Nanopub> exportCachedNanopubs() {
+        return new HashMap<>(nanopubs.asMap());
+    }
+
+    /**
+     * Restores previously exported nanopubs into the cache, skipping any that are already
+     * cached. Meant to run once at startup, before the instance serves requests.
+     *
+     * @param map the nanopubs to restore, keyed by artifact code
+     * @return the number of restored nanopubs
+     */
+    static int importCachedNanopubs(Map<String, Nanopub> map) {
+        int count = 0;
+        for (Map.Entry<String, Nanopub> e : map.entrySet()) {
+            if (e.getKey() == null || e.getValue() == null) continue;
+            if (nanopubs.getIfPresent(e.getKey()) != null) continue;
+            nanopubs.put(e.getKey(), e.getValue());
+            count++;
+        }
+        return count;
+    }
+
+    /**
      * Adds a nanopublication to the local cache so it can be retrieved immediately
      * without needing to fetch it from the registry.
      *

--- a/src/main/java/com/knowledgepixels/nanodash/View.java
+++ b/src/main/java/com/knowledgepixels/nanodash/View.java
@@ -105,6 +105,74 @@ public class View implements Serializable {
     }
 
     /**
+     * The current latest-version resolution memo, for persisting across restarts (issue
+     * #570; see {@link ApiCachePersistence}). Restoring it is what lets pages build their
+     * view panels synchronously right after a restart — {@link #isCached(String)} decides
+     * that — and the stale-while-revalidate handling re-resolves the restored entries in
+     * the background as they are used.
+     *
+     * @return a copy of the memoized resolutions
+     */
+    static Map<String, Pair<Long, View>> exportResolvedViews() {
+        return new HashMap<>(latestResolvedViews.asMap());
+    }
+
+    /**
+     * The current exact-version view cache, for persisting across restarts (issue #570; see
+     * {@link ApiCachePersistence}). These are the constructed View objects the view displays
+     * hand out; rebuilding one involves governed-version lookups and query construction, so
+     * restoring them is what makes a page's views renderable right after a restart. Keyed by
+     * the exact (immutable) version id, so a restored entry can never be out of date.
+     *
+     * @return a copy of the cached views
+     */
+    static Map<String, View> exportViews() {
+        return new HashMap<>(views.asMap());
+    }
+
+    /**
+     * Restores previously exported views into the exact-version cache, skipping any that are
+     * already cached. Meant to run once at startup.
+     *
+     * @param map the views to restore
+     * @return the number of restored views
+     */
+    static int importViews(Map<String, View> map) {
+        int count = 0;
+        for (Map.Entry<String, View> e : map.entrySet()) {
+            if (e.getKey() == null || e.getValue() == null) continue;
+            if (views.getIfPresent(e.getKey()) != null) continue;
+            views.put(e.getKey(), e.getValue());
+            count++;
+        }
+        return count;
+    }
+
+    /**
+     * Restores previously exported latest-version resolutions, keeping their original
+     * resolution times so the normal re-resolution age logic takes over. Entries already
+     * memoized are left alone, as are entries older than the given maximum age or carrying
+     * a timestamp from the future. Meant to run once at startup.
+     *
+     * @param map      the resolutions to restore
+     * @param maxAgeMs entries resolved further back than this are dropped
+     * @return the number of restored entries
+     */
+    static int importResolvedViews(Map<String, Pair<Long, View>> map, long maxAgeMs) {
+        long timeNow = System.currentTimeMillis();
+        int count = 0;
+        for (Map.Entry<String, Pair<Long, View>> e : map.entrySet()) {
+            if (e.getKey() == null || e.getValue() == null || e.getValue().getLeft() == null || e.getValue().getRight() == null) continue;
+            long t = e.getValue().getLeft();
+            if (t > timeNow || timeNow - t > maxAgeMs) continue;
+            if (latestResolvedViews.getIfPresent(e.getKey()) != null) continue;
+            latestResolvedViews.put(e.getKey(), e.getValue());
+            count++;
+        }
+        return count;
+    }
+
+    /**
      * Get a View by its ID, resolving to the latest version (following the
      * supersedes chain).
      *

--- a/src/main/java/com/knowledgepixels/nanodash/WicketApplication.java
+++ b/src/main/java/com/knowledgepixels/nanodash/WicketApplication.java
@@ -12,6 +12,7 @@ import com.knowledgepixels.nanodash.connector.pensoft.RioOverviewPage;
 import com.knowledgepixels.nanodash.domain.AbstractResourceWithProfile;
 import com.knowledgepixels.nanodash.domain.MaintainedResource;
 import com.knowledgepixels.nanodash.domain.Space;
+import com.knowledgepixels.nanodash.domain.User;
 import com.knowledgepixels.nanodash.events.NanopubPublishedListener;
 import com.knowledgepixels.nanodash.events.NanopubPublishedPublisher;
 import com.knowledgepixels.nanodash.page.*;
@@ -224,12 +225,52 @@ public class WicketApplication extends WebApplication implements NanopubPublishe
 
         registerListeners();
 
+        ApiCachePersistence.init();
+
+        // Warm up the shared state in the background while the server finishes starting, so
+        // the first request doesn't pay for it: the user data, the space and resource
+        // repositories, and the home resource's view displays. Each of these builds from the
+        // restored cache snapshot when one was loaded (issue #570) and from live queries
+        // otherwise; either way the work happens now instead of on the first page render.
+        // Two tasks rather than one: the home resource's data is sub-second when built from
+        // the snapshot, and queueing it behind the user data (which always makes a few live
+        // registry calls) would leave the home page showing its loading spinner for exactly
+        // that long to anyone reloading the moment the server is up.
+        NanodashThreadPool.submit(() -> {
+            try {
+                MaintainedResource homeResource = MaintainedResourceRepository.get()
+                        .findById(NanodashPreferences.get().getHomeResource());
+                if (homeResource != null) homeResource.triggerDataUpdate();
+            } catch (Exception ex) {
+                logger.error("Startup home-resource warm-up failed", ex);
+            }
+        });
+        NanodashThreadPool.submit(() -> {
+            try {
+                User.ensureLoaded();
+            } catch (Exception ex) {
+                logger.error("Startup user-data warm-up failed", ex);
+            }
+        });
+
         String umamiScriptUrl = NanodashPreferences.get().getUmamiScriptUrl();
         if (umamiScriptUrl != null && !umamiScriptUrl.isBlank()) {
             logger.info("Umami analytics configured: {}", umamiScriptUrl);
         } else {
             logger.info("Umami analytics not configured (set NANODASH_UMAMI_SCRIPT_URL and NANODASH_UMAMI_WEBSITE_ID)");
         }
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Writes a final API cache snapshot, so a restart or upgrade comes back up with the
+     * content it went down with.
+     */
+    @Override
+    protected void onDestroy() {
+        ApiCachePersistence.shutdown();
+        super.onDestroy();
     }
 
     /**

--- a/src/main/java/com/knowledgepixels/nanodash/domain/AbstractResourceWithProfile.java
+++ b/src/main/java/com/knowledgepixels/nanodash/domain/AbstractResourceWithProfile.java
@@ -144,14 +144,8 @@ public abstract class AbstractResourceWithProfile implements Serializable, Resou
                     // (latest first) so the per-view-kind latest-wins / deactivation
                     // aggregation in getViewDisplays() resolves overrides between presets and
                     // standalone displays correctly, in either direction.
-                    // For a space, scope the displays to its representative ref (root nanopub) so a
-                    // multi-ref identifier doesn't merge displays across rival definitions; other
-                    // resource kinds (and spaces with no known ref root) stay IRI-keyed.
-                    String vdRefRoot = getViewDisplayRefRoot();
-                    QueryRef vdQuery = (vdRefRoot != null && !vdRefRoot.isEmpty())
-                            ? viewDisplaysRefQueryRef(vdRefRoot)
-                            : new QueryRef(QueryApiAccess.GET_VIEW_DISPLAYS, "resource", id);
-                    newData.viewDisplays.addAll(buildViewDisplays(vdQuery));
+                    seedFromCacheIfPossible();
+                    newData.viewDisplays.addAll(buildViewDisplays(viewDisplaysQueryRef()));
                     data = newData;
                     dataInitialized = true;
                 } catch (Exception ex) {
@@ -162,6 +156,44 @@ public abstract class AbstractResourceWithProfile implements Serializable, Resou
             });
         }
         return null;
+    }
+
+    /**
+     * The query for this resource's view displays. For a space, scoped to its
+     * representative ref (root nanopub) so a multi-ref identifier doesn't merge displays
+     * across rival definitions; other resource kinds (and spaces with no known ref root)
+     * stay IRI-keyed.
+     */
+    private QueryRef viewDisplaysQueryRef() {
+        String vdRefRoot = getViewDisplayRefRoot();
+        return (vdRefRoot != null && !vdRefRoot.isEmpty())
+                ? viewDisplaysRefQueryRef(vdRefRoot)
+                : new QueryRef(QueryApiAccess.GET_VIEW_DISPLAYS, "resource", id);
+    }
+
+    /**
+     * Initializes the resource data from whatever view-displays response the cache still
+     * holds — typically the persisted snapshot right after a restart (issue #570) — so
+     * pages gated on {@link #isDataInitialized()} render their content on the first
+     * request instead of a loading spinner. Purely cache-fed, so it is quick exactly when
+     * it can succeed and does nothing on a genuinely cold cache, where the asynchronous
+     * update (whose fetch also brings seeded data current) remains the only path. The
+     * seeded data doubles as the outage fallback should that fetch fail.
+     */
+    private synchronized void seedFromCacheIfPossible() {
+        if (dataInitialized) return;
+        // A pending delayed refresh (forceRefresh, e.g. just after publishing) must not be
+        // masked by re-seeding the old state as initialized: there the page is meant to
+        // wait for the fresh data. Seeding is for the never-initialized case, where
+        // runUpdateAfter has not been set.
+        if (runUpdateAfter != null) return;
+        QueryRef vdQuery = viewDisplaysQueryRef();
+        ApiResponse cachedResponse = ApiCache.retrieveStaleResponse(vdQuery);
+        if (cachedResponse == null) return;
+        ResourceWithProfile seeded = new ResourceWithProfile();
+        seeded.viewDisplays.addAll(buildViewDisplays(cachedResponse, vdQuery));
+        data = seeded;
+        dataInitialized = true;
     }
 
     /**
@@ -208,6 +240,13 @@ public abstract class AbstractResourceWithProfile implements Serializable, Resou
 
     @Override
     public boolean isDataInitialized() {
+        // Seeding synchronously (cache-only, no network) is what lets the FIRST render of
+        // a page reach this resource's content: the update below runs asynchronously, so
+        // without the seed that render would fall back to a loading spinner even though
+        // everything it needs is in the (restored) cache.
+        if (!dataInitialized) {
+            seedFromCacheIfPossible();
+        }
         triggerDataUpdate();
         return dataInitialized;
     }
@@ -319,10 +358,13 @@ public abstract class AbstractResourceWithProfile implements Serializable, Resou
      * displays with a bound {@code ?display}, and preset-supplied views with an unbound one).
      */
     private List<ViewDisplay> buildViewDisplays(QueryRef ref) {
+        // Null on a cold cache or a failed (flaky federated) fetch — yields nothing for now;
+        // the cache refreshes asynchronously and the page's auto-refresh repopulates it.
+        return buildViewDisplays(ApiCache.retrieveResponseSync(ref, true), ref);
+    }
+
+    private List<ViewDisplay> buildViewDisplays(ApiResponse response, QueryRef ref) {
         List<ViewDisplay> list = new ArrayList<>();
-        ApiResponse response = ApiCache.retrieveResponseSync(ref, true);
-        // Null on a cold cache or a failed (flaky federated) fetch — yield nothing for now; the
-        // cache refreshes asynchronously and the page's auto-refresh repopulates it.
         if (response == null) return list;
         // The unresolved query variant returns ?view as the referenced version, leaving
         // latest-version resolution to us (View.get with resolveLatest=true, memoized;

--- a/src/main/java/com/knowledgepixels/nanodash/domain/User.java
+++ b/src/main/java/com/knowledgepixels/nanodash/domain/User.java
@@ -31,17 +31,26 @@ public class User {
         synchronized (User.class) {
             if (userData == null || System.currentTimeMillis() - lastRefresh > REFRESH_INTERVAL) {
                 lastRefresh = System.currentTimeMillis();
-                userData = new UserData();
+                userData = new UserData(true);
             }
         }
     }
 
     /**
-     * Ensures that the user data is loaded. If not, it refreshes the user data.
+     * Ensures that the user data is loaded. If not, it loads it from the cached query
+     * responses where available — in particular from the persisted snapshot right after a
+     * restart (issue #570) — instead of forcing the fetches like the periodic
+     * {@link #refreshUsers()} cycle does, which would stall the first request (session
+     * creation runs through here) on the network.
      */
     public static void ensureLoaded() {
         if (userData == null) {
-            refreshUsers();
+            synchronized (User.class) {
+                if (userData == null) {
+                    lastRefresh = System.currentTimeMillis();
+                    userData = new UserData(false);
+                }
+            }
         }
     }
 

--- a/src/main/java/com/knowledgepixels/nanodash/domain/UserData.java
+++ b/src/main/java/com/knowledgepixels/nanodash/domain/UserData.java
@@ -49,10 +49,17 @@ public class UserData implements Serializable {
     private final HashMap<IRI, IRI> defaultLicense = new HashMap<>();
 
     /**
-     * Default constructor for UserData.
+     * Constructor for UserData.
      * Initializes the user data by fetching nanopublications settings.
+     *
+     * @param forced whether the user-detail queries must be re-fetched from the API even
+     *               when a cached response exists. The periodic refresh passes true so each
+     *               cycle actually brings the data current; the initial load passes false so
+     *               it can build from cached responses right away — in particular from the
+     *               persisted snapshot after a restart (issue #570), where forced fetches
+     *               would stall the first request on the network.
      */
-    UserData() {
+    UserData(boolean forced) {
         final NanodashPreferences pref = NanodashPreferences.get();
 
         // TODO Make nanopublication setting configurable:
@@ -116,15 +123,15 @@ public class UserData implements Serializable {
 
         logger.info("Loading user details...");
         // Get latest introductions for all users, including unapproved ones:
-        for (ApiResponseEntry entry : ApiCache.retrieveResponseSync(new QueryRef(QueryApiAccess.GET_ALL_USER_INTROS), true).getData()) {
+        for (ApiResponseEntry entry : ApiCache.retrieveResponseSync(new QueryRef(QueryApiAccess.GET_ALL_USER_INTROS), forced).getData()) {
             register(entry);
         }
 
-        for (ApiResponseEntry entry : ApiCache.retrieveResponseSync(new QueryRef(QueryApiAccess.GET_ALL_USER_PROFILE_PICS), true).getData()) {
+        for (ApiResponseEntry entry : ApiCache.retrieveResponseSync(new QueryRef(QueryApiAccess.GET_ALL_USER_PROFILE_PICS), forced).getData()) {
             profilePictures.put(Values.iri(entry.get("user")), Values.iri(entry.get("imageUrl")));
         }
 
-        for (ApiResponseEntry entry : ApiCache.retrieveResponseSync(new QueryRef(QueryApiAccess.GET_ALL_USER_DEFAULT_LICENSE), true).getData()) {
+        for (ApiResponseEntry entry : ApiCache.retrieveResponseSync(new QueryRef(QueryApiAccess.GET_ALL_USER_DEFAULT_LICENSE), forced).getData()) {
             defaultLicense.put(Values.iri(entry.get("user")), Values.iri(entry.get("license")));
         }
     }

--- a/src/test/java/com/knowledgepixels/nanodash/ApiCachePersistenceTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/ApiCachePersistenceTest.java
@@ -1,0 +1,219 @@
+package com.knowledgepixels.nanodash;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.nanopub.extra.services.ApiResponse;
+import org.nanopub.extra.services.ApiResponseEntry;
+
+import com.google.common.cache.Cache;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentMap;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ApiCachePersistenceTest {
+
+    @TempDir
+    File tempDir;
+
+    private static final String RESPONSE_ID = "RAe-oA5eSmkCXCALZ99-0k4imnlI74KPqURfhHOmnzo6A/get-latest-nanopubs-from-pubkeys";
+    private static final String MAP_ID = "RAe-oA5eSmkCXCALZ99-0k4imnlI74KPqURfhHOmnzo6A/get-some-map";
+
+    @BeforeEach
+    void setUp() throws Exception {
+        resetMap("cachedResponses");
+        resetMap("cachedMaps");
+        resetMap("failed");
+        resetMap("lastRefresh");
+        resetMap("refreshStart");
+        resetMap("runAfter");
+        resetMap("forcedRefresh");
+        // The nanopub cache is saved along with the query caches and is populated by
+        // other tests in the suite, so it needs the same reset.
+        Field f = Utils.class.getDeclaredField("nanopubs");
+        f.setAccessible(true);
+        ((Cache<?, ?>) f.get(null)).invalidateAll();
+    }
+
+    private void resetMap(String fieldName) throws Exception {
+        Field f = ApiCache.class.getDeclaredField(fieldName);
+        f.setAccessible(true);
+        Object obj = f.get(null);
+        if (obj instanceof Cache<?, ?> cache) {
+            cache.invalidateAll();
+        } else if (obj instanceof ConcurrentMap<?, ?> map) {
+            map.clear();
+        } else if (obj instanceof Set<?> set) {
+            set.clear();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private <K, V> ConcurrentMap<K, V> getMap(String fieldName) throws Exception {
+        Field f = ApiCache.class.getDeclaredField(fieldName);
+        f.setAccessible(true);
+        Object obj = f.get(null);
+        if (obj instanceof Cache<?, ?> cache) {
+            return (ConcurrentMap<K, V>) cache.asMap();
+        }
+        return (ConcurrentMap<K, V>) obj;
+    }
+
+    private static ApiResponse makeResponse(String value) {
+        ApiResponse response = new ApiResponse();
+        response.setHeader(new String[] {"thing"});
+        ApiResponseEntry entry = new ApiResponseEntry();
+        entry.add("thing", value);
+        response.add(entry);
+        return response;
+    }
+
+    private void putCachedResponse(String cacheId, ApiResponse response, long ageMillis) throws Exception {
+        ConcurrentMap<String, ApiResponse> cachedResponses = getMap("cachedResponses");
+        ConcurrentMap<String, Long> lastRefresh = getMap("lastRefresh");
+        cachedResponses.put(cacheId, response);
+        lastRefresh.put(cacheId, System.currentTimeMillis() - ageMillis);
+    }
+
+    private void putCachedMap(String cacheId, Map<String, String> map, long ageMillis) throws Exception {
+        ConcurrentMap<String, Map<String, String>> cachedMaps = getMap("cachedMaps");
+        ConcurrentMap<String, Long> lastRefresh = getMap("lastRefresh");
+        cachedMaps.put(cacheId, map);
+        lastRefresh.put(cacheId, System.currentTimeMillis() - ageMillis);
+    }
+
+    @Test
+    @DisplayName("save and load should round-trip responses and maps with their refresh timestamps")
+    void saveAndLoadRoundTrip() throws Exception {
+        putCachedResponse(RESPONSE_ID, makeResponse("some-value"), 5000L);
+        Map<String, String> map = new HashMap<>();
+        map.put("key1", "value1");
+        putCachedMap(MAP_ID, map, 5000L);
+        ConcurrentMap<String, Long> lastRefreshBefore = getMap("lastRefresh");
+        long responseRefreshTime = lastRefreshBefore.get(RESPONSE_ID);
+        long mapRefreshTime = lastRefreshBefore.get(MAP_ID);
+
+        File file = new File(tempDir, "cache.ser");
+        ApiCachePersistence.save(file);
+        assertTrue(file.isFile());
+
+        setUp(); // back to an empty cache, as after a restart
+        ApiCachePersistence.load(file);
+
+        ConcurrentMap<String, ApiResponse> cachedResponses = getMap("cachedResponses");
+        assertNotNull(cachedResponses.get(RESPONSE_ID));
+        assertEquals("some-value", cachedResponses.get(RESPONSE_ID).getData().getFirst().get("thing"));
+        ConcurrentMap<String, Map<String, String>> cachedMaps = getMap("cachedMaps");
+        assertEquals(map, cachedMaps.get(MAP_ID));
+        ConcurrentMap<String, Long> lastRefresh = getMap("lastRefresh");
+        assertEquals(responseRefreshTime, lastRefresh.get(RESPONSE_ID));
+        assertEquals(mapRefreshTime, lastRefresh.get(MAP_ID));
+    }
+
+    @Test
+    @DisplayName("load should drop entries older than the maximum snapshot age")
+    void loadDropsAncientEntries() throws Exception {
+        putCachedResponse(RESPONSE_ID, makeResponse("ancient"), 8L * 24 * 60 * 60 * 1000);
+        putCachedResponse(MAP_ID, makeResponse("recent"), 5000L);
+
+        File file = new File(tempDir, "cache.ser");
+        ApiCachePersistence.save(file);
+
+        setUp();
+        ApiCachePersistence.load(file);
+
+        ConcurrentMap<String, ApiResponse> cachedResponses = getMap("cachedResponses");
+        assertNull(cachedResponses.get(RESPONSE_ID));
+        assertNotNull(cachedResponses.get(MAP_ID));
+    }
+
+    @Test
+    @DisplayName("load should drop entries with a refresh timestamp from the future")
+    void loadDropsFutureTimestamps() throws Exception {
+        putCachedResponse(RESPONSE_ID, makeResponse("from-the-future"), -60 * 60 * 1000L);
+
+        File file = new File(tempDir, "cache.ser");
+        ApiCachePersistence.save(file);
+
+        setUp();
+        ApiCachePersistence.load(file);
+
+        ConcurrentMap<String, ApiResponse> cachedResponses = getMap("cachedResponses");
+        assertNull(cachedResponses.get(RESPONSE_ID));
+    }
+
+    @Test
+    @DisplayName("save should not write an empty cache over an existing snapshot")
+    void saveSkipsEmptyCache() throws Exception {
+        putCachedResponse(RESPONSE_ID, makeResponse("kept"), 5000L);
+        File file = new File(tempDir, "cache.ser");
+        ApiCachePersistence.save(file);
+        long lengthBefore = file.length();
+
+        setUp();
+        ApiCachePersistence.save(file);
+
+        assertEquals(lengthBefore, file.length(), "the snapshot from the warm run should still be there");
+        ApiCachePersistence.load(file);
+        ConcurrentMap<String, ApiResponse> cachedResponses = getMap("cachedResponses");
+        assertNotNull(cachedResponses.get(RESPONSE_ID));
+    }
+
+    @Test
+    @DisplayName("save should skip entries whose refresh timestamp is missing")
+    void saveSkipsEntriesWithoutRefreshTimestamp() throws Exception {
+        ConcurrentMap<String, ApiResponse> cachedResponses = getMap("cachedResponses");
+        cachedResponses.put(RESPONSE_ID, makeResponse("mid-refresh"));
+        putCachedResponse(MAP_ID, makeResponse("complete"), 5000L);
+
+        File file = new File(tempDir, "cache.ser");
+        ApiCachePersistence.save(file);
+
+        setUp();
+        ApiCachePersistence.load(file);
+
+        assertNull(getMap("cachedResponses").get(RESPONSE_ID));
+        assertNotNull(getMap("cachedResponses").get(MAP_ID));
+    }
+
+    @Test
+    @DisplayName("load should ignore a corrupt snapshot file and leave the cache empty")
+    void loadIgnoresCorruptFile() throws Exception {
+        File file = new File(tempDir, "cache.ser");
+        Files.write(file.toPath(), new byte[] {1, 2, 3, 4, 5});
+
+        assertDoesNotThrow(() -> ApiCachePersistence.load(file));
+        assertTrue(this.<String, ApiResponse>getMap("cachedResponses").isEmpty());
+    }
+
+    @Test
+    @DisplayName("load should do nothing when the snapshot file does not exist")
+    void loadHandlesMissingFile() {
+        assertDoesNotThrow(() -> ApiCachePersistence.load(new File(tempDir, "does-not-exist.ser")));
+    }
+
+    @Test
+    @DisplayName("load should not overwrite entries already in the cache")
+    void loadKeepsExistingEntries() throws Exception {
+        putCachedResponse(RESPONSE_ID, makeResponse("old"), 5000L);
+        File file = new File(tempDir, "cache.ser");
+        ApiCachePersistence.save(file);
+
+        setUp();
+        ApiResponse current = makeResponse("current");
+        putCachedResponse(RESPONSE_ID, current, 0L);
+        ApiCachePersistence.load(file);
+
+        ConcurrentMap<String, ApiResponse> cachedResponses = getMap("cachedResponses");
+        assertSame(current, cachedResponses.get(RESPONSE_ID));
+    }
+
+}

--- a/src/test/java/com/knowledgepixels/nanodash/ApiCacheTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/ApiCacheTest.java
@@ -117,18 +117,23 @@ class ApiCacheTest {
     }
 
     @Test
-    @DisplayName("retrieveResponseSync should refresh stale cache and return fresh response through API call")
-    void retrieveResponseSync_refreshesStaleCache() throws Exception {
+    @DisplayName("retrieveResponseSync should serve an outdated response and leave the re-fetch to the background")
+    void retrieveResponseSync_servesOutdatedResponse() throws Exception {
         ApiResponse stale = mock(ApiResponse.class);
-        ApiResponse fresh = mock(ApiResponse.class);
+        // Well past the refresh threshold, as e.g. every entry restored from the
+        // persisted snapshot after a restart is.
         putCachedResponse(stale, 90000L);
+        // A refresh is already in flight, so nothing new is submitted while the test runs.
+        getMap("refreshStart").put(MOCK_CACHE_ID, System.currentTimeMillis());
 
         try (MockedStatic<QueryApiAccess> queryApiAccess = mockStatic(QueryApiAccess.class)) {
-            queryApiAccess.when(() -> QueryApiAccess.get(mockQueryRef)).thenReturn(fresh);
-
+            long start = System.currentTimeMillis();
             ApiResponse result = ApiCache.retrieveResponseSync(mockQueryRef, false);
+            long elapsed = System.currentTimeMillis() - start;
 
-            assertSame(fresh, result);
+            assertSame(stale, result, "the outdated response should be served straight away");
+            assertTrue(elapsed < 1000, "should not have re-fetched inline, but took " + elapsed + "ms");
+            queryApiAccess.verify(() -> QueryApiAccess.get(any()), never());
         }
     }
 
@@ -252,6 +257,29 @@ class ApiCacheTest {
             assertSame(cached, result, "the outdated response should be served straight away");
             assertTrue(elapsed < 1000, "should not have waited for the ingest delay, but took " + elapsed + "ms");
             queryApiAccess.verify(() -> QueryApiAccess.get(any()), never());
+        } finally {
+            tester.destroy();
+            ThreadContext.detach();
+        }
+    }
+
+    @Test
+    @DisplayName("retrieveResponseSync should still re-fetch a clearCache-marked entry on a request thread")
+    void retrieveResponseSync_stillRefreshesMarkedEntryOnRequestThread() throws Exception {
+        ApiResponse stale = mock(ApiResponse.class);
+        ApiResponse fresh = mock(ApiResponse.class);
+        putCachedResponse(stale, 90000L);
+        ApiCache.clearCache(mockQueryRef, 0L);
+
+        WicketTester tester = new WicketTester();
+        try (MockedStatic<QueryApiAccess> queryApiAccess = mockStatic(QueryApiAccess.class)) {
+            queryApiAccess.when(() -> QueryApiAccess.get(mockQueryRef)).thenReturn(fresh);
+
+            ApiResponse result = ApiCache.retrieveResponseSync(mockQueryRef, false);
+
+            // The marking means the kept entry must not be handed out as current, so the
+            // request thread does wait for the re-fetch here.
+            assertSame(fresh, result);
         } finally {
             tester.destroy();
             ThreadContext.detach();


### PR DESCRIPTION
Addresses #570 with the disk-snapshot approach discussed there (drafts/sessions persistence is split off as its own concern): the query responses, cached nanopubs and constructed views are snapshotted to a file every 5 minutes and on shutdown, and restored at startup, so a restarted or upgraded instance serves fully rendered pages right away instead of starting cold.

## What's in the snapshot

- **Query responses and maps** from `ApiCache`, with their `lastRefresh` timestamps — restored entries go through the existing age logic, so everything re-fetches in the background while the restored content is shown (the #599 stale-but-displayable model, now surviving restarts). Entries older than 7 days, and the transient bookkeeping (`failed`, `runAfter`, forced-refresh marks), are not carried over.
- **Nanopubs** (`Utils` cache) and **constructed views** (`View` exact-version cache + latest-resolution memo) — both content-addressed/immutable, so restoring them has no staleness concerns. These matter as much as the queries: building the user data means fetching an intro nanopub per user, serially, when they are not cached.

The default file is `~/.nanopub/nanodash-api-cache.ser` — inside the volume the standard Docker setup already mounts, so deployments get persistence without configuration (the backup-keys container only archives `nanodash-users/`, so key backups don't grow). `NANODASH_API_CACHE_FILE` / the `apiCacheFile` preference override the path; `none` disables it. Writes are atomic (tmp + move), an empty cache never overwrites a previous snapshot, and a corrupt or version-incompatible file just means a cold start, never a failed startup.

## Making the restored data reach the first render

Persisting alone didn't help — thread dumps showed the cold-start paths bypassing the cache — so:

- `retrieveResponseSync` now serves an outdated (e.g. restored) response on any thread and hands the re-fetch to the background, extending the existing ingest-delay rule. Forced calls and `clearCache`-marked entries (post-publish) keep their blocking fetch.
- The initial user-data load builds unforced (`UserData(boolean forced)`); the periodic refresh cycle stays forced. First session creation previously ran three forced queries plus serial intro-nanopub fetches on the request thread (~15–21s).
- Resource data seeds synchronously from the cached view-displays response in `isDataInitialized()`, so user/space pages render content on their first request after a restart. A pending delayed `forceRefresh` (post-publish ingest wait) still waits for fresh data instead of re-showing the old state.
- `WicketApplication.init()` warms up the user data, the repositories and the home resource in the background while the server is still booting.

## Measured

Before: first request after a restart took ~21s and every view section started as a spinner, converging over ~10–60s. After (second restart on, once the enriched snapshot exists): the first request the moment the port opens returns the complete home page; first visit to a previously-viewed user page renders all content with zero spinners. Never-visited pages keep the graceful spinner path; full test suite passes (1088 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
