### PR TITLE
fix(QueryPage): explain why a query can't be loaded instead of failing

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/GrlcQuery.java
+++ b/src/main/java/com/knowledgepixels/nanodash/GrlcQuery.java
@@ -1,6 +1,7 @@
 package com.knowledgepixels.nanodash;
 
 import com.knowledgepixels.nanodash.component.QueryParamField;
+import org.eclipse.rdf4j.query.MalformedQueryException;
 import org.nanopub.extra.services.QueryRef;
 import org.nanopub.extra.services.QueryTemplate;
 import org.slf4j.Logger;
@@ -22,7 +23,7 @@ import java.util.regex.Pattern;
  * <p>
  * Query parsing (SPARQL, endpoint, label, description, placeholders) is inherited from
  * {@link QueryTemplate} in nanopub-java. This subclass adds Nanodash-specific concerns:
- * an instance cache with {@link #get} factory methods, and integration with the
+ * an instance cache with the {@link #get} and {@link #load} factory methods, and integration with the
  * {@link QueryParamField} form components used by the query UI.
  */
 public class GrlcQuery extends QueryTemplate {
@@ -37,6 +38,14 @@ public class GrlcQuery extends QueryTemplate {
     private static final Pattern ARTIFACT_CODE_PATTERN = Pattern.compile("RA[A-Za-z0-9\\-_]{43}");
 
     /**
+     * Picks the numeric character code out of the lexical errors the RDF4J SPARQL parser
+     * reports, which read like {@code Lexical error at line 20, column 56.  Encountered: "..."
+     * (160), after : ""} — where the number in brackets is the code of the character it
+     * tripped over.
+     */
+    private static final Pattern LEXICAL_ERROR_CHARACTER_PATTERN = Pattern.compile("Encountered:[^(]*\\((\\d+)\\)");
+
+    /**
      * Returns a singleton instance of GrlcQuery for the given QueryRef.
      *
      * @param ref the QueryRef object containing the query name
@@ -47,27 +56,127 @@ public class GrlcQuery extends QueryTemplate {
     }
 
     /**
-     * Returns a singleton instance of GrlcQuery for the given query ID.
+     * Returns a singleton instance of GrlcQuery for the given query ID, or null if there is
+     * no query to be had for it. Use {@link #load(String)} instead where the reason matters,
+     * e.g. to tell the user what is wrong with the query.
      *
      * @param id the unique identifier or URI of the query
-     * @return a GrlcQuery instance
+     * @return a GrlcQuery instance, or null if the query couldn't be loaded
      */
     public static GrlcQuery get(String id) {
-        if (id == null) return null;
-        GrlcQuery cached = instanceMap.getIfPresent(id);
-        if (cached == null) {
-            try {
-                GrlcQuery q = new GrlcQuery(id);
-                id = q.getQueryId();
-                cached = instanceMap.getIfPresent(id);
-                if (cached != null) return cached;
-                instanceMap.put(id, q);
-                cached = q;
-            } catch (Exception ex) {
-                logger.warn("Could not load query: {}", id, ex);
-            }
+        try {
+            return load(id);
+        } catch (QueryLoadException ex) {
+            return null;
         }
-        return cached;
+    }
+
+    /**
+     * Returns a singleton instance of GrlcQuery for the given query ID, reporting why it
+     * can't be had when it can't. Queries come from nanopublications that anybody can
+     * publish, so failing to load one says something about that nanopublication rather than
+     * about Nanodash, and the user is better served by being told what is wrong with it than
+     * by a generic error.
+     *
+     * @param id the unique identifier or URI of the query
+     * @return a GrlcQuery instance, never null
+     * @throws QueryLoadException if the query cannot be loaded, with a message explaining why
+     */
+    public static GrlcQuery load(String id) {
+        if (id == null || id.isBlank()) {
+            throw new QueryLoadException("No query was given to show or run.");
+        }
+        GrlcQuery cached = instanceMap.getIfPresent(id);
+        if (cached != null) return cached;
+        GrlcQuery q;
+        try {
+            q = new GrlcQuery(id);
+        } catch (Exception ex) {
+            // Logged in full here, because what is shown to the user is only the gist of it.
+            logger.warn("Could not load query: {}", id, ex);
+            throw new QueryLoadException(explainLoadFailure(id, ex), ex);
+        }
+        // Cached under the normalized ID, so that the different ways of referring to the same
+        // query (URI, ID, containing nanopublication) share one instance.
+        cached = instanceMap.getIfPresent(q.getQueryId());
+        if (cached != null) return cached;
+        instanceMap.put(q.getQueryId(), q);
+        return q;
+    }
+
+    /**
+     * Puts into plain words why the query with the given ID couldn't be loaded, for showing
+     * to the user.
+     *
+     * @param id the query ID or URI that was asked for
+     * @param ex the failure that loading it ran into
+     * @return the explanation
+     */
+    private static String explainLoadFailure(String id, Exception ex) {
+        MalformedQueryException sparqlFailure = null;
+        if (ex instanceof MalformedQueryException direct) {
+            sparqlFailure = direct;
+        } else if (ex.getCause() instanceof MalformedQueryException wrapped) {
+            sparqlFailure = wrapped;
+        }
+        if (sparqlFailure != null) {
+            String characterHint = explainOffendingCharacter(sparqlFailure.getMessage());
+            String detail = summarize(sparqlFailure.getMessage());
+            return "The SPARQL code of the query '" + id + "' is not valid, so the query can't be shown or run."
+                    + (detail == null ? "" : " The SPARQL parser reports: " + detail)
+                    + (characterHint == null ? "" : " " + characterHint)
+                    + " This is a problem with the published query itself, which only a corrected version of it can fix.";
+        }
+        String detail = ex.getMessage();
+        if (detail == null || detail.isBlank()) detail = ex.getClass().getSimpleName();
+        return "The query '" + id + "' couldn't be loaded: " + detail;
+    }
+
+    /**
+     * Reduces a SPARQL parser failure to the one line that says what it tripped over and
+     * where, leaving out the list of what it was expecting instead. That list runs to dozens
+     * of grammar rules, which is more than an error page can carry; it is kept in the log.
+     *
+     * @param parserMessage the message of the SPARQL parser failure
+     * @return the gist of it as a single sentence, or null if there is nothing to say
+     */
+    private static String summarize(String parserMessage) {
+        if (parserMessage == null) return null;
+        // Lexical errors trail off into a dangling comma, which would run into what follows.
+        String firstLine = parserMessage.split("\\R", 2)[0].trim().replaceAll("[,;:\\s]+$", "");
+        if (firstLine.isEmpty()) return null;
+        return firstLine.endsWith(".") ? firstLine : firstLine + ".";
+    }
+
+    /**
+     * Names the character a SPARQL lexical error tripped over, as long as it is one that
+     * doesn't belong in SPARQL in the first place. Such characters — a non-breaking space, a
+     * typographic quote — look like their plain ASCII counterparts or like nothing at all, so
+     * the parser's report of a numeric character code leaves the author of the query none the
+     * wiser about what to correct.
+     *
+     * @param parserMessage the message of the SPARQL parser failure
+     * @return the explanation, or null if the message doesn't point at such a character
+     */
+    private static String explainOffendingCharacter(String parserMessage) {
+        if (parserMessage == null) return null;
+        Matcher m = LEXICAL_ERROR_CHARACTER_PATTERN.matcher(parserMessage);
+        if (!m.find()) return null;
+        int codePoint;
+        try {
+            codePoint = Integer.parseInt(m.group(1));
+        } catch (NumberFormatException ex) {
+            return null;
+        }
+        // Only non-ASCII characters are worth naming: for the ASCII ones the parser's own
+        // report already shows what is there.
+        if (codePoint < 128 || !Character.isValidCodePoint(codePoint)) return null;
+        String name = Character.getName(codePoint);
+        return "The character in that position is " + String.format("U+%04X", codePoint)
+                + (name == null ? "" : " (" + name + ")")
+                + ", which SPARQL doesn't allow there. Characters like this one tend to slip in when a query is"
+                + " copied from a word processor or a web page, and replacing them with their plain equivalents"
+                + " makes the query valid again.";
     }
 
     /**

--- a/src/main/java/com/knowledgepixels/nanodash/QueryLoadException.java
+++ b/src/main/java/com/knowledgepixels/nanodash/QueryLoadException.java
@@ -1,0 +1,37 @@
+package com.knowledgepixels.nanodash;
+
+/**
+ * Thrown when a query cannot be loaded: its identifier doesn't denote a query, the
+ * nanopublication holding it can't be retrieved, or the SPARQL code it carries is not
+ * valid.
+ * <p>
+ * The message is written for the user rather than for the log, because it ends up on the
+ * {@link com.knowledgepixels.nanodash.page.ErrorPage} that a request for a query that
+ * can't be loaded is answered with. It should therefore say what is wrong with the query
+ * in plain words, instead of exposing internals.
+ *
+ * @see GrlcQuery#load(String)
+ */
+public class QueryLoadException extends RuntimeException {
+
+    /**
+     * Constructs a new QueryLoadException with the given user-facing message.
+     *
+     * @param message explains, in plain words, why the query couldn't be loaded
+     */
+    public QueryLoadException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new QueryLoadException with the given user-facing message and the
+     * underlying failure.
+     *
+     * @param message explains, in plain words, why the query couldn't be loaded
+     * @param cause   the failure this message was derived from, kept for the log
+     */
+    public QueryLoadException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/src/main/java/com/knowledgepixels/nanodash/page/QueryPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/QueryPage.java
@@ -6,6 +6,7 @@ import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 import com.knowledgepixels.nanodash.ApiCache;
 import com.knowledgepixels.nanodash.GrlcQuery;
+import com.knowledgepixels.nanodash.QueryLoadException;
 import com.knowledgepixels.nanodash.Utils;
 import com.knowledgepixels.nanodash.ViewDisplay;
 import com.knowledgepixels.nanodash.component.QueryParamField;
@@ -78,12 +79,25 @@ public class QueryPage extends NanodashPage {
      */
     public QueryPage(final PageParameters parameters) {
         super(parameters);
-        add(new TitleBar("titlebar", this));
-        add(new Label("pagetitle", "Query Info | nanodash"));
 
         String id = parameters.get("id").toString();
         final String queryId = parameters.get("runquery").toString();
         if (id == null) id = queryId;
+
+        // The query is resolved before anything is built, because there is no page to show
+        // without it. Queries are published by anyone, so one that can't be loaded — a broken
+        // identifier, a nanopublication that isn't there, invalid SPARQL — is a normal thing to
+        // run into here, and saying what is wrong with it beats failing to build the page (#284).
+        GrlcQuery q;
+        try {
+            q = GrlcQuery.load(id);
+        } catch (QueryLoadException ex) {
+            throw new RestartResponseException(ErrorPage.class,
+                    new PageParameters().set(ErrorPage.MESSAGE_PARAM, ex.getMessage()));
+        }
+        if (!q.getQueryId().equals(id)) {
+            throw new RestartResponseException(getClass(), parameters.set("id", q.getQueryId()));
+        }
 
         final Multimap<String, String> queryParams = ArrayListMultimap.create();
         for (NamedPair param : parameters.getAllNamed()) {
@@ -91,11 +105,8 @@ public class QueryPage extends NanodashPage {
             queryParams.put(param.getKey().replaceFirst("queryparam_", ""), param.getValue());
         }
 
-        GrlcQuery q = GrlcQuery.get(id);
-        if (!q.getQueryId().equals(id)) {
-            throw new RestartResponseException(getClass(), parameters.set("id", q.getQueryId()));
-        }
-
+        add(new TitleBar("titlebar", this));
+        add(new Label("pagetitle", "Query Info | nanodash"));
         add(new Label("querylabel", q.getLabel()));
         add(new BookmarkablePageLink<Void>("np", ExplorePage.class, new PageParameters().set("id", q.getNanopub().getUri().stringValue()))
                 .add(NavigationContext.pageContextFallback()));

--- a/src/test/java/com/knowledgepixels/nanodash/GrlcQueryTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/GrlcQueryTest.java
@@ -2,6 +2,7 @@ package com.knowledgepixels.nanodash;
 
 import com.knowledgepixels.nanodash.component.QueryParamField;
 import com.knowledgepixels.nanodash.utils.TestUtils;
+import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.junit.jupiter.api.AfterEach;
@@ -19,6 +20,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import static com.knowledgepixels.nanodash.utils.TestUtils.anyIri;
 import static com.knowledgepixels.nanodash.utils.TestUtils.randomIri;
 import static org.eclipse.rdf4j.model.util.Values.iri;
+import static org.eclipse.rdf4j.model.util.Values.literal;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mockStatic;
@@ -31,6 +33,13 @@ class GrlcQueryTest {
     private static final String QUERY_DESCRIPTION = "This query returns all participation links.";
     private static final String QUERY_LABEL = "Get participation links";
     private static final String ENDPOINT = "https://w3id.org/np/l/nanopub-query-1.1/repo/full";
+
+    /**
+     * SPARQL with a non-breaking space (U+00A0) where a plain space belongs — the kind of
+     * character that a query picks up on its way through a word processor, and that the SPARQL
+     * parser rejects with nothing but a numeric character code to go on (#284).
+     */
+    private static final String SPARQL_WITH_NON_BREAKING_SPACE = "select ?thing where { ?thing ?p\u00A0?o }";
 
     @AfterEach
     void tearDown() throws NoSuchFieldException, IllegalAccessException {
@@ -78,6 +87,81 @@ class GrlcQueryTest {
     @Test
     void getNullForNullId() {
         assertNull(GrlcQuery.get((String) null));
+    }
+
+    @Test
+    void getNullForMalformedSparql() throws MalformedNanopubException, NanopubAlreadyFinalizedException {
+        try (MockedStatic<Utils> utilsMock = mockStatic(Utils.class)) {
+            utilsMock.when(() -> Utils.getNanopub(any())).thenReturn(queryNanopubWith(SPARQL_WITH_NON_BREAKING_SPACE));
+            assertNull(GrlcQuery.get(NANOPUB_URI));
+        }
+    }
+
+    // A query whose SPARQL doesn't parse can't be loaded, and the reason is worth passing on:
+    // the query is published by someone else, so the user can only be told what is wrong with
+    // it (#284).
+    @Test
+    void loadExplainsMalformedSparql() throws MalformedNanopubException, NanopubAlreadyFinalizedException {
+        try (MockedStatic<Utils> utilsMock = mockStatic(Utils.class)) {
+            utilsMock.when(() -> Utils.getNanopub(any())).thenReturn(queryNanopubWith(SPARQL_WITH_NON_BREAKING_SPACE));
+
+            QueryLoadException ex = assertThrows(QueryLoadException.class, () -> GrlcQuery.load(NANOPUB_URI));
+            assertTrue(ex.getMessage().contains("SPARQL code"), ex.getMessage());
+            // The offending character is invisible, so naming it is the only way the author of
+            // the query can find it.
+            assertTrue(ex.getMessage().contains("U+00A0"), ex.getMessage());
+            assertTrue(ex.getMessage().contains("NO-BREAK SPACE"), ex.getMessage());
+        }
+    }
+
+    // An ordinary syntax error has nothing invisible about it, so the parser's own report is
+    // passed on as it is.
+    @Test
+    void loadExplainsSyntaxErrorWithoutNamingACharacter() throws MalformedNanopubException, NanopubAlreadyFinalizedException {
+        try (MockedStatic<Utils> utilsMock = mockStatic(Utils.class)) {
+            utilsMock.when(() -> Utils.getNanopub(any())).thenReturn(queryNanopubWith("select ?thing where { ?thing"));
+
+            QueryLoadException ex = assertThrows(QueryLoadException.class, () -> GrlcQuery.load(NANOPUB_URI));
+            assertTrue(ex.getMessage().contains("SPARQL code"), ex.getMessage());
+            assertFalse(ex.getMessage().contains("U+"), ex.getMessage());
+        }
+    }
+
+    @Test
+    void loadExplainsNanopubWithoutQuery() throws MalformedNanopubException, NanopubAlreadyFinalizedException {
+        Nanopub nanopub = TestUtils.createNanopub();
+
+        try (MockedStatic<Utils> utilsMock = mockStatic(Utils.class)) {
+            utilsMock.when(() -> Utils.getNanopub(any())).thenReturn(nanopub);
+
+            QueryLoadException ex = assertThrows(QueryLoadException.class, () -> GrlcQuery.load(NANOPUB_URI));
+            assertTrue(ex.getMessage().contains("No query found in nanopublication"), ex.getMessage());
+        }
+    }
+
+    @Test
+    void loadThrowsForMissingId() {
+        assertThrows(QueryLoadException.class, () -> GrlcQuery.load(null));
+        assertThrows(QueryLoadException.class, () -> GrlcQuery.load("  "));
+    }
+
+    @Test
+    void loadThrowsForIdThatIsNotAQueryId() {
+        assertThrows(QueryLoadException.class, () -> GrlcQuery.load("https://example.com/not-a-query"));
+    }
+
+    /**
+     * Builds a nanopublication holding a single query with the given SPARQL code.
+     */
+    private static Nanopub queryNanopubWith(String sparql) throws MalformedNanopubException, NanopubAlreadyFinalizedException {
+        NanopubCreator creator = TestUtils.getNanopubCreator(NANOPUB_URI);
+        IRI queryUri = iri(NANOPUB_URI + "/" + QUERY_SUFFIX);
+        creator.addAssertionStatement(queryUri, RDF.TYPE, KPXL_GRLC.GRLC_QUERY);
+        creator.addAssertionStatement(queryUri, KPXL_GRLC.SPARQL, literal(sparql));
+        creator.addAssertionStatement(queryUri, KPXL_GRLC.ENDPOINT, iri(ENDPOINT));
+        TestUtils.fillProvenanceGraph(creator);
+        TestUtils.fillPubInfoGraph(creator);
+        return creator.finalizeNanopub();
     }
 
     @Test

--- a/src/test/java/com/knowledgepixels/nanodash/page/QueryPageTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/page/QueryPageTest.java
@@ -1,0 +1,84 @@
+package com.knowledgepixels.nanodash.page;
+
+import com.knowledgepixels.nanodash.GrlcQuery;
+import com.knowledgepixels.nanodash.Utils;
+import com.knowledgepixels.nanodash.WicketApplication;
+import com.knowledgepixels.nanodash.utils.TestUtils;
+import com.google.common.cache.Cache;
+import org.apache.wicket.RestartResponseException;
+import org.apache.wicket.request.mapper.parameter.PageParameters;
+import org.apache.wicket.util.tester.WicketTester;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.nanopub.MalformedNanopubException;
+import org.nanopub.Nanopub;
+import org.nanopub.NanopubAlreadyFinalizedException;
+import org.nanopub.NanopubCreator;
+import org.nanopub.vocabulary.KPXL_GRLC;
+
+import static org.eclipse.rdf4j.model.util.Values.iri;
+import static org.eclipse.rdf4j.model.util.Values.literal;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+
+class QueryPageTest {
+
+    private static final String NANOPUB_URI = "https://w3id.org/np/RA6T-YLqLnYd5XfnqR9PaGUjCzudvHdYjcG4GvOc7fdpA";
+
+    private WicketTester tester;
+
+    @BeforeEach
+    void setUp() {
+        tester = new WicketTester(new WicketApplication());
+    }
+
+    @AfterEach
+    void tearDown() throws NoSuchFieldException, IllegalAccessException {
+        var field = GrlcQuery.class.getDeclaredField("instanceMap");
+        field.setAccessible(true);
+        ((Cache<?, ?>) field.get(null)).invalidateAll();
+    }
+
+    // A query whose SPARQL doesn't parse used to take this page down with a
+    // NullPointerException; it now says what is wrong with the query instead (#284).
+    @Test
+    void malformedSparqlForwardsToErrorPageWithDetails() throws MalformedNanopubException, NanopubAlreadyFinalizedException {
+        NanopubCreator creator = TestUtils.getNanopubCreator(NANOPUB_URI);
+        IRI queryUri = iri(NANOPUB_URI + "/get-things");
+        creator.addAssertionStatement(queryUri, RDF.TYPE, KPXL_GRLC.GRLC_QUERY);
+        // A non-breaking space where a plain space belongs: invisible, and rejected by the
+        // SPARQL parser.
+        creator.addAssertionStatement(queryUri, KPXL_GRLC.SPARQL, literal("select ?thing where { ?thing ?p\u00A0?o }"));
+        creator.addAssertionStatement(queryUri, KPXL_GRLC.ENDPOINT, iri("https://w3id.org/np/l/nanopub-query-1.1/repo/full"));
+        TestUtils.fillProvenanceGraph(creator);
+        TestUtils.fillPubInfoGraph(creator);
+        Nanopub nanopub = creator.finalizeNanopub();
+
+        try (MockedStatic<Utils> utilsMock = mockStatic(Utils.class)) {
+            utilsMock.when(() -> Utils.getNanopub(any())).thenReturn(nanopub);
+
+            RestartResponseException ex = assertThrows(RestartResponseException.class,
+                    () -> new QueryPage(new PageParameters().add("id", NANOPUB_URI)));
+            assertEquals(ErrorPage.class, TestUtils.forwardedPageClass(ex));
+            String message = TestUtils.forwardedPageParameters(ex).get(ErrorPage.MESSAGE_PARAM).toString();
+            assertTrue(message.contains("NO-BREAK SPACE"), message);
+        }
+    }
+
+    // Asking for a query without saying which one is a request that can't be answered, but it
+    // shouldn't take the page down either (#284).
+    @Test
+    void missingQueryIdForwardsToErrorPage() {
+        RestartResponseException ex = assertThrows(RestartResponseException.class,
+                () -> new QueryPage(new PageParameters()));
+        assertEquals(ErrorPage.class, TestUtils.forwardedPageClass(ex));
+    }
+
+}


### PR DESCRIPTION
Closes #284.

## The bug

`GrlcQuery.get()` swallowed every load failure and returned `null`, which `QueryPage` then dereferenced (`q.getLabel()`). A query whose SPARQL doesn't parse took the page down with a `NullPointerException`, leaving the user with Wicket's "Can't instantiate page" and nothing else.

The nanopublication from the issue is [non-compliant, as @tkuhn diagnosed](https://github.com/knowledgepixels/nanodash/issues/284#issuecomment-3512555236) — fetching it today shows **three non-breaking spaces (U+00A0)** in its SPARQL, which RDF4J rejects with nothing but `Encountered: '160' (160)`. Nanodash can't fix someone else's published query, but it can say what is wrong with it instead of falling over.

## The change

- **`GrlcQuery`** — a new `load(String)` alongside `get(String)`. `load` returns the query or throws `QueryLoadException` carrying a user-facing explanation; `get` keeps its null-returning contract by catching it, so the other call sites are untouched. The full stack trace is logged where the failure happens, since only the gist reaches the page.
- **`QueryLoadException`** (new) — its message is written for the user, not for the log.
- **`QueryPage`** — resolves the query *before* building any component (there is no page without it) and forwards to `ErrorPage` with the explanation. A missing `id`/`runquery` is handled the same way instead of throwing.

Two helpers shape the message: `summarize()` keeps the parser's "what and where" line and drops its dozens-of-grammar-rules "was expecting" dump, and `explainOffendingCharacter()` reads the numeric character code out of a lexical error and names it via `Character.getName` when it is non-ASCII. That last part is what makes the difference here, since the character in question can't be seen.

For the query from the issue, the page now reads:

> The SPARQL code of the query '…' is not valid, so the query can't be shown or run. The SPARQL parser reports: Lexical error at line 20, column 56. Encountered: '160' (160). The character in that position is U+00A0 (NO-BREAK SPACE), which SPARQL doesn't allow there. Characters like this one tend to slip in when a query is copied from a word processor or a web page, and replacing them with their plain equivalents makes the query valid again. This is a problem with the published query itself, which only a corrected version of it can fix.

## Tests

Six new cases in `GrlcQueryTest` (the invisible-character case, an ordinary syntax error, a nanopublication without a query, a missing and an invalid id, and `get` still returning `null`), plus a new `QueryPageTest` covering the forward to `ErrorPage` with the details. Full suite green: 1097 tests.

## Deliberately left out

- Validating SPARQL at query-**creation** time — both of us framed that as later work in the issue thread. Opened as #615.
- Wording promising the query "will be fixed soon". Nanodash can't promise that for someone else's nanopublication, so the message says who *can* act instead. The gap behind that request — the error page being a dead end — is opened as #616.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
