### PR TITLE
fix: keep the cached map when a refresh fails

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/ApiCache.java
+++ b/src/main/java/com/knowledgepixels/nanodash/ApiCache.java
@@ -410,7 +410,10 @@ public class ApiCache {
                     ApiCache.updateMap(queryRef);
                 } catch (Exception ex) {
                     logger.error("Failed to update cache for {}: {}", cacheId, ex.getMessage());
-                    cachedMaps.invalidate(cacheId);
+                    // Keep whatever is cached, as the response and RDF-model paths do: a query we
+                    // cannot reach right now is a reason to go on showing the previous data, never
+                    // to throw it away. Only the refresh timestamp is bumped, so the next attempt
+                    // waits out the usual interval instead of retrying on every access.
                     lastRefresh.put(cacheId, System.currentTimeMillis());
                 }  finally {
                     refreshStart.remove(cacheId);

--- a/src/test/java/com/knowledgepixels/nanodash/ApiCacheTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/ApiCacheTest.java
@@ -16,6 +16,7 @@ import org.nanopub.extra.services.QueryRef;
 import com.google.common.cache.Cache;
 
 import java.lang.reflect.Field;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 
@@ -158,6 +159,34 @@ class ApiCacheTest {
             assertNull(result);
             ConcurrentMap<String, Integer> failed = getMap("failed");
             assertEquals(1, failed.get(MOCK_CACHE_ID));
+        }
+    }
+
+    @Test
+    @DisplayName("retrieveMap should keep the cached map when the refresh fails")
+    void retrieveMap_keepsCachedMapWhenApiCallFails() throws Exception {
+        ConcurrentMap<String, Map<String, String>> cachedMaps = getMap("cachedMaps");
+        ConcurrentMap<String, Long> lastRefresh = getMap("lastRefresh");
+        Map<String, String> cached = Map.of("key", "value");
+        cachedMaps.put(MOCK_CACHE_ID, cached);
+        // Outdated enough to trigger a refresh, but well within the maximum cache age.
+        lastRefresh.put(MOCK_CACHE_ID, System.currentTimeMillis() - 2 * 60 * 1000);
+
+        try (MockedStatic<QueryApiAccess> queryApiAccess = mockStatic(QueryApiAccess.class);
+             MockedStatic<NanodashThreadPool> threadPool = mockStatic(NanodashThreadPool.class)) {
+            queryApiAccess.when(() -> QueryApiAccess.get(mockQueryRef))
+                    .thenThrow(new FailedApiCallException(new Exception("API call failed")));
+            // Run the refresh job on this thread, where the mocked API access applies.
+            threadPool.when(() -> NanodashThreadPool.submit(any(Runnable.class))).thenAnswer(inv -> {
+                inv.getArgument(0, Runnable.class).run();
+                return null;
+            });
+
+            Map<String, String> result = ApiCache.retrieveMap(mockQueryRef);
+
+            assertSame(cached, result);
+            assertSame(cached, cachedMaps.get(MOCK_CACHE_ID),
+                    "a failed refresh must not throw away the cached map");
         }
     }
 


### PR DESCRIPTION
`ApiCache.retrieveMap` was the only refresh path that threw away its cached entry when the API call failed:

```java
} catch (Exception ex) {
    logger.error("Failed to update cache for {}: {}", cacheId, ex.getMessage());
    cachedMaps.invalidate(cacheId);   // ← discarded good data because the re-fetch failed
    lastRefresh.put(cacheId, System.currentTimeMillis());
}
```

`retrieveResponseSync`, `retrieveResponseAsync` and `retrieveRdfModelAsync` all keep whatever is cached and only count a failure when nothing was cached — a query we cannot reach right now is a reason to go on showing the previous data, not to drop it. The map path had been left behind, so an unreachable API turned a usable cached map into nothing.

It now keeps the entry and bumps only `lastRefresh`, so the next attempt waits out the usual refresh interval instead of retrying on every access.

Note that `retrieveMap` currently has no live callers (only the commented-out `UserPage` stats lookups), so this was dormant rather than something users were hitting.

## Test

`ApiCacheTest.retrieveMap_keepsCachedMapWhenApiCallFails` caches a map, ages it past the refresh threshold, makes the API call throw, and asserts the entry survives. The refresh job is run inline via a mocked `NanodashThreadPool`, since Mockito's static mocks are thread-confined. Verified it fails against the old behaviour.

Full suite: 1089 tests, 0 failures.

## Related, not changed here

`retrieveMap` still invalidates on a browser reload (`isForcedReload`), unlike responses and RDF models, which mark via `forcedRefresh` and keep the entry. That means a map query has nothing to fall back on if the reload's re-fetch then fails — worth aligning separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)