### PR TITLE
feat: allow inline SVG in HTML snippets from queries

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/Utils.java
+++ b/src/main/java/com/knowledgepixels/nanodash/Utils.java
@@ -76,7 +76,7 @@ public class Utils {
      */
     public static final ValueFactory vf = SimpleValueFactory.getInstance();
     private static final Logger logger = LoggerFactory.getLogger(Utils.class);
-    private static final Pattern LEADING_TAG = Pattern.compile("^\\s*<(p|div|span|img|pre)(\\s|>|/).*", Pattern.CASE_INSENSITIVE);
+    private static final Pattern LEADING_TAG = Pattern.compile("^\\s*<(p|div|span|img|pre|svg)(\\s|>|/).*", Pattern.CASE_INSENSITIVE);
     private static final String DEFAULT_MAIN_QUERY_URL = "https://query.knowledgepixels.com/";
     private static final String DEFAULT_MAIN_REGISTRY_URL = "https://registry.knowledgepixels.com/";
 
@@ -635,56 +635,100 @@ public class Utils {
         return null;
     }
 
-    private static final PolicyFactory htmlSanitizePolicy = new HtmlPolicyBuilder().allowCommonBlockElements().allowCommonInlineFormattingElements().allowUrlProtocols("https", "http", "mailto").allowElements("a").allowAttributes("href").onElements("a").allowElements("img").allowAttributes("src").onElements("img").allowElements("pre").requireRelNofollowOnLinks().toFactory();
+    // A conservative static-SVG subset: basic shapes, text, grouping, and links.
+    // Everything not allowed is dropped — in particular script/foreignObject/style
+    // and all event handlers, plus use/image, whose href would reach outside the
+    // sanitized document. Used by SVG views (QueryResultSvg) and, folded into the
+    // HTML policy below, by inline SVG in HTML snippets coming from queries.
+    // Attribute-name matching is case-sensitive and the matched spelling is emitted
+    // verbatim, so the camelCase SVG attributes are listed in both spellings
+    // (browsers also map the lowercase form back via the SVG attribute-adjustment
+    // table, but the camelCase form works everywhere, including XML contexts).
+    private static final String[] SVG_ELEMENTS = {"svg", "g", "defs", "marker", "title", "desc",
+            "rect", "circle", "ellipse", "line", "polyline", "polygon", "path", "text", "tspan"};
+
+    // The SVG elements plus the link element they can be wrapped in, which is
+    // shared with HTML and therefore allowed separately by each policy.
+    private static final String[] SVG_ELEMENTS_WITH_LINK = concat(SVG_ELEMENTS, "a");
+
+    private static final String[] SVG_ATTRIBUTES = {"viewbox", "viewBox", "width", "height",
+            "preserveaspectratio", "preserveAspectRatio", "xmlns",
+            "x", "y", "x1", "y1", "x2", "y2", "cx", "cy", "r", "rx", "ry",
+            "d", "points", "dx", "dy", "transform",
+            "fill", "fill-opacity", "fill-rule",
+            "stroke", "stroke-width", "stroke-opacity", "stroke-linecap",
+            "stroke-linejoin", "stroke-dasharray", "opacity",
+            "font-family", "font-size", "font-weight", "font-style",
+            "text-anchor", "dominant-baseline", "text-decoration",
+            "marker-start", "marker-mid", "marker-end",
+            "markerwidth", "markerWidth", "markerheight", "markerHeight",
+            "refx", "refX", "refy", "refY", "orient", "markerunits", "markerUnits",
+            "id"};
+
+    private static String[] concat(String[] values, String... more) {
+        String[] result = Arrays.copyOf(values, values.length + more.length);
+        System.arraycopy(more, 0, result, values.length, more.length);
+        return result;
+    }
 
     /**
-     * Sanitizes raw HTML input to ensure safe rendering.
+     * Adds the static-SVG subset (elements and presentation attributes, but not the
+     * {@code a} element itself, whose link handling differs per policy) to a policy
+     * builder.
+     *
+     * @param builder the policy builder to extend
+     * @return the given builder
+     */
+    private static HtmlPolicyBuilder allowSvgSubset(HtmlPolicyBuilder builder) {
+        return builder
+                .allowElements(SVG_ELEMENTS)
+                .allowWithoutAttributes("svg", "g", "defs", "title", "desc", "text", "tspan")
+                .allowAttributes(SVG_ATTRIBUTES).onElements(SVG_ELEMENTS_WITH_LINK);
+    }
+
+    private static final PolicyFactory htmlSanitizePolicy = allowSvgSubset(new HtmlPolicyBuilder()
+            .allowCommonBlockElements().allowCommonInlineFormattingElements()
+            .allowUrlProtocols("https", "http", "mailto")
+            .allowElements("a").allowAttributes("href").onElements("a")
+            .allowElements("img").allowAttributes("src").onElements("img")
+            .allowElements("pre")
+            .requireRelNofollowOnLinks()).toFactory();
+
+    /**
+     * Sanitizes raw HTML input to ensure safe rendering. Inline SVG is kept, reduced
+     * to the same static subset as in {@link #sanitizeSvg(String)}.
      *
      * @param rawHtml the raw HTML input to sanitize
      * @return sanitized HTML string
      */
     public static String sanitizeHtml(String rawHtml) {
-        return htmlSanitizePolicy.sanitize(rawHtml);
+        return htmlSanitizePolicy.sanitize(normalizeSelfClosedSvgTags(rawHtml));
     }
 
-    // A conservative static-SVG subset for SVG views (QueryResultSvg): basic shapes,
-    // text, grouping, and links. Everything not allowed is dropped — in particular
-    // script/foreignObject/style and all event handlers, plus use/image, whose
-    // href would reach outside the sanitized document. Attribute-name matching is
-    // case-sensitive and the matched spelling is emitted verbatim, so the camelCase
-    // SVG attributes are listed in both spellings (browsers also map the lowercase
-    // form back via the SVG attribute-adjustment table, but the camelCase form
-    // works everywhere, including XML contexts).
-    private static final PolicyFactory svgSanitizePolicy = new HtmlPolicyBuilder()
+    private static final PolicyFactory svgSanitizePolicy = allowSvgSubset(new HtmlPolicyBuilder()
             .allowUrlProtocols("https", "http")
-            .allowElements("svg", "g", "defs", "marker", "title", "desc",
-                    "rect", "circle", "ellipse", "line", "polyline", "polygon", "path",
-                    "text", "tspan", "a")
-            .allowWithoutAttributes("svg", "g", "defs", "title", "desc", "text", "tspan", "a")
-            .allowAttributes("viewbox", "viewBox", "width", "height",
-                    "preserveaspectratio", "preserveAspectRatio", "xmlns",
-                    "x", "y", "x1", "y1", "x2", "y2", "cx", "cy", "r", "rx", "ry",
-                    "d", "points", "dx", "dy", "transform",
-                    "fill", "fill-opacity", "fill-rule",
-                    "stroke", "stroke-width", "stroke-opacity", "stroke-linecap",
-                    "stroke-linejoin", "stroke-dasharray", "opacity",
-                    "font-family", "font-size", "font-weight", "font-style",
-                    "text-anchor", "dominant-baseline", "text-decoration",
-                    "marker-start", "marker-mid", "marker-end",
-                    "markerwidth", "markerWidth", "markerheight", "markerHeight",
-                    "refx", "refX", "refy", "refY", "orient", "markerunits", "markerUnits",
-                    "id")
-            .globally()
-            .allowAttributes("href").onElements("a")
-            .toFactory();
+            .allowElements("a")
+            .allowWithoutAttributes("a")
+            .allowAttributes("href").onElements("a")).toFactory();
 
-    // XML-style self-closed tags (<rect .../>): the HTML-parsing sanitizer ignores
-    // the slash on non-void elements and would re-parent all following siblings as
-    // children of the "unclosed" element — which in SVG makes them invisible (shape
-    // elements don't render children). Expanded to explicit end tags before
-    // sanitizing. Quoted attribute values (which may contain ">") are matched as
-    // units so the tag end is found correctly.
-    private static final Pattern SELF_CLOSED_TAG = Pattern.compile("<([a-zA-Z][a-zA-Z0-9-]*)((?:[^<>\"']|\"[^\"]*\"|'[^']*')*)/>");
+    // XML-style self-closed SVG tags (<rect .../>): the HTML-parsing sanitizer
+    // ignores the slash on non-void elements and would re-parent all following
+    // siblings as children of the "unclosed" element — which in SVG makes them
+    // invisible (shape elements don't render children). Expanded to explicit end
+    // tags before sanitizing. Quoted attribute values (which may contain ">") are
+    // matched as units so the tag end is found correctly, and the attribute part
+    // must start with whitespace so that a longer element name is not matched as
+    // one of the listed ones plus attributes. Only SVG element names are expanded,
+    // so that HTML void elements (<br/>, <img/>) and self-closed links keep their
+    // HTML parsing.
+    private static final Pattern SELF_CLOSED_SVG_TAG = Pattern.compile(
+            "<(" + String.join("|", SVG_ELEMENTS) + ")((?:\\s(?:[^<>\"']|\"[^\"]*\"|'[^']*')*)?)/>",
+            Pattern.CASE_INSENSITIVE);
+
+    private static String normalizeSelfClosedSvgTags(String raw) {
+        if (raw == null) return null;
+        return SELF_CLOSED_SVG_TAG.matcher(raw).replaceAll("<$1$2></$1>");
+    }
 
     /**
      * Sanitizes SVG markup (as produced by an SVG view's query) down to a static
@@ -695,8 +739,7 @@ public class Utils {
      * @return sanitized SVG markup
      */
     public static String sanitizeSvg(String rawSvg) {
-        String normalized = SELF_CLOSED_TAG.matcher(rawSvg).replaceAll("<$1$2></$1>");
-        return svgSanitizePolicy.sanitize(normalized);
+        return svgSanitizePolicy.sanitize(normalizeSelfClosedSvgTags(rawSvg));
     }
 
     /**

--- a/src/main/java/com/knowledgepixels/nanodash/Utils.java
+++ b/src/main/java/com/knowledgepixels/nanodash/Utils.java
@@ -742,6 +742,53 @@ public class Utils {
         return svgSanitizePolicy.sanitize(normalizeSelfClosedSvgTags(rawSvg));
     }
 
+    // A whole inline SVG figure, dropped wherever HTML is reduced to text: its
+    // labels would come out as a run of disconnected words.
+    private static final Pattern SVG_FRAGMENT = Pattern.compile("<svg\\b.*?</svg\\s*>",
+            Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+
+    private static final Pattern NUMERIC_ENTITY = Pattern.compile("&#(?:([0-9]{1,7})|[xX]([0-9a-fA-F]{1,6}));");
+
+    /**
+     * Reduces an HTML fragment to plain text: SVG figures are dropped entirely, the
+     * remaining tags are stripped, the named and numeric entities are unescaped (the
+     * sanitizer emits quotes etc. as numeric entities like {@code &#34;}), and
+     * whitespace is collapsed.
+     *
+     * @param html the HTML fragment
+     * @return the plain text
+     */
+    public static String htmlToPlainText(String html) {
+        String text = SVG_FRAGMENT.matcher(html).replaceAll(" ");
+        text = text.replaceAll("<[^>]*>", " ");
+        text = text.replace("&lt;", "<").replace("&gt;", ">").replace("&quot;", "\"")
+                .replace("&nbsp;", " ");
+        text = NUMERIC_ENTITY.matcher(text).replaceAll(m -> {
+            int codePoint = m.group(1) != null
+                    ? Integer.parseInt(m.group(1))
+                    : Integer.parseInt(m.group(2), 16);
+            return Matcher.quoteReplacement(new String(Character.toChars(codePoint)));
+        });
+        text = text.replace("&amp;", "&");
+        return text.replaceAll("\\s+", " ").trim();
+    }
+
+    /**
+     * Reduces a value to the text to use for it in a label. HTML is a rendering
+     * detail that has no place in a label, so an SVG figure is dropped wherever it
+     * occurs, and a value that is HTML is further reduced to its text.
+     *
+     * @param value the raw value
+     * @return the value as label text
+     */
+    public static String toLabelText(String value) {
+        if (value == null) return null;
+        if (looksLikeHtml(value)) {
+            return htmlToPlainText(value);
+        }
+        return SVG_FRAGMENT.matcher(value).replaceAll(" ").replaceAll("\\s+", " ").trim();
+    }
+
     /**
      * Checks if a given string is likely to be HTML content.
      *

--- a/src/main/java/com/knowledgepixels/nanodash/component/PublishForm.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/PublishForm.java
@@ -1177,7 +1177,9 @@ public class PublishForm extends Panel {
                     logger.error("Nanopub label placeholder IRI error: {}", ex.getMessage());
                 }
             }
-            placeholderLabel = placeholderLabel.replaceAll("\\s+", " ");
+            // HTML in a value is a rendering detail with no place in a label: SVG
+            // figures are dropped entirely and the remaining tags stripped.
+            placeholderLabel = Utils.toLabelText(placeholderLabel);
             if (placeholderLabel.length() > 100) {
                 placeholderLabel = placeholderLabel.substring(0, 97) + "...";
             }

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultPlainParagraph.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultPlainParagraph.html
@@ -21,7 +21,7 @@
         <h5 wicket:id="title">[title]</h5>
         <span class="buttons"><span wicket:id="pnp"></span></span>
       </div>
-      <p wicket:id="content">[content]</p>
+      <p wicket:id="content" class="paragraph-content">[content]</p>
     </div>
     <p wicket:id="no-records" class="no-records-note">(nothing found)</p>
   </div>

--- a/src/main/java/com/knowledgepixels/nanodash/component/StatusLine.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/StatusLine.java
@@ -25,7 +25,9 @@ import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * A component that displays the status of a nanopublication.
@@ -140,8 +142,11 @@ public class StatusLine extends Panel {
     }
 
     private void applyResponse(ApiResponse response, boolean mayBlock) {
-        List<String> latest = new ArrayList<>();
-        List<String> retractions = new ArrayList<>();
+        // Sets, because the query returns one row per indexed signature key and
+        // creation date, so the same version can come back several times -- and a
+        // query instance with damaged metadata can multiply that further.
+        Set<String> latest = new LinkedHashSet<>();
+        Set<String> retractions = new LinkedHashSet<>();
         for (ApiResponseEntry e : response.getData()) {
             String newerVersion = e.get("newerVersion");
             String retractedBy = e.get("retractedBy");
@@ -152,6 +157,10 @@ public class StatusLine extends Panel {
                 retractions.add(retractedBy);
             }
         }
+        // The supersedes path in the query is reflexive, so this nanopublication is
+        // always among the results and is never a newer version of itself.
+        List<String> newerVersions = new ArrayList<>(latest);
+        newerVersions.remove(npId);
 
         latestBySupersedes = false;
         if (latest.isEmpty() && retractions.isEmpty()) {
@@ -159,21 +168,21 @@ public class StatusLine extends Panel {
             links = List.of();
             verified = false;
         } else if (!latest.isEmpty()) {
-            if (latest.size() == 1 && latest.getFirst().equals(npId)) {
+            if (newerVersions.isEmpty()) {
                 statusText = LATEST_TEXT;
                 links = List.of();
                 latestBySupersedes = true;
-            } else if (latest.size() == 1) {
+            } else if (newerVersions.size() == 1) {
                 statusText = NEWER_VERSION_TEXT;
-                links = latest;
+                links = newerVersions;
             } else {
                 statusText = "This nanopublication has <strong>newer versions</strong>:";
-                links = latest;
+                links = newerVersions;
             }
             verified = true;
         } else {
             statusText = "This nanopublication has been <strong>retracted</strong>:";
-            links = retractions;
+            links = new ArrayList<>(retractions);
             verified = true;
         }
         applyGovernedOverride(mayBlock);

--- a/src/main/java/com/knowledgepixels/nanodash/export/DocumentModelBuilder.java
+++ b/src/main/java/com/knowledgepixels/nanodash/export/DocumentModelBuilder.java
@@ -28,8 +28,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * Builds a {@link DocumentModel} from a resource's view displays and their query
@@ -412,34 +410,15 @@ public final class DocumentModelBuilder {
     }
 
     /**
-     * Strips tags from an HTML fragment and unescapes the named and numeric
-     * entities (the sanitizer emits quotes etc. as numeric entities like
-     * {@code &#34;}).
+     * Reduces an HTML fragment to plain text; see {@link Utils#htmlToPlainText(String)},
+     * which the document export shares with label creation.
      *
      * @param html the HTML fragment
      * @return the plain text
      */
     static String htmlToPlainText(String html) {
-        // Inline SVG figures have no plain-text rendering: their labels would come
-        // out as a run of disconnected words, so the whole figure is dropped.
-        String text = SVG_FRAGMENT.matcher(html).replaceAll(" ");
-        text = text.replaceAll("<[^>]*>", " ");
-        text = text.replace("&lt;", "<").replace("&gt;", ">").replace("&quot;", "\"")
-                .replace("&nbsp;", " ");
-        text = NUMERIC_ENTITY.matcher(text).replaceAll(m -> {
-            int codePoint = m.group(1) != null
-                    ? Integer.parseInt(m.group(1))
-                    : Integer.parseInt(m.group(2), 16);
-            return Matcher.quoteReplacement(new String(Character.toChars(codePoint)));
-        });
-        text = text.replace("&amp;", "&");
-        return text.replaceAll("\\s+", " ").trim();
+        return Utils.htmlToPlainText(html);
     }
-
-    private static final Pattern NUMERIC_ENTITY = Pattern.compile("&#(?:([0-9]{1,7})|[xX]([0-9a-fA-F]{1,6}));");
-
-    private static final Pattern SVG_FRAGMENT = Pattern.compile("<svg\\b.*?</svg\\s*>",
-            Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
 
     private static String orEmpty(String s) {
         return s == null ? "" : s;

--- a/src/main/java/com/knowledgepixels/nanodash/export/DocumentModelBuilder.java
+++ b/src/main/java/com/knowledgepixels/nanodash/export/DocumentModelBuilder.java
@@ -420,7 +420,10 @@ public final class DocumentModelBuilder {
      * @return the plain text
      */
     static String htmlToPlainText(String html) {
-        String text = html.replaceAll("<[^>]*>", " ");
+        // Inline SVG figures have no plain-text rendering: their labels would come
+        // out as a run of disconnected words, so the whole figure is dropped.
+        String text = SVG_FRAGMENT.matcher(html).replaceAll(" ");
+        text = text.replaceAll("<[^>]*>", " ");
         text = text.replace("&lt;", "<").replace("&gt;", ">").replace("&quot;", "\"")
                 .replace("&nbsp;", " ");
         text = NUMERIC_ENTITY.matcher(text).replaceAll(m -> {
@@ -434,6 +437,9 @@ public final class DocumentModelBuilder {
     }
 
     private static final Pattern NUMERIC_ENTITY = Pattern.compile("&#(?:([0-9]{1,7})|[xX]([0-9a-fA-F]{1,6}));");
+
+    private static final Pattern SVG_FRAGMENT = Pattern.compile("<svg\\b.*?</svg\\s*>",
+            Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
 
     private static String orEmpty(String s) {
         return s == null ? "" : s;

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -2727,16 +2727,29 @@ div.navigator .goto a[disabled] {
   height: auto;
 }
 
-/* Links in SVG-view figures follow the page's link colors (matching the a /
-   a:hover rules above). CSS overrides the SVG's own fill presentation
-   attributes, which queries keep as a fallback for standalone rendering. */
+/* Links in SVG figures (both SVG views and inline SVG in HTML snippets) follow
+   the page's link colors (matching the a / a:hover rules above). CSS overrides
+   the SVG's own fill presentation attributes, which queries keep as a fallback
+   for standalone rendering. */
 .svg-view-content a text,
-.svg-view-content a tspan {
+.svg-view-content a tspan,
+.cell-data-html a text,
+.cell-data-html a tspan,
+.inline-list a text,
+.inline-list a tspan,
+.paragraph-content a text,
+.paragraph-content a tspan {
   fill: #0b73da;
 }
 
 .svg-view-content a:hover text,
-.svg-view-content a:hover tspan {
+.svg-view-content a:hover tspan,
+.cell-data-html a:hover text,
+.cell-data-html a:hover tspan,
+.inline-list a:hover text,
+.inline-list a:hover tspan,
+.paragraph-content a:hover text,
+.paragraph-content a:hover tspan {
   fill: #6eb2f7;
 }
 
@@ -3021,6 +3034,16 @@ a.source:hover {
 .cell-data-html span,
 .cell-data-html div {
   margin: 0;
+}
+
+/* Inline SVG in HTML snippets coming from queries (table cells, list entries and
+   paragraph content), scaled down to the available width like SVG-view figures. */
+.cell-data-html svg,
+.inline-list svg,
+.paragraph-content svg {
+  max-width: 100%;
+  height: auto;
+  vertical-align: middle;
 }
 
 /* Advanced/Simple mode toggle */

--- a/src/test/java/com/knowledgepixels/nanodash/UtilsTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/UtilsTest.java
@@ -175,6 +175,33 @@ class UtilsTest {
     }
 
     @Test
+    void toLabelTextDropsSvgAndTags() {
+        // The label of an HTML value with an inline figure, as published from a
+        // template whose nanopub label pattern includes that placeholder.
+        String value = "<div>\nImage Test:\n<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 8 8\" width=\"2cm\">\n"
+                + "<path d=\"M5,8H8L3,0H0M8,4.8V0H5M0,3.2V8H3\"/>\n</svg>\n</div>";
+        assertEquals("Image Test:", Utils.toLabelText(value));
+    }
+
+    @Test
+    void toLabelTextDropsSvgFromNonHtmlValue() {
+        // The value doesn't start with a tag, so it isn't HTML by our rule, but a
+        // figure is never label text either.
+        assertEquals("Image Test:", Utils.toLabelText("Image Test: <svg viewBox=\"0 0 8 8\"><rect/></svg>"));
+    }
+
+    @Test
+    void toLabelTextLeavesPlainTextAlone() {
+        assertEquals("a < b and c > d", Utils.toLabelText("  a < b and c > d "));
+    }
+
+    @Test
+    void htmlToPlainTextUnescapesEntities() {
+        assertEquals("a < b & c d", Utils.htmlToPlainText("<p>a &lt; b &amp; c</p> <b>d</b>"));
+        assertEquals("\"quoted\" and 'single' and é", Utils.htmlToPlainText("&#34;quoted&#34; and &#39;single&#39; and &#xe9;"));
+    }
+
+    @Test
     void looksLikeHtmlRecognizesInlineSvg() {
         assertTrue(Utils.looksLikeHtml("<svg viewBox=\"0 0 10 10\"><rect/></svg>"));
         assertFalse(Utils.looksLikeHtml("svg is a format"));

--- a/src/test/java/com/knowledgepixels/nanodash/UtilsTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/UtilsTest.java
@@ -138,6 +138,49 @@ class UtilsTest {
     }
 
     @Test
+    void sanitizeHtmlKeepsInlineSvg() {
+        String rawHtml = "<p>Chart:</p><svg viewBox=\"0 0 20 10\" width=\"20\" height=\"10\">"
+                + "<rect x=\"0\" y=\"0\" width=\"5\" height=\"5\" fill=\"#eee\"/>"
+                + "<text x=\"1\" y=\"9\" font-size=\"4\">hi</text></svg>";
+        String sanitized = Utils.sanitizeHtml(rawHtml);
+        for (String kept : new String[] {"<p>Chart:</p>", "<svg", "viewBox=\"0 0 20 10\"", "<rect",
+                "fill=\"#eee\"", "</rect><text", "font-size=\"4\"", "hi"}) {
+            assertTrue(sanitized.contains(kept), "expected to keep: " + kept + " in: " + sanitized);
+        }
+    }
+
+    @Test
+    void sanitizeHtmlRemovesScriptingFromInlineSvg() {
+        String rawHtml = "<div><svg width=\"10\" height=\"10\">"
+                + "<script>alert('XSS')</script>"
+                + "<rect width=\"10\" height=\"10\" onclick=\"alert('XSS')\" style=\"fill:red\"></rect>"
+                + "<foreignObject><body onload=\"alert('XSS')\">x</body></foreignObject>"
+                + "<use href=\"https://evil.example/x.svg#a\"></use>"
+                + "</svg></div>";
+        String sanitized = Utils.sanitizeHtml(rawHtml);
+        for (String dropped : new String[] {"<script", "alert", "onclick", "onload", "style", "<foreignObject",
+                "<use", "evil.example"}) {
+            assertFalse(sanitized.contains(dropped), "expected to drop: " + dropped + " but got: " + sanitized);
+        }
+        assertTrue(sanitized.contains("<rect width=\"10\" height=\"10\""));
+    }
+
+    @Test
+    void sanitizeHtmlLeavesHtmlSelfClosedElementsAlone() {
+        // Only SVG element names are expanded to explicit end tags; HTML void
+        // elements (and element names that merely start with an SVG one) are not.
+        String sanitized = Utils.sanitizeHtml("<p>a<br/>b</p><img src=\"x.png\"/>");
+        assertFalse(sanitized.contains("</br>"), "unexpected: " + sanitized);
+        assertEquals("<p>a<br />b</p><img src=\"x.png\" />", sanitized);
+    }
+
+    @Test
+    void looksLikeHtmlRecognizesInlineSvg() {
+        assertTrue(Utils.looksLikeHtml("<svg viewBox=\"0 0 10 10\"><rect/></svg>"));
+        assertFalse(Utils.looksLikeHtml("svg is a format"));
+    }
+
+    @Test
     void sanitizeSvgKeepsStaticSvgSubset() {
         String rawSvg = "<svg viewBox=\"0 0 504 900\" width=\"504\" height=\"900\" font-family=\"sans-serif\">"
                 + "<rect x=\"20\" y=\"8\" width=\"464\" height=\"34\" rx=\"6\" fill=\"#dbeafe\" stroke=\"#93c5fd\"></rect>"

--- a/src/test/java/com/knowledgepixels/nanodash/component/StatusLineTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/component/StatusLineTest.java
@@ -13,6 +13,8 @@ import org.nanopub.extra.services.ApiResponseEntry;
 
 import java.io.File;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -88,6 +90,40 @@ class StatusLineTest {
         String renderedHtml = wicketTester.getLastResponseAsString();
 
         assertTrue(renderedHtml.contains("This nanopublication has <strong>newer versions</strong>:"));
+    }
+
+    @Test
+    void statusLineIgnoresSelfAndDuplicateRows() {
+        // The query's supersedes path is reflexive and joins on the indexed
+        // signature keys and creation dates, so the nanopublication comes back as
+        // its own "newer version", possibly many times over.
+        ApiResponse response = new ApiResponse();
+        for (int i = 0; i < 12; i++) {
+            response.getData().add(entry(TRUSTY_C, "", ""));
+        }
+        StatusLine statusLine = new StatusLine("testMarkupId", TRUSTY_C, response, null);
+
+        wicketTester.startComponentInPage(statusLine);
+        String renderedHtml = wicketTester.getLastResponseAsString();
+
+        assertTrue(renderedHtml.contains("This is the latest version."));
+        assertFalse(renderedHtml.contains("newer version"));
+    }
+
+    @Test
+    void statusLineListsEachNewerVersionOnce() {
+        ApiResponse response = new ApiResponse();
+        response.getData().add(entry(TRUSTY_C, "", ""));
+        response.getData().add(entry(TRUSTY_A, "", ""));
+        response.getData().add(entry(TRUSTY_A, "", ""));
+        StatusLine statusLine = new StatusLine("testMarkupId", TRUSTY_C, response, null);
+
+        wicketTester.startComponentInPage(statusLine);
+        String renderedHtml = wicketTester.getLastResponseAsString();
+
+        assertTrue(renderedHtml.contains("This nanopublication has a <strong>newer version</strong>:"));
+        // One rendered link label, not one per duplicate row.
+        assertEquals(1, renderedHtml.split("<span>RAAAAAAAAA</span>", -1).length - 1, renderedHtml);
     }
 
     @Test


### PR DESCRIPTION
Three independent changes, one commit each.

## `feat`: inline SVG in HTML snippets

HTML coming out of a query (table cells, list entries, plain-paragraph content) was sanitized by a policy that dropped `<svg>` entirely, so SVG could only be shown through a dedicated `kpxl:SvgView`. The static-SVG subset is now shared between the two policies, so inline SVG survives with the same guarantees the SVG view already had: no `script`/`style`/`foreignObject`/`use`/`image`, no event handlers, `http(s)` links only.

- `looksLikeHtml()` recognizes a leading `<svg>` — without it a value that is nothing but SVG never reached the sanitizer and was shown as escaped source.
- The self-closed-tag normalization (`<rect …/>` → `<rect …></rect>`, needed because the HTML-parsing sanitizer would otherwise swallow the following siblings) now runs for HTML too, restricted to SVG element names so `<br/>`/`<img/>` keep their HTML parsing, and requiring whitespace before the attributes so `<glyph/>` isn't matched as `g` + attributes.
- Export: `HtmlWriter` carries the SVG through; RTF/PDF use the plain-text fallback, and `htmlToPlainText()` now drops whole `<svg>…</svg>` fragments instead of emitting their labels as a run of loose words.
- Inline SVG gets the same sizing (`max-width: 100%`) and link colors as SVG-view figures.

`data:` URIs are still blocked, so `<img src="data:image/svg+xml,…">` does not work; an `https:` `.svg` URL in `<img>` worked before and still does.

Note for authors: an `<svg>` that declares no `width`/`height` defaults to `width: 100%`, which collapses to zero inside the shrink-to-fit containers used for HTML snippets. Setting the attributes (both are on the allowlist) avoids that.

## `fix`: a nanopublication is not its own newer version

The supersedes path in `get-newer-versions-of-np` is reflexive, so the nanopublication itself is always in the result set. `StatusLine` only recognized that as "latest version" when it was the *single* result — so a nanopublication with two real newer versions listed itself alongside them.

Rows can also repeat: the query joins on the indexed signature keys and creation dates without projecting them and without `DISTINCT`, so a version comes back once per (key, date) pair. Hitting a query instance whose `npa:graph` holds the metadata of several nanopublications merged onto one subject (4 keys × 4 `dct:created` values, observed on one instance) produced a status line linking the same nanopublication twelve times. Self-references are now dropped and duplicates collapse.

## `fix`: generated nanopublication labels are plain text

The label a template's nanopub label pattern produces took placeholder values verbatim, so an HTML value ended up as a label of markup, truncated mid-attribute. SVG figures are now dropped wherever they occur in a value, and a value that is HTML is reduced to its text before the label is assembled — e.g. the value

```html
<div>
Image Test:
<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8" width="2cm">
<path d="M5,8H8L3,0H0M8,4.8V0H5M0,3.2V8H3"/>
</svg>
</div>
```

now yields the label `Image Test:` instead of `<div> Image Test: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8" width="2cm"> <path d=...`. Already-published labels are unaffected; this applies to nanopublications created from now on.

The plain-text reduction the document export already had moves to `Utils` and is shared by both.

## Testing

`mvn test` — 1122 tests, 0 failures. New coverage: inline SVG kept, scripting/styling dropped, HTML void elements untouched, `looksLikeHtml` on `<svg>`, the two `StatusLine` cases, and label text from HTML/SVG values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
