### PR TITLE
fix: refresh the acted-on view, not the whole page structure (#622)

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/PostPublishRefresh.java
+++ b/src/main/java/com/knowledgepixels/nanodash/PostPublishRefresh.java
@@ -1,0 +1,122 @@
+package com.knowledgepixels.nanodash;
+
+import com.knowledgepixels.nanodash.domain.AbstractResourceWithProfile;
+import com.knowledgepixels.nanodash.domain.Space;
+import com.knowledgepixels.nanodash.vocabulary.KPXL_TERMS;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Statement;
+import org.nanopub.Nanopub;
+import org.nanopub.NanopubUtils;
+import org.nanopub.vocabulary.NPX;
+
+import java.util.Set;
+
+/**
+ * Decides what a publication has to invalidate (issue #622).
+ * <p>
+ * A publication made from a view's action button names the view's query in
+ * {@code refresh-upon-publish}, and that query is what has to be re-run — the view then
+ * updates where it stands. The publish flow used to <em>also</em> refresh the whole
+ * context resource on top of that, on every publication, which re-runs the resource's
+ * view-display query and rebuilds the entire page structure around the view. That is the
+ * right thing only for the publications that actually change the structure: which views a
+ * resource shows, and who may see them.
+ */
+public class PostPublishRefresh {
+
+    private PostPublishRefresh() {
+    }  // no instances allowed
+
+    /**
+     * Nanopub types (npx:hasNanopubType) that make a publication part of a resource's page
+     * structure: its view displays, the presets supplying them, the resource or space
+     * declaration itself, and the views being displayed.
+     */
+    private static final Set<IRI> STRUCTURAL_TYPES = Set.of(
+            KPXL_TERMS.VIEW_DISPLAY,
+            KPXL_TERMS.ACTIVATED_VIEW_DISPLAY,
+            KPXL_TERMS.DEACTIVATED_VIEW_DISPLAY,
+            KPXL_TERMS.TOP_LEVEL_VIEW_DISPLAY,
+            KPXL_TERMS.PART_LEVEL_VIEW_DISPLAY,
+            KPXL_TERMS.PRESET,
+            KPXL_TERMS.PRESET_ASSIGNMENT,
+            KPXL_TERMS.ACTIVATED_PRESET_ASSIGNMENT,
+            KPXL_TERMS.DEACTIVATED_PRESET_ASSIGNMENT,
+            KPXL_TERMS.VIEW_ENTITY,
+            KPXL_TERMS.ROLE_INSTANTIATION,
+            KPXL_TERMS.SPACE,
+            KPXL_TERMS.MAINTAINED_RESOURCE
+    );
+
+    /**
+     * Assertion predicates that make a publication part of a resource's page structure,
+     * for the publications whose type alone does not say so.
+     */
+    private static final Set<IRI> STRUCTURAL_PREDICATES = Set.of(
+            KPXL_TERMS.IS_DISPLAY_OF_VIEW,
+            KPXL_TERMS.IS_DISPLAY_FOR,
+            KPXL_TERMS.IS_ASSIGNMENT_OF_PRESET,
+            KPXL_TERMS.IS_ASSIGNMENT_FOR,
+            KPXL_TERMS.HAS_TOP_LEVEL_VIEW,
+            KPXL_TERMS.HAS_VIEW,
+            KPXL_TERMS.HAS_ADMIN_PREDICATE,
+            KPXL_TERMS.HAS_ROLE,
+            KPXL_TERMS.IS_VISIBLE_TO,
+            KPXL_TERMS.IS_MAINTAINED_BY,
+            KPXL_TERMS.HAS_ROOT_DEFINITION,
+            KPXL_TERMS.GOVERNED_BY,
+            // A retraction says nothing about what it retracts, so it is taken to possibly
+            // be the removal of a view display, a preset assignment or a role.
+            NPX.RETRACTS
+    );
+
+    /**
+     * Whether the publication can change the page structure of the given context resource:
+     * the set of views the resource shows, or the roles that decide who sees them. When it
+     * cannot, the publication only affects the contents of one or more views, and refreshing
+     * the view queries it named is enough.
+     *
+     * @param np        the just-published nanopub
+     * @param contextId the id of the context resource whose page is being returned to
+     * @return true if the context resource's own data has to be refreshed as well
+     */
+    public static boolean changesPageStructure(Nanopub np, String contextId) {
+        if (np == null) return false;
+        for (IRI type : NanopubUtils.getTypes(np)) {
+            if (STRUCTURAL_TYPES.contains(type)) return true;
+        }
+        Set<IRI> rolePredicates = rolePredicatesOf(contextId);
+        for (Statement st : np.getAssertion()) {
+            IRI predicate = st.getPredicate();
+            if (STRUCTURAL_PREDICATES.contains(predicate)) return true;
+            // Roles are assigned with the space's own role predicates, which are declared
+            // per space rather than drawn from a fixed vocabulary, so they are matched
+            // against the space being returned to.
+            if (rolePredicates.contains(predicate)) return true;
+        }
+        return false;
+    }
+
+    /**
+     * The role-assigning predicates declared by the context resource's space, in both
+     * directions, or an empty set when the context is not a space (or its roles are not
+     * loaded).
+     *
+     * @param contextId the id of the context resource
+     * @return the role predicates to watch for
+     */
+    private static Set<IRI> rolePredicatesOf(String contextId) {
+        if (contextId == null || contextId.isEmpty()) return Set.of();
+        AbstractResourceWithProfile resource = AbstractResourceWithProfile.get(contextId);
+        if (!(resource instanceof Space space)) return Set.of();
+        Set<IRI> predicates = new java.util.HashSet<>();
+        for (SpaceMemberRoleRef roleRef : space.getRoles()) {
+            SpaceMemberRole role = roleRef.getRole();
+            if (role == null) continue;
+            for (IRI p : role.getRegularProperties()) predicates.add(p);
+            for (IRI p : role.getInverseProperties()) predicates.add(p);
+        }
+        return predicates;
+    }
+
+}

--- a/src/main/java/com/knowledgepixels/nanodash/QueryResult.java
+++ b/src/main/java/com/knowledgepixels/nanodash/QueryResult.java
@@ -84,6 +84,15 @@ public abstract class QueryResult extends Panel {
      *
      * @param refreshing true while the view's results are being brought up to date
      */
+    /**
+     * The query reference this view's results come from.
+     *
+     * @return the query reference
+     */
+    public QueryRef getQueryRef() {
+        return queryRef;
+    }
+
     public void setRefreshing(boolean refreshing) {
         refreshIndicator.setVisible(refreshing);
     }

--- a/src/main/java/com/knowledgepixels/nanodash/component/PageTitleMenu.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/PageTitleMenu.html
@@ -2,8 +2,9 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:wicket="http://wicket.apache.org">
 <body>
 <wicket:panel>
+  <span wicket:id="spinner" class="refresh-spinner" title="Updating this page..."></span>
   <span class="actionmenu title-menu">
-    <button type="button" class="actionmenu-button" aria-label="space actions"></button>
+    <button type="button" class="actionmenu-button" aria-label="page actions"></button>
     <span class="actionmenu-content">
       <span wicket:id="groups" class="actionmenu-subitem">
         <span wicket:id="sublabel" class="actionmenu-sublabel">add to calendar</span>
@@ -13,6 +14,8 @@
       </span>
       <hr wicket:id="separator" class="actionmenu-separator"/>
       <span wicket:id="extraEntries" class="actionmenu-item"><a wicket:id="link">entry</a></span>
+      <hr wicket:id="refreshSeparator" class="actionmenu-separator"/>
+      <a wicket:id="refreshNow"><span class="actionmenu-icon">↻</span>refresh now</a>
     </span>
   </span>
 </wicket:panel>

--- a/src/main/java/com/knowledgepixels/nanodash/component/PageTitleMenu.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/PageTitleMenu.html
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:wicket="http://wicket.apache.org">
 <body>
 <wicket:panel>
-  <span wicket:id="spinner" class="refresh-spinner" title="Updating this page..."></span>
   <span class="actionmenu title-menu">
     <button type="button" class="actionmenu-button" aria-label="page actions"></button>
     <span class="actionmenu-content">
@@ -18,6 +17,7 @@
       <a wicket:id="refreshNow"><span class="actionmenu-icon">↻</span>refresh now</a>
     </span>
   </span>
+  <span wicket:id="spinner" class="refresh-spinner" title="Updating this page..."></span>
 </wicket:panel>
 </body>
 </html>

--- a/src/main/java/com/knowledgepixels/nanodash/component/PageTitleMenu.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/PageTitleMenu.java
@@ -54,8 +54,8 @@ import java.util.Set;
  * calendar", "add events to calendar") and opens its entries in a submenu flyout on
  * hover; the configuration shortcuts are plain entries below them.
  *
- * <p>Beside the chevron sits the {@link StructureRefreshIndicator}: the spinner saying the
- * page structure is being recalculated (issue #622).</p>
+ * <p>Just right of the chevron sits the {@link StructureRefreshIndicator}: the spinner
+ * saying the page structure is being recalculated (issue #622).</p>
  *
  * <p>Each supplied link must use the markup id {@code "link"}; the links are rendered in
  * order as menu entries.</p>

--- a/src/main/java/com/knowledgepixels/nanodash/component/PageTitleMenu.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/PageTitleMenu.java
@@ -1,10 +1,14 @@
 package com.knowledgepixels.nanodash.component;
 
+import com.knowledgepixels.nanodash.ApiCache;
+import com.knowledgepixels.nanodash.NanodashSession;
+import com.knowledgepixels.nanodash.QueryResult;
 import com.knowledgepixels.nanodash.SpaceMemberRole;
 import com.knowledgepixels.nanodash.Utils;
 import com.knowledgepixels.nanodash.View;
 import com.knowledgepixels.nanodash.calendar.CalendarEvent;
 import com.knowledgepixels.nanodash.calendar.CalendarUrls;
+import com.knowledgepixels.nanodash.domain.AbstractResourceWithProfile;
 import com.knowledgepixels.nanodash.domain.Space;
 import com.knowledgepixels.nanodash.page.CalendarFeedPage;
 import com.knowledgepixels.nanodash.page.PublishPage;
@@ -14,6 +18,7 @@ import com.knowledgepixels.nanodash.vocabulary.KPXL_TERMS;
 import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.Component;
 import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.ajax.markup.html.AjaxFallbackLink;
 import org.apache.wicket.ajax.markup.html.AjaxLink;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
@@ -32,23 +37,32 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.Serializable;
+import org.apache.wicket.util.visit.IVisitor;
+import org.nanopub.extra.services.QueryRef;
+
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 /**
- * The dropdown next to a space title: a regular chevron menu (like the other dropdowns)
- * offering the space's calendar actions and, for maintainer-tier members and above, the
+ * The dropdown next to a page title: a regular chevron menu (like the other dropdowns)
+ * offering whatever the page as a whole can be asked to do. Every logged-in viewer gets
+ * "refresh now", the page-level counterpart of a view display's own refresh entry; a space
+ * additionally gets its calendar actions and, for maintainer-tier members and above, the
  * space-configuration shortcuts. Each calendar entry names a group of actions ("add to
  * calendar", "add events to calendar") and opens its entries in a submenu flyout on
  * hover; the configuration shortcuts are plain entries below them.
  *
+ * <p>Beside the chevron sits the {@link StructureRefreshIndicator}: the spinner saying the
+ * page structure is being recalculated (issue #622).</p>
+ *
  * <p>Each supplied link must use the markup id {@code "link"}; the links are rendered in
  * order as menu entries.</p>
  */
-public class SpaceTitleMenu extends Panel {
+public class PageTitleMenu extends Panel {
 
-    private static final Logger logger = LoggerFactory.getLogger(SpaceTitleMenu.class);
+    private static final Logger logger = LoggerFactory.getLogger(PageTitleMenu.class);
 
     /** A submenu: its label in the top-level dropdown, and the entries of its flyout. */
     private record Group(String label, List<AbstractLink> entries) implements Serializable {
@@ -62,8 +76,12 @@ public class SpaceTitleMenu extends Panel {
         }
     }
 
-    private SpaceTitleMenu(String id, List<Group> groups, List<AbstractLink> extraEntries) {
+    private PageTitleMenu(String id, List<Group> groups, List<AbstractLink> extraEntries, AbstractResourceWithProfile resource, boolean canRefresh) {
         super(id);
+        add(new StructureRefreshIndicator("spinner", resource));
+        add(new WebMarkupContainer("refreshSeparator")
+                .setVisible(canRefresh && !(groups.isEmpty() && extraEntries.isEmpty())));
+        add(refreshNowLink(resource).setVisible(canRefresh));
         add(new DataView<Group>("groups", new ListDataProvider<>(groups)) {
             @Override
             protected void populateItem(Item<Group> groupItem) {
@@ -86,8 +104,56 @@ public class SpaceTitleMenu extends Panel {
     }
 
     /**
+     * Brings the whole page up to date: the resource's own structure (which views it shows)
+     * and every view query rendered on it, then a re-render so each of them comes back
+     * through the refreshing panels — the page keeps what it has on screen and swaps in the
+     * parts that turn out to have changed. The page-level counterpart of a view display's
+     * "refresh now", which does the same for its one query.
+     *
+     * @param resource the page's resource, or null if the page has none
+     * @return the menu entry
+     */
+    private static AbstractLink refreshNowLink(AbstractResourceWithProfile resource) {
+        // Held by id: see StructureRefreshIndicator on why the singleton itself is not kept.
+        final String resourceId = resource == null ? null : resource.getId();
+        return new AjaxFallbackLink<Void>("refreshNow") {
+            @Override
+            public void onClick(Optional<AjaxRequestTarget> target) {
+                AbstractResourceWithProfile r = resourceId == null ? null : AbstractResourceWithProfile.get(resourceId);
+                if (r != null) r.forceRefresh(0);
+                getPage().visitChildren(QueryResult.class, (IVisitor<QueryResult, Void>) (view, visit) -> {
+                    QueryRef queryRef = view.getQueryRef();
+                    if (queryRef != null) ApiCache.clearCache(queryRef, 0);
+                });
+                setResponsePage(getPage().getClass(), getPage().getPageParameters());
+            }
+        };
+    }
+
+    /**
+     * The title menu for a page showing a resource that is not a space: the refresh entry
+     * and the structure spinner. Invisible for viewers who are not logged in, who have
+     * nothing to ask of the page.
+     *
+     * @param id       the Wicket component id
+     * @param resource the resource whose page this is
+     * @return the menu, or an invisible {@link EmptyPanel}
+     */
+    public static Component forResource(String id, AbstractResourceWithProfile resource) {
+        return build(id, new ArrayList<>(), new ArrayList<>(), resource);
+    }
+
+    private static Component build(String id, List<Group> groups, List<AbstractLink> extraEntries, AbstractResourceWithProfile resource) {
+        boolean canRefresh = resource != null && NanodashSession.get().getUserIri() != null;
+        if (groups.isEmpty() && extraEntries.isEmpty() && !canRefresh) {
+            return new EmptyPanel(id).setVisible(false);
+        }
+        return new PageTitleMenu(id, groups, extraEntries, resource, canRefresh);
+    }
+
+    /**
      * The title menu for a space, or an invisible placeholder when there is nothing to
-     * offer: no calendar-relevant dates and no configuration rights.
+     * offer: no calendar-relevant dates, no configuration rights and nobody logged in.
      *
      * <p>An Event space offers its own date as a one-off copy (an {@code .ics} file, or a
      * pre-filled form at Google or Outlook). A space containing Events offers a
@@ -134,10 +200,7 @@ public class SpaceTitleMenu extends Panel {
             if (addViewDisplay != null) extraEntries.add(addViewDisplay);
         }
 
-        if (groups.isEmpty() && extraEntries.isEmpty()) {
-            return new EmptyPanel(id).setVisible(false);
-        }
-        return new SpaceTitleMenu(id, groups, extraEntries);
+        return build(id, groups, extraEntries, space);
     }
 
     /**

--- a/src/main/java/com/knowledgepixels/nanodash/component/PublishForm.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/PublishForm.java
@@ -557,9 +557,13 @@ public class PublishForm extends Panel {
                     // Broaden the refresh: also force-refresh the context resource's own
                     // data (e.g. a space's roles/members) so the page we redirect to —
                     // typically its Content tab — reflects the just-published change, not
-                    // only the specific view query that was acted on.
+                    // only the specific view query that was acted on. Only for publications
+                    // that can change the page structure, though: for the rest, re-running
+                    // the resource's view-display query and rebuilding the page around the
+                    // view would only get in the way of the view's own refresh (#622).
                     if (!contextId.isEmpty() && !contextId.equals(toRefresh)
-                            && AbstractResourceWithProfile.isResourceWithProfile(contextId)) {
+                            && AbstractResourceWithProfile.isResourceWithProfile(contextId)
+                            && PostPublishRefresh.changesPageStructure(signedNp, contextId)) {
                         WicketApplication.get().notifyNanopubPublished(signedNp, contextId, 5 * 1000);
                     }
                     if (pageParams.get("postpub-redirect-url").isEmpty() && confirmPageClass == null) {

--- a/src/main/java/com/knowledgepixels/nanodash/component/RefreshingStructurePanel.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/RefreshingStructurePanel.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html xmlns:wicket="http://wicket.apache.org">
+<body>
+
+<!-- As in LazyContentPanel: a container rather than an element, so the wrapped content
+     sits in the page exactly where the directly rendered one does. -->
+<wicket:panel><wicket:container wicket:id="content"></wicket:container></wicket:panel>
+
+</body>
+</html>

--- a/src/main/java/com/knowledgepixels/nanodash/component/RefreshingStructurePanel.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/RefreshingStructurePanel.java
@@ -1,0 +1,110 @@
+package com.knowledgepixels.nanodash.component;
+
+import com.knowledgepixels.nanodash.domain.AbstractResourceWithProfile;
+import org.apache.wicket.Component;
+import org.apache.wicket.ajax.AbstractAjaxTimerBehavior;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.markup.html.panel.Panel;
+
+import java.io.Serial;
+import java.time.Duration;
+import java.util.Objects;
+
+/**
+ * Keeps a resource's currently loaded page structure (its {@link ViewList} of view
+ * displays) on screen while a refresh of that structure is in flight, and swaps in the
+ * rebuilt one once the refreshed data has landed — but only if the structure actually
+ * changed (issue #622).
+ * <p>
+ * The counterpart of {@link RefreshingResultPanel} one level up: that one keeps a single
+ * view's outdated results visible while its query is re-fetched, this one keeps the set of
+ * views itself visible while the resource's view-display query is re-fetched. Blanking the
+ * whole content area out instead — which is what {@code forceRefresh} used to do by
+ * invalidating the loaded data — also destroyed the in-place refresh of the very view the
+ * user had just published from, since every view panel was rebuilt cold afterwards.
+ */
+public class RefreshingStructurePanel extends Panel {
+
+    private static final String CONTENT_ID = "content";
+
+    private static final Duration POLL_INTERVAL = Duration.ofSeconds(1);
+
+    // How long to keep waiting for the refreshed structure before settling on the one
+    // shown; the same budget the refreshing result panels get.
+    private static final long REFRESH_TIMEOUT_MS = 60_000;
+
+    /**
+     * Wraps the content in a refreshing panel while the resource's structure refresh is
+     * pending, and returns the content itself otherwise, so an ordinary render neither
+     * gains a wrapper nor a polling timer.
+     *
+     * @param id       the Wicket markup id
+     * @param resource the resource whose structure the content renders
+     * @param factory  builds the content component for a markup id
+     * @return the content component, or a refreshing panel around it
+     */
+    public static Component of(String id, AbstractResourceWithProfile resource, LazyContentPanel.ContentFactory factory) {
+        if (resource == null || !resource.isStructureRefreshPending()) return factory.create(id);
+        return new RefreshingStructurePanel(id, resource, factory);
+    }
+
+    private final String resourceId;
+    private final LazyContentPanel.ContentFactory factory;
+    private final String shownSignature;
+    private final long deadline;
+
+    private RefreshingStructurePanel(String id, AbstractResourceWithProfile resource, LazyContentPanel.ContentFactory factory) {
+        super(id);
+        // Held by id rather than by reference: the resources are process-wide singletons,
+        // and a copy revived from the page store would carry its own stale refresh flags.
+        this.resourceId = resource.getId();
+        this.factory = factory;
+        this.shownSignature = resource.getStructureSignature();
+        this.deadline = System.currentTimeMillis() + REFRESH_TIMEOUT_MS;
+        setOutputMarkupId(true);
+        add(factory.create(CONTENT_ID));
+        add(new StructurePollTimer());
+    }
+
+    private void poll(AjaxRequestTarget target, AbstractAjaxTimerBehavior timer) {
+        AbstractResourceWithProfile resource = AbstractResourceWithProfile.get(resourceId);
+        if (resource == null) {
+            timer.stop(target);
+            return;
+        }
+        if (resource.isStructureRefreshPending()) {
+            if (System.currentTimeMillis() > deadline) timer.stop(target);
+            return;
+        }
+        timer.stop(target);
+        if (Objects.equals(shownSignature, resource.getStructureSignature())) {
+            // The refresh left the page structure as it is, so there is nothing worth
+            // rebuilding — and rebuilding anyway would throw away whatever the user is
+            // doing in the views (a typed filter, an open menu, the current table page).
+            return;
+        }
+        addOrReplace(factory.create(CONTENT_ID));
+        target.add(this);
+    }
+
+    /**
+     * Polls for the refreshed structure, in the manner of Wicket's own
+     * {@code AjaxLazyLoadPanel} timer: one per panel, removing itself once it is done.
+     */
+    private class StructurePollTimer extends AbstractAjaxTimerBehavior {
+
+        @Serial
+        private static final long serialVersionUID = 1L;
+
+        StructurePollTimer() {
+            super(POLL_INTERVAL);
+        }
+
+        @Override
+        protected void onTimer(AjaxRequestTarget target) {
+            poll(target, this);
+        }
+
+    }
+
+}

--- a/src/main/java/com/knowledgepixels/nanodash/component/StructureRefreshIndicator.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/StructureRefreshIndicator.java
@@ -9,11 +9,11 @@ import java.io.Serial;
 import java.time.Duration;
 
 /**
- * The spinner beside a page's title menu, shown while the page structure — which views the
- * resource shows — is being recalculated after a publication that can change it (issue
- * #622). The views themselves each show their own spinner while their query is re-run
- * ({@link RefreshingResultPanel}); this one is about the page as a whole, whose recalculation
- * is otherwise invisible now that it no longer blanks the content out.
+ * The spinner just right of a page's title menu, shown while the page structure — which
+ * views the resource shows — is being recalculated after a publication that can change it
+ * (issue #622). The views themselves each show their own spinner while their query is
+ * re-run ({@link RefreshingResultPanel}); this one is about the page as a whole, whose
+ * recalculation is otherwise invisible now that it no longer blanks the content out.
  * <p>
  * It polls on its own rather than being driven by {@link RefreshingStructurePanel}: the
  * structure is not always rendered through that panel (an empty one still goes down the

--- a/src/main/java/com/knowledgepixels/nanodash/component/StructureRefreshIndicator.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/StructureRefreshIndicator.java
@@ -1,0 +1,87 @@
+package com.knowledgepixels.nanodash.component;
+
+import com.knowledgepixels.nanodash.domain.AbstractResourceWithProfile;
+import org.apache.wicket.ajax.AbstractAjaxTimerBehavior;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.markup.html.WebMarkupContainer;
+
+import java.io.Serial;
+import java.time.Duration;
+
+/**
+ * The spinner beside a page's title menu, shown while the page structure — which views the
+ * resource shows — is being recalculated after a publication that can change it (issue
+ * #622). The views themselves each show their own spinner while their query is re-run
+ * ({@link RefreshingResultPanel}); this one is about the page as a whole, whose recalculation
+ * is otherwise invisible now that it no longer blanks the content out.
+ * <p>
+ * It polls on its own rather than being driven by {@link RefreshingStructurePanel}: the
+ * structure is not always rendered through that panel (an empty one still goes down the
+ * pages' lazy path), and a title that sits outside the content area has no other way of
+ * hearing that the refresh has landed. The timer is only installed when a refresh is
+ * actually pending, so an ordinary page render carries no polling at all.
+ */
+public class StructureRefreshIndicator extends WebMarkupContainer {
+
+    private static final Duration POLL_INTERVAL = Duration.ofSeconds(1);
+
+    // How long to keep the spinner up before giving up on the refresh; the same budget the
+    // refreshing view panels get.
+    private static final long TIMEOUT_MS = 60_000;
+
+    // Held by id rather than by reference: the resources are process-wide singletons, and a
+    // copy revived from the page store would carry its own stale refresh flags.
+    private final String resourceId;
+
+    private final long deadline;
+
+    /**
+     * @param id       the Wicket markup id
+     * @param resource the resource whose structure is being watched, or null for none
+     */
+    public StructureRefreshIndicator(String id, AbstractResourceWithProfile resource) {
+        super(id);
+        this.resourceId = resource == null ? null : resource.getId();
+        this.deadline = System.currentTimeMillis() + TIMEOUT_MS;
+        setOutputMarkupPlaceholderTag(true);
+        if (isRefreshing()) add(new IndicatorPollTimer());
+    }
+
+    private boolean isRefreshing() {
+        if (resourceId == null) return false;
+        AbstractResourceWithProfile resource = AbstractResourceWithProfile.get(resourceId);
+        return resource != null && resource.isStructureRefreshPending();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void onConfigure() {
+        super.onConfigure();
+        setVisible(isRefreshing());
+    }
+
+    /**
+     * Polls for the end of the refresh and takes the spinner away when it lands.
+     */
+    private class IndicatorPollTimer extends AbstractAjaxTimerBehavior {
+
+        @Serial
+        private static final long serialVersionUID = 1L;
+
+        IndicatorPollTimer() {
+            super(POLL_INTERVAL);
+        }
+
+        @Override
+        protected void onTimer(AjaxRequestTarget target) {
+            if (isRefreshing() && System.currentTimeMillis() <= deadline) return;
+            setVisible(false);
+            target.add(StructureRefreshIndicator.this);
+            stop(target);
+        }
+
+    }
+
+}

--- a/src/main/java/com/knowledgepixels/nanodash/domain/AbstractResourceWithProfile.java
+++ b/src/main/java/com/knowledgepixels/nanodash/domain/AbstractResourceWithProfile.java
@@ -37,10 +37,16 @@ public abstract class AbstractResourceWithProfile implements Serializable, Resou
 
     private final String id;
     private Space space;
-    private ResourceWithProfile data = new ResourceWithProfile();
+    // Volatile: replaced wholesale by the update task on a pool thread and read by the
+    // request threads rendering (and polling for) the structure it holds.
+    private volatile ResourceWithProfile data = new ResourceWithProfile();
     private volatile boolean dataInitialized = false;
     private volatile boolean dataNeedsUpdate = true;
     private volatile Long runUpdateAfter = null;
+    // A refresh of this resource's own data (its view displays, i.e. the page structure)
+    // requested after a publication, with the previously loaded structure kept on screen
+    // meanwhile. Cleared once the refreshed data has landed. See forceRefresh.
+    private volatile boolean structureRefreshPending = false;
 
     /**
      * Inner class to hold the data associated with a resource, including its view displays.
@@ -148,6 +154,10 @@ public abstract class AbstractResourceWithProfile implements Serializable, Resou
                     newData.viewDisplays.addAll(buildViewDisplays(viewDisplaysQueryRef()));
                     data = newData;
                     dataInitialized = true;
+                    // A forceRefresh that came in while this fetch was already running has
+                    // re-armed dataNeedsUpdate, so what just landed is not the refreshed
+                    // structure yet and the refresh stays pending for the next round.
+                    if (!dataNeedsUpdate) structureRefreshPending = false;
                 } catch (Exception ex) {
                     logger.error("Error while trying to update data for resource {}", id, ex);
                     runUpdateAfter = System.currentTimeMillis() + FAILED_UPDATE_BACKOFF_MS;
@@ -198,14 +208,56 @@ public abstract class AbstractResourceWithProfile implements Serializable, Resou
 
     /**
      * Forces a refresh of the resource data after a specified delay.
+     * <p>
+     * A structure that is already loaded is <b>kept</b>: the pages go on rendering it and
+     * swap in the rebuilt one once the refreshed data lands (see
+     * {@link com.knowledgepixels.nanodash.component.RefreshingStructurePanel}), rather
+     * than blanking out into a loading spinner for the whole ingest delay. Blanking out
+     * would also throw away the in-place refresh of the individual view the user just
+     * published from (issue #622), since the view panels would be rebuilt cold. Only an
+     * empty structure is invalidated outright, as there is nothing on screen to keep and
+     * the pages' lazy path is what makes a first view display appear.
      *
      * @param waitMillis the delay in milliseconds before the data refresh is triggered
      */
     public void forceRefresh(long waitMillis) {
         logger.info("Forcing refresh of resource {} after {} ms", id, waitMillis);
         dataNeedsUpdate = true;
-        dataInitialized = false;
+        if (dataInitialized && !data.viewDisplays.isEmpty()) {
+            structureRefreshPending = true;
+        } else {
+            dataInitialized = false;
+        }
         runUpdateAfter = System.currentTimeMillis() + waitMillis;
+    }
+
+    /**
+     * Whether a {@link #forceRefresh} of this resource's structure is still in flight while
+     * the previously loaded structure stays on screen. Triggers the pending update, so that
+     * polling this also drives it (once its delay has passed).
+     *
+     * @return true while the refreshed structure has not landed yet
+     */
+    public boolean isStructureRefreshPending() {
+        if (!structureRefreshPending) return false;
+        triggerDataUpdate();
+        return structureRefreshPending;
+    }
+
+    /**
+     * A fingerprint of the resource's view-display structure, to tell a refresh that
+     * changed the page structure from one that left it as it was.
+     *
+     * @return the fingerprint of the current structure
+     */
+    public String getStructureSignature() {
+        StringBuilder sb = new StringBuilder();
+        for (ViewDisplay vd : data.viewDisplays) {
+            sb.append(vd.getNanopubId()).append('\t')
+                    .append(vd.getViewIri()).append('\t')
+                    .append(vd.getStructuralPosition()).append('\n');
+        }
+        return sb.toString();
     }
 
     /**

--- a/src/main/java/com/knowledgepixels/nanodash/page/HomePage.html
+++ b/src/main/java/com/knowledgepixels/nanodash/page/HomePage.html
@@ -8,7 +8,8 @@
 
   <div class="row-section">
     <div class="col-12">
-      <h2><img src="images/logo.svg" alt="nanodash" style="height:2.4em;vertical-align:middle;" /></h2>
+      <h2><img src="images/logo.svg" alt="nanodash" style="height:2.4em;vertical-align:middle;" /><span
+          class="title-actions" wicket:id="titlemenu"></span></h2>
       <p><span wicket:id="warning" class="negative"></span></p>
       <p><span wicket:id="text"></span></p>
     </div>

--- a/src/main/java/com/knowledgepixels/nanodash/page/HomePage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/HomePage.java
@@ -6,6 +6,7 @@ import com.knowledgepixels.nanodash.Utils;
 import com.knowledgepixels.nanodash.WicketApplication;
 import com.knowledgepixels.nanodash.component.LazyContentPanel;
 import com.knowledgepixels.nanodash.component.ResultComponent;
+import com.knowledgepixels.nanodash.component.PageTitleMenu;
 import com.knowledgepixels.nanodash.component.RefreshingStructurePanel;
 import com.knowledgepixels.nanodash.component.TitleBar;
 import com.knowledgepixels.nanodash.component.ViewList;
@@ -92,6 +93,9 @@ public class HomePage extends NanodashPage {
 
         final String homeResourceId = NanodashPreferences.get().getHomeResource();
         final MaintainedResource homeResource = MaintainedResourceRepository.get().findById(homeResourceId);
+
+        // Added before the branching below, which returns early on several paths.
+        add(PageTitleMenu.forResource("titlemenu", homeResource));
 
         // Rendered only for a genuine misconfiguration (see below): the resource
         // repository is warm but the configured id is not a known maintained resource.

--- a/src/main/java/com/knowledgepixels/nanodash/page/HomePage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/HomePage.java
@@ -6,6 +6,7 @@ import com.knowledgepixels.nanodash.Utils;
 import com.knowledgepixels.nanodash.WicketApplication;
 import com.knowledgepixels.nanodash.component.LazyContentPanel;
 import com.knowledgepixels.nanodash.component.ResultComponent;
+import com.knowledgepixels.nanodash.component.RefreshingStructurePanel;
 import com.knowledgepixels.nanodash.component.TitleBar;
 import com.knowledgepixels.nanodash.component.ViewList;
 import org.apache.wicket.markup.html.panel.Fragment;
@@ -109,9 +110,11 @@ public class HomePage extends NanodashPage {
         if (homeResource != null) {
             homeResource.triggerDataUpdate();
             if (homeResource.isDataInitialized()) {
-                ViewList viewList = new ViewList("views", homeResource);
-                viewList.setPageFooter(new Fragment("page-footer", "homeFooterFragment", this));
-                add(viewList);
+                add(RefreshingStructurePanel.of("views", homeResource, markupId -> {
+                    ViewList viewList = new ViewList(markupId, homeResource);
+                    viewList.setPageFooter(new Fragment("page-footer", "homeFooterFragment", HomePage.this));
+                    return viewList;
+                }));
                 return;
             }
         }

--- a/src/main/java/com/knowledgepixels/nanodash/page/MaintainedResourcePage.html
+++ b/src/main/java/com/knowledgepixels/nanodash/page/MaintainedResourcePage.html
@@ -13,7 +13,8 @@
 
   <div class="row-section">
     <div class="col-12 header">
-      <h2><span wicket:id="resourcename">Resource ABC</span><span class="title-suffix" wicket:id="titlesuffix"></span></h2>
+      <h2><span wicket:id="resourcename">Resource ABC</span><span class="title-suffix" wicket:id="titlesuffix"></span><span
+          class="title-actions" wicket:id="titlemenu"></span></h2>
       <p><span wicket:id="id"></span></p>
     </div>
   </div>

--- a/src/main/java/com/knowledgepixels/nanodash/page/MaintainedResourcePage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/MaintainedResourcePage.java
@@ -90,6 +90,7 @@ public class MaintainedResourcePage extends NanodashPage {
         add(new Label("pagetitle", resource.getLabel() + " (resource) | nanodash"));
         add(new Label("resourcename", resource.getLabel()));
         add(new Label("titlesuffix", ResourceTabs.titleSuffix(activeTab)));
+        add(PageTitleMenu.forResource("titlemenu", resource));
         add(new ExternalLinkWithActionsPanel("id", Model.of(resource.getId()), Model.of(resource.getLabel()), Values.iri(resource.getNanopubId())));
 
         WebMarkupContainer contentContainer = new WebMarkupContainer("contentContainer");

--- a/src/main/java/com/knowledgepixels/nanodash/page/MaintainedResourcePage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/MaintainedResourcePage.java
@@ -101,7 +101,8 @@ public class MaintainedResourcePage extends NanodashPage {
                 if (empty) {
                     contentContainer.add(new WebMarkupContainer("views").setVisible(false));
                 } else {
-                    contentContainer.add(new ViewList("views", resource));
+                    contentContainer.add(RefreshingStructurePanel.of("views", resource,
+                            markupId -> new ViewList(markupId, resourceModel.getObject())));
                 }
                 addUnconfiguredFallback(contentContainer, resource, empty);
             } else {

--- a/src/main/java/com/knowledgepixels/nanodash/page/PreviewPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/PreviewPage.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 import com.knowledgepixels.nanodash.NanodashSession;
 import com.knowledgepixels.nanodash.NanopubElement;
 import com.knowledgepixels.nanodash.NavigationContext;
+import com.knowledgepixels.nanodash.PostPublishRefresh;
 import com.knowledgepixels.nanodash.Utils;
 import com.knowledgepixels.nanodash.WicketApplication;
 import com.knowledgepixels.nanodash.component.NanopubItem;
@@ -106,9 +107,12 @@ public class PreviewPage extends NanodashPage {
                     String contextId = pageParams.get("context").toString("");
                     // Broaden the refresh: also force-refresh the context resource's own
                     // data so the page we redirect to reflects the just-published change,
-                    // not only the specific view query that was acted on.
+                    // not only the specific view query that was acted on. Only for
+                    // publications that can change the page structure; see #622 and
+                    // PostPublishRefresh.
                     if (!contextId.isEmpty() && !contextId.equals(toRefresh)
-                            && AbstractResourceWithProfile.isResourceWithProfile(contextId)) {
+                            && AbstractResourceWithProfile.isResourceWithProfile(contextId)
+                            && PostPublishRefresh.changesPageStructure(signedNp, contextId)) {
                         WicketApplication.get().notifyNanopubPublished(signedNp, contextId, 5 * 1000);
                     }
                     if (confirmPageClass != null) {

--- a/src/main/java/com/knowledgepixels/nanodash/page/ResourcePartPage.html
+++ b/src/main/java/com/knowledgepixels/nanodash/page/ResourcePartPage.html
@@ -13,7 +13,8 @@
 
   <div class="row-section">
     <div class="col-12 header">
-      <h2><span wicket:id="name">ABC</span><span class="title-suffix" wicket:id="titlesuffix"></span></h2>
+      <h2><span wicket:id="name">ABC</span><span class="title-suffix" wicket:id="titlesuffix"></span><span
+          class="title-actions" wicket:id="titlemenu"></span></h2>
       <p><span wicket:id="id"></span></p>
     </div>
   </div>

--- a/src/main/java/com/knowledgepixels/nanodash/page/ResourcePartPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/ResourcePartPage.java
@@ -182,7 +182,8 @@ public class ResourcePartPage extends NanodashPage {
         } else {
             add(new EmptyPanel("otherTab").setVisible(false));
             if (resourceWithProfile.isDataInitialized()) {
-                contentContainer.add(new ViewList("views", resourceWithProfile, id, nanopubRef, classes));
+                contentContainer.add(RefreshingStructurePanel.of("views", resourceWithProfile,
+                        markupId -> new ViewList(markupId, resourceWithProfile, id, nanopubRef, classes)));
             } else {
                 contentContainer.add(new LazyContentPanel("views", markupId -> new ViewList(markupId, resourceWithProfile, id, nanopubRef, classes)) {
 

--- a/src/main/java/com/knowledgepixels/nanodash/page/ResourcePartPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/ResourcePartPage.java
@@ -158,6 +158,7 @@ public class ResourcePartPage extends NanodashPage {
         add(new Label("pagetitle", label + " (resource part) | nanodash"));
         add(new Label("name", label));
         add(new Label("titlesuffix", ResourceTabs.titleSuffix(activeTab)));
+        add(PageTitleMenu.forResource("titlemenu", resourceWithProfile));
         add(new ExternalLinkWithActionsPanel("id", Model.of(id), Model.of(label), nanopubId == null ? Values.iri(id) : Values.iri(nanopubId)));
 
         final String nanopubRef = nanopubId == null ? "x:" : nanopubId;

--- a/src/main/java/com/knowledgepixels/nanodash/page/SpacePage.html
+++ b/src/main/java/com/knowledgepixels/nanodash/page/SpacePage.html
@@ -14,7 +14,7 @@
   <div class="row-section">
     <div class="col-12 header">
       <h2><span wicket:id="spacename">Space ABC</span><span class="title-suffix" wicket:id="titlesuffix"></span><span
-          class="title-actions" wicket:id="calendarmenu"></span></h2>
+          class="title-actions" wicket:id="titlemenu"></span></h2>
       <p><span wicket:id="id"></span></p>
       <details class="ref-conflict-notice" wicket:id="ref-conflict">
         <summary><span wicket:id="ref-conflict-text">[notice]</span></summary>

--- a/src/main/java/com/knowledgepixels/nanodash/page/SpacePage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/SpacePage.java
@@ -110,8 +110,8 @@ public class SpacePage extends NanodashPage {
         add(new Label("titlesuffix", ResourceTabs.titleSuffix(activeTab)));
         // Calendar submenus for (event-containing) event spaces, plus configuration
         // shortcuts for maintainers+; invisible when there is neither. See
-        // SpaceTitleMenu.forSpace.
-        add(SpaceTitleMenu.forSpace("calendarmenu", space));
+        // PageTitleMenu.forSpace.
+        add(PageTitleMenu.forSpace("titlemenu", space));
         add(new ExternalLinkWithActionsPanel("id", Model.of(space.getId()), Model.of(space.getLabel())));
 
         // Disambiguation notice: shown when viewing a specific claimant (ref pinned) or the

--- a/src/main/java/com/knowledgepixels/nanodash/page/SpacePage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/SpacePage.java
@@ -172,7 +172,8 @@ public class SpacePage extends NanodashPage {
             if (empty) {
                 contentContainer.add(new WebMarkupContainer("views").setVisible(false));
             } else {
-                contentContainer.add(new ViewList("views", space));
+                contentContainer.add(RefreshingStructurePanel.of("views", space,
+                        markupId -> new ViewList(markupId, spaceModel.getObject())));
             }
             addUnconfiguredFallback(contentContainer, space, empty);
         } else {

--- a/src/main/java/com/knowledgepixels/nanodash/page/UserPage.html
+++ b/src/main/java/com/knowledgepixels/nanodash/page/UserPage.html
@@ -14,7 +14,8 @@
     <div class="col-12">
       <h2>
         <img class="user-profile-pic" wicket:id="userIcon"/>
-        <span wicket:id="username">User Name</span><span class="title-suffix" wicket:id="titlesuffix"></span></h2>
+        <span wicket:id="username">User Name</span><span class="title-suffix" wicket:id="titlesuffix"></span><span
+            class="title-actions" wicket:id="titlemenu"></span></h2>
       <span wicket:id="fullid"></span>
       <div wicket:id="accountpart"></div>
     </div>

--- a/src/main/java/com/knowledgepixels/nanodash/page/UserPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/UserPage.java
@@ -102,6 +102,7 @@ public class UserPage extends NanodashPage {
         add(new Label("pagetitle", displayName + " (user) | nanodash"));
         add(new Label("username", displayName));
         add(new Label("titlesuffix", ResourceTabs.titleSuffix(activeTab)));
+        add(PageTitleMenu.forResource("titlemenu", IndividualAgent.get(userIriString)));
 
         add(new ExternalLinkWithActionsPanel("fullid", Model.of(userIriString), Model.of(displayName)));
 

--- a/src/main/java/com/knowledgepixels/nanodash/page/UserPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/UserPage.java
@@ -181,7 +181,8 @@ public class UserPage extends NanodashPage {
                 if (empty) {
                     contentContainer.add(new WebMarkupContainer("views").setVisible(false));
                 } else {
-                    contentContainer.add(new ViewList("views", individualAgent));
+                    contentContainer.add(RefreshingStructurePanel.of("views", individualAgent,
+                            markupId -> new ViewList(markupId, IndividualAgent.get(userIriString))));
                 }
                 contentContainer.add(new WebMarkupContainer("unconfigured-notice").setVisible(empty));
                 if (empty) {

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -1249,6 +1249,14 @@ input[type=radio] + label strong {
   vertical-align: middle;
 }
 
+/* The page-structure spinner, immediately left of the title menu's chevron: a little
+   larger than the in-row one, since the heading beside it is larger too. */
+.title-actions .refresh-spinner {
+  width: 13px;
+  height: 13px;
+  margin-right: 8px;
+}
+
 /* Nested submenu inside a dropdown (e.g. the calendar menu): a group row whose entries
    open in a flyout to the right on hover (nanodash.js flips it leftward when the right
    edge lacks room). The flyout is deliberately NOT an .actionmenu-content, so the

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -1249,12 +1249,12 @@ input[type=radio] + label strong {
   vertical-align: middle;
 }
 
-/* The page-structure spinner, immediately left of the title menu's chevron: a little
+/* The page-structure spinner, immediately right of the title menu's chevron: a little
    larger than the in-row one, since the heading beside it is larger too. */
 .title-actions .refresh-spinner {
   width: 13px;
   height: 13px;
-  margin-right: 8px;
+  margin-left: 8px;
 }
 
 /* Nested submenu inside a dropdown (e.g. the calendar menu): a group row whose entries

--- a/src/test/java/com/knowledgepixels/nanodash/PostPublishRefreshTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/PostPublishRefreshTest.java
@@ -1,0 +1,96 @@
+package com.knowledgepixels.nanodash;
+
+import com.knowledgepixels.nanodash.utils.TestUtils;
+import com.knowledgepixels.nanodash.vocabulary.KPXL_TERMS;
+import org.eclipse.rdf4j.model.IRI;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.nanopub.MalformedNanopubException;
+import org.nanopub.Nanopub;
+import org.nanopub.NanopubAlreadyFinalizedException;
+import org.nanopub.NanopubCreator;
+import org.nanopub.vocabulary.NPX;
+
+import static com.knowledgepixels.nanodash.utils.TestUtils.vf;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PostPublishRefreshTest {
+
+    private static final String SPACE_ID = "https://w3id.org/spaces/test";
+
+    private static Nanopub withType(IRI type) throws MalformedNanopubException, NanopubAlreadyFinalizedException {
+        NanopubCreator creator = TestUtils.getNanopubCreator();
+        creator.addAssertionStatement(TestUtils.anyIri, TestUtils.anyIri, TestUtils.anyIri);
+        TestUtils.fillProvenanceGraph(creator);
+        creator.addPubinfoStatement(NPX.HAS_NANOPUB_TYPE, type);
+        return creator.finalizeNanopub();
+    }
+
+    private static Nanopub withAssertionPredicate(IRI predicate) throws MalformedNanopubException, NanopubAlreadyFinalizedException {
+        NanopubCreator creator = TestUtils.getNanopubCreator();
+        creator.addAssertionStatement(vf.createIRI(SPACE_ID), predicate, TestUtils.anyIri);
+        TestUtils.fillProvenanceGraph(creator);
+        TestUtils.fillPubInfoGraph(creator);
+        return creator.finalizeNanopub();
+    }
+
+    @Test
+    @DisplayName("a plain content publication does not change the page structure")
+    void plainPublicationIsNotStructural() throws Exception {
+        assertFalse(PostPublishRefresh.changesPageStructure(TestUtils.createNanopub(), SPACE_ID));
+    }
+
+    @Test
+    @DisplayName("null nanopub does not change the page structure")
+    void nullIsNotStructural() {
+        assertFalse(PostPublishRefresh.changesPageStructure(null, SPACE_ID));
+    }
+
+    @Test
+    @DisplayName("view-display publications change the page structure")
+    void viewDisplayTypesAreStructural() throws Exception {
+        assertTrue(PostPublishRefresh.changesPageStructure(withType(KPXL_TERMS.ACTIVATED_VIEW_DISPLAY), SPACE_ID));
+        assertTrue(PostPublishRefresh.changesPageStructure(withType(KPXL_TERMS.DEACTIVATED_VIEW_DISPLAY), SPACE_ID));
+        assertTrue(PostPublishRefresh.changesPageStructure(withType(KPXL_TERMS.VIEW_DISPLAY), SPACE_ID));
+    }
+
+    @Test
+    @DisplayName("preset, space, resource and role-instantiation publications change the page structure")
+    void otherStructuralTypes() throws Exception {
+        assertTrue(PostPublishRefresh.changesPageStructure(withType(KPXL_TERMS.ACTIVATED_PRESET_ASSIGNMENT), SPACE_ID));
+        assertTrue(PostPublishRefresh.changesPageStructure(withType(KPXL_TERMS.SPACE), SPACE_ID));
+        assertTrue(PostPublishRefresh.changesPageStructure(withType(KPXL_TERMS.MAINTAINED_RESOURCE), SPACE_ID));
+        assertTrue(PostPublishRefresh.changesPageStructure(withType(KPXL_TERMS.ROLE_INSTANTIATION), SPACE_ID));
+    }
+
+    @Test
+    @DisplayName("structural assertion predicates change the page structure")
+    void structuralPredicates() throws Exception {
+        assertTrue(PostPublishRefresh.changesPageStructure(withAssertionPredicate(KPXL_TERMS.IS_DISPLAY_OF_VIEW), SPACE_ID));
+        assertTrue(PostPublishRefresh.changesPageStructure(withAssertionPredicate(KPXL_TERMS.HAS_ADMIN_PREDICATE), SPACE_ID));
+        assertTrue(PostPublishRefresh.changesPageStructure(withAssertionPredicate(KPXL_TERMS.IS_MAINTAINED_BY), SPACE_ID));
+    }
+
+    @Test
+    @DisplayName("a retraction is treated as changing the page structure")
+    void retractionIsStructural() throws Exception {
+        assertTrue(PostPublishRefresh.changesPageStructure(withAssertionPredicate(NPX.RETRACTS), SPACE_ID));
+    }
+
+    @Test
+    @DisplayName("an unrelated predicate on the context resource is not structural")
+    void unrelatedPredicateIsNotStructural() throws Exception {
+        assertFalse(PostPublishRefresh.changesPageStructure(
+                withAssertionPredicate(vf.createIRI("http://purl.org/dc/terms/description")), SPACE_ID));
+    }
+
+    @Test
+    @DisplayName("an unknown context is tolerated")
+    void unknownContext() throws Exception {
+        assertFalse(PostPublishRefresh.changesPageStructure(TestUtils.createNanopub(), null));
+        assertFalse(PostPublishRefresh.changesPageStructure(TestUtils.createNanopub(), ""));
+        assertTrue(PostPublishRefresh.changesPageStructure(withType(KPXL_TERMS.SPACE), null));
+    }
+
+}

--- a/src/test/java/com/knowledgepixels/nanodash/component/StructureRefreshIndicatorTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/component/StructureRefreshIndicatorTest.java
@@ -1,0 +1,154 @@
+package com.knowledgepixels.nanodash.component;
+
+import com.knowledgepixels.nanodash.ViewDisplay;
+import com.knowledgepixels.nanodash.domain.AbstractResourceWithProfile;
+import org.apache.wicket.ajax.AbstractAjaxTimerBehavior;
+import org.apache.wicket.util.tester.WicketTester;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.nanopub.Nanopub;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The spinner beside the page title while the page structure is being recalculated
+ * (issue #622).
+ */
+class StructureRefreshIndicatorTest {
+
+    private static int counter = 0;
+
+    private static class TestResource extends AbstractResourceWithProfile {
+
+        TestResource(String id) {
+            super(id);
+        }
+
+        @Override
+        public String getNanopubId() {
+            return null;
+        }
+
+        @Override
+        public Nanopub getNanopub() {
+            return null;
+        }
+
+        @Override
+        public String getNamespace() {
+            return null;
+        }
+
+        @Override
+        public String getLabel() {
+            return getId();
+        }
+
+    }
+
+    private WicketTester tester;
+
+    @BeforeEach
+    void setUp() {
+        tester = new WicketTester();
+    }
+
+    @AfterEach
+    void tearDown() {
+        tester.destroy();
+    }
+
+    private static void set(Object target, String name, Object value) throws Exception {
+        Field f = AbstractResourceWithProfile.class.getDeclaredField(name);
+        f.setAccessible(true);
+        f.set(target, value);
+    }
+
+    /**
+     * A resource with a loaded, non-empty structure, so that forceRefresh takes the
+     * "keep what is on screen" branch. The update itself is disarmed afterwards: the
+     * indicator triggers it whenever it checks, and here there is no API to reach.
+     */
+    @SuppressWarnings("unchecked")
+    private static TestResource resourceWithStructure() throws Exception {
+        TestResource r = new TestResource("https://example.org/test/indicator/" + (counter++));
+        Field dataField = AbstractResourceWithProfile.class.getDeclaredField("data");
+        dataField.setAccessible(true);
+        Object data = dataField.get(r);
+        Field viewDisplays = data.getClass().getDeclaredField("viewDisplays");
+        viewDisplays.setAccessible(true);
+        ((List<ViewDisplay>) viewDisplays.get(data)).add(new ViewDisplay(10));
+        set(r, "dataInitialized", true);
+        return r;
+    }
+
+    private static void disarmUpdate(TestResource r) throws Exception {
+        set(r, "dataNeedsUpdate", false);
+    }
+
+    // Returned straight from the tester: getComponentFromLastRenderedPage hands back null
+    // for a component that is not visible, which is half of what is under test here.
+    private StructureRefreshIndicator start(AbstractResourceWithProfile r) {
+        return (StructureRefreshIndicator) tester.startComponentInPage(new StructureRefreshIndicator("indicator", r));
+    }
+
+    @Test
+    @DisplayName("no spinner and no polling when nothing is being recalculated")
+    void hiddenWhenIdle() throws Exception {
+        TestResource r = resourceWithStructure();
+        disarmUpdate(r);
+
+        StructureRefreshIndicator indicator = start(r);
+
+        assertFalse(indicator.isVisible(), "nothing is refreshing, so nothing should be shown");
+        assertTrue(timersOf(indicator).isEmpty(), "an idle page should carry no polling timer");
+    }
+
+    @Test
+    @DisplayName("the spinner shows and polls while the structure is being recalculated")
+    void shownWhileRefreshing() throws Exception {
+        TestResource r = resourceWithStructure();
+        r.forceRefresh(5000);
+        disarmUpdate(r);
+
+        StructureRefreshIndicator indicator = start(r);
+
+        assertTrue(indicator.isVisible(), "the recalculation should be visible as a spinner");
+        assertFalse(timersOf(indicator).isEmpty(), "the indicator should poll for the end of the refresh");
+    }
+
+    @Test
+    @DisplayName("the spinner goes away when the refreshed structure lands")
+    void hiddenAgainWhenRefreshLands() throws Exception {
+        TestResource r = resourceWithStructure();
+        r.forceRefresh(5000);
+        disarmUpdate(r);
+
+        StructureRefreshIndicator indicator = start(r);
+        assertTrue(indicator.isVisible());
+
+        set(r, "structureRefreshPending", false);
+        tester.executeBehavior(timersOf(indicator).getFirst());
+
+        assertFalse(indicator.isVisible(), "the spinner should be taken away once the refresh has landed");
+    }
+
+    @Test
+    @DisplayName("a page without a resource carries no spinner")
+    void noResource() {
+        StructureRefreshIndicator indicator = start(null);
+        assertFalse(indicator.isVisible());
+        assertTrue(timersOf(indicator).isEmpty());
+    }
+
+    private static List<AbstractAjaxTimerBehavior> timersOf(StructureRefreshIndicator indicator) {
+        return indicator.getBehaviors(AbstractAjaxTimerBehavior.class);
+    }
+
+}

--- a/src/test/java/com/knowledgepixels/nanodash/domain/StructureRefreshTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/domain/StructureRefreshTest.java
@@ -1,0 +1,125 @@
+package com.knowledgepixels.nanodash.domain;
+
+import com.knowledgepixels.nanodash.ViewDisplay;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.nanopub.Nanopub;
+
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The post-publish refresh of a resource's page structure (issue #622): a structure that
+ * is already on screen is kept and swapped in place, and only an empty one is invalidated
+ * outright so the pages' lazy path can make a first view display appear.
+ */
+class StructureRefreshTest {
+
+    private static class TestResource extends AbstractResourceWithProfile {
+
+        TestResource(String id) {
+            super(id);
+        }
+
+        @Override
+        public String getNanopubId() {
+            return null;
+        }
+
+        @Override
+        public Nanopub getNanopub() {
+            return null;
+        }
+
+        @Override
+        public String getNamespace() {
+            return null;
+        }
+
+        @Override
+        public String getLabel() {
+            return getId();
+        }
+
+    }
+
+    // The flags forceRefresh acts on are read directly: going through isDataInitialized()
+    // would kick off the (network-bound) data update the assertions are not about.
+    private static Object field(AbstractResourceWithProfile r, String name) throws Exception {
+        Field f = AbstractResourceWithProfile.class.getDeclaredField(name);
+        f.setAccessible(true);
+        return f.get(r);
+    }
+
+    private static void setField(AbstractResourceWithProfile r, String name, Object value) throws Exception {
+        Field f = AbstractResourceWithProfile.class.getDeclaredField(name);
+        f.setAccessible(true);
+        f.set(r, value);
+    }
+
+    private static void setStructure(AbstractResourceWithProfile r, ViewDisplay... viewDisplays) throws Exception {
+        AbstractResourceWithProfile.ResourceWithProfile data = new AbstractResourceWithProfile.ResourceWithProfile();
+        for (ViewDisplay vd : viewDisplays) data.viewDisplays.add(vd);
+        setField(r, "data", data);
+        setField(r, "dataInitialized", !data.viewDisplays.isEmpty());
+    }
+
+    private static ViewDisplay viewDisplay() {
+        // A minimal view display with no view attached: enough to be an entry of the
+        // structure, which is all the signature and the empty checks look at.
+        return new ViewDisplay(10);
+    }
+
+    @Test
+    @DisplayName("a loaded structure is kept on screen and marked as refreshing")
+    void loadedStructureIsKept() throws Exception {
+        TestResource r = new TestResource("https://example.org/test/kept");
+        setStructure(r, viewDisplay());
+
+        r.forceRefresh(5000);
+
+        assertTrue((Boolean) field(r, "dataInitialized"), "the loaded structure must stay renderable");
+        assertTrue((Boolean) field(r, "structureRefreshPending"), "the refresh must be marked as pending");
+        assertTrue((Boolean) field(r, "dataNeedsUpdate"));
+        assertTrue(r.getRunUpdateAfter() > System.currentTimeMillis());
+    }
+
+    @Test
+    @DisplayName("an empty structure is invalidated outright, as before")
+    void emptyStructureIsInvalidated() throws Exception {
+        TestResource r = new TestResource("https://example.org/test/empty");
+        setStructure(r);
+
+        r.forceRefresh(5000);
+
+        assertFalse((Boolean) field(r, "dataInitialized"), "nothing on screen to keep");
+        assertFalse((Boolean) field(r, "structureRefreshPending"), "the lazy path handles this one");
+    }
+
+    @Test
+    @DisplayName("the structure signature tells a changed structure from an unchanged one")
+    void structureSignature() throws Exception {
+        TestResource r = new TestResource("https://example.org/test/signature");
+        setStructure(r, viewDisplay());
+        String before = r.getStructureSignature();
+
+        setStructure(r, viewDisplay());
+        assertEquals(before, r.getStructureSignature(), "the same structure must fingerprint the same");
+
+        setStructure(r, viewDisplay(), viewDisplay());
+        assertNotEquals(before, r.getStructureSignature(), "an added view display must show up");
+    }
+
+    @Test
+    @DisplayName("no refresh pending without a forceRefresh")
+    void nothingPendingByDefault() throws Exception {
+        TestResource r = new TestResource("https://example.org/test/idle");
+        setStructure(r, viewDisplay());
+        assertFalse(r.isStructureRefreshPending());
+    }
+
+}


### PR DESCRIPTION
Addresses the first half of #622: *"sometimes the overall page structure is refreshed instead of the specific view that was used to create a new nanopublication."*

## The problem

`PublishForm` (and `PreviewPage`) broadened every post-publish refresh to the context resource:

```java
if (!contextId.isEmpty() && !contextId.equals(toRefresh)
        && AbstractResourceWithProfile.isResourceWithProfile(contextId)) {
    WicketApplication.get().notifyNanopubPublished(signedNp, contextId, 5 * 1000);
}
```

`refresh-upon-publish` for a view action is the query-ref URL string, so it never equals the context IRI — this fired on essentially every publish from a view. It lands on `AbstractResourceWithProfile.forceRefresh`, which set `dataInitialized = false`, so the redirect target rendered through the lazy branch: the whole content area became a spinner, waited out the ingest delay plus the view-displays query, and rebuilt the entire `ViewList`. The in-place update from #599 / #600 never got a chance, because the panel it would have updated was thrown away and rebuilt cold.

The broadening was added deliberately in 8c172e2 for role/member changes that *do* alter page structure — it was just applied unconditionally.

## The fix

**1. Gate the broadening on whether the publication can change the structure**

New `PostPublishRefresh.changesPageStructure(np, contextId)` says yes for:

- nanopub types: view displays (activated / deactivated / top / part-level), presets and preset assignments, view entities, role instantiations, `gen:Space`, `gen:MaintainedResource`
- assertion predicates: `isDisplayOfView` / `isDisplayFor`, `isAssignmentOfPreset` / `isAssignmentFor`, `hasTopLevelView` / `hasView`, `hasAdmin`, `hasRole`, `isVisibleTo`, `isMaintainedBy`, `hasRootDefinition`, `governedBy`, and `npx:retracts` (a retraction says nothing about its target, so it is taken to possibly remove a view display or a role)
- any predicate the context **space itself** declares as a role property, regular or inverse — role predicates are per-space rather than a fixed vocabulary, so they are read off `Space.getRoles()`

Everything else — the ordinary "add a row / post a message" view action — now refreshes only the view query it named, and that view updates where it stands.

**2. The structural refresh no longer blanks the page**

`forceRefresh` keeps a loaded structure and marks `structureRefreshPending` instead of invalidating it. The new `RefreshingStructurePanel` — the resource-level counterpart of `RefreshingResultPanel` — keeps the current `ViewList` on screen, polls once a second, and swaps in a rebuilt one when the refreshed data lands, **only if the structure signature actually changed**; an unchanged refresh leaves open menus, typed filters and the current table page alone. 60s deadline, then it settles. Wired into the content-tab branches of `SpacePage`, `UserPage`, `MaintainedResourcePage`, `ResourcePartPage` and `HomePage`.

An *empty* structure is still invalidated outright: there is nothing on screen to keep, and the pages' lazy path is what makes a first view display appear.

Also: `data` is now `volatile` (swapped on a pool thread, read by polling request threads), and `structureRefreshPending` stays set if a second `forceRefresh` arrives while a fetch is already in flight.

## Verification

- New tests: `PostPublishRefreshTest` (8), `StructureRefreshTest` (4). Full suite: 1134 tests, 0 failures.
- Smoke-tested a local instance: home, /spaces, space, user, maintained-resource and part pages all render, no JS errors, view sections present.
- **Not verified end to end**: the actual publish → swap sequence, which needs a real publication. The resource-level logic is unit-tested; the panel's swap path is not exercised against a live refresh.

## Not in this PR

The second half of #622 — checking whether the just-published nanopub has made the round trip instead of guessing a fixed 5s delay. Today `ApiCache.clearCache` sleeps 5s and fetches exactly once; if the nanopub has not been ingested yet, `RefreshingResultPanel` sees an unchanged digest and settles on the stale content permanently. Left for a follow-up.

## Known gap

A resource whose *top-level* views are empty but which has part-level ones takes the "keep the structure" path while the page rendered an invisible container, so a structural change there will not appear until the next page load. Narrow case, chosen over blanking every page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)