### PR TITLE
feat: show `/publish?...` links from views as buttons (#628)

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/QueryResult.java
+++ b/src/main/java/com/knowledgepixels/nanodash/QueryResult.java
@@ -4,11 +4,13 @@ import com.knowledgepixels.nanodash.component.QueryResultComponentFactory;
 import com.knowledgepixels.nanodash.component.menu.ViewDisplayMenu;
 import com.knowledgepixels.nanodash.domain.AbstractResourceWithProfile;
 import com.knowledgepixels.nanodash.page.NanodashPage;
+import com.knowledgepixels.nanodash.page.PublishPage;
 import org.apache.wicket.Component;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
+import org.apache.wicket.util.string.Strings;
 import org.nanopub.extra.services.ApiResponse;
 import org.nanopub.extra.services.QueryRef;
 
@@ -283,6 +285,80 @@ public abstract class QueryResult extends Panel {
         }
         m.appendTail(sb);
         return sb.toString();
+    }
+
+    // An "<a ...>" start tag in sanitized cell HTML, with its attribute part.
+    private static final Pattern ANCHOR_TAG_PATTERN = Pattern.compile("<a\\b([^>]*)>", Pattern.CASE_INSENSITIVE);
+    private static final Pattern HREF_ATTRIBUTE_PATTERN = Pattern.compile("href=\"([^\"]*)\"");
+
+    // The look given to publish links in result content: the small transparent button
+    // used for secondary actions elsewhere in the app.
+    private static final String PUBLISH_BUTTON_CLASSES = "smallbutton button light";
+
+    /**
+     * Prepares raw HTML coming from query data for display in result content: it is
+     * sanitized, its app-internal links get the navigation context, and its links to
+     * the publish form are turned into buttons.
+     *
+     * @param rawHtml the raw HTML from the query data, or null
+     * @return the sanitized and enriched HTML
+     */
+    protected String cellHtml(String rawHtml) {
+        return withPublishLinksAsButtons(withContextInHtmlLinks(Utils.sanitizeHtml(rawHtml)));
+    }
+
+    /**
+     * Shows links to the publish form as buttons, so that the actions a view offers
+     * stand out from the links to content. Only links that don't bring their own class
+     * are styled.
+     *
+     * @param sanitizedHtml the sanitized cell HTML, or null
+     * @return the HTML with publish links marked as buttons
+     */
+    protected static String withPublishLinksAsButtons(String sanitizedHtml) {
+        if (sanitizedHtml == null) return null;
+        Matcher m = ANCHOR_TAG_PATTERN.matcher(sanitizedHtml);
+        StringBuilder sb = new StringBuilder();
+        while (m.find()) {
+            String attributes = m.group(1);
+            String replacement = m.group();
+            Matcher hrefMatcher = HREF_ATTRIBUTE_PATTERN.matcher(attributes);
+            if (hrefMatcher.find() && isPublishLink(hrefMatcher.group(1)) && !attributes.contains("class=")) {
+                replacement = "<a class=\"" + PUBLISH_BUTTON_CLASSES + "\"" + attributes + ">";
+            }
+            m.appendReplacement(sb, Matcher.quoteReplacement(replacement));
+        }
+        m.appendTail(sb);
+        return sb.toString();
+    }
+
+    /**
+     * Whether the given value is a link to the publish form, i.e. the app-internal
+     * {@code /publish} path, with or without query parameters. Only the path is
+     * checked, so the sanitizer's escaping inside the parameters (it writes "=" as
+     * "&#61;") makes no difference.
+     *
+     * @param value the value to check, or null
+     * @return true if the value is a publish link
+     */
+    public static boolean isPublishLink(String value) {
+        if (value == null) return false;
+        return value.split("[?#]", 2)[0].equals(PublishPage.MOUNT_PATH);
+    }
+
+    /**
+     * The content for a publish link that comes as a plain cell value: a button
+     * carrying the label from the sibling label column where there is one, and a
+     * generic label otherwise.
+     *
+     * @param url   the publish link
+     * @param label the label from the sibling label column, or null
+     * @return the HTML for the button
+     */
+    protected String publishButtonHtml(String url, String label) {
+        String text = (label == null || label.isBlank() || label.equals(url)) ? "publish…" : label;
+        String inner = Utils.looksLikeHtml(text) ? text : Strings.escapeMarkup(text).toString();
+        return cellHtml("<a href=\"" + Strings.escapeMarkup(url) + "\">" + inner + "</a>");
     }
 
     /**

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultList.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultList.java
@@ -165,7 +165,9 @@ public class QueryResultList extends QueryResult {
                             for (int i = 0; i < parts.length; i++) {
                                 String part = parts[i];
                                 String label = (labels != null && i < labels.length && !labels[i].isBlank()) ? Utils.unescapeMultiValue(labels[i]) : null;
-                                if (part.matches("https?://.+")) {
+                                if (isPublishLink(part)) {
+                                    multiComponents.add(new Label("component", publishButtonHtml(part, label)).setEscapeModelStrings(false));
+                                } else if (part.matches("https?://.+")) {
                                     if (label != null && label.equals(part)) {
                                         label = null;
                                     }
@@ -179,7 +181,7 @@ public class QueryResultList extends QueryResult {
                                         String display = label != null ? label : unescaped;
                                         boolean isHtml = Utils.looksLikeHtml(display);
                                         if (isHtml) {
-                                            display = withContextInHtmlLinks(Utils.sanitizeHtml(display));
+                                            display = cellHtml(display);
                                         }
                                         multiComponents.add(new Label("component", display).setEscapeModelStrings(!isHtml));
                                     }
@@ -203,6 +205,10 @@ public class QueryResultList extends QueryResult {
                                 }
                             }
                             components.add(new ComponentSequence("component", ", ", multiComponents));
+                        } else if (isPublishLink(entryValue)) {
+                            // A ready-made link to the publish form: an action the view offers,
+                            // shown as a button rather than as a link to content.
+                            components.add(new Label("component", publishButtonHtml(entryValue, entry.get(key + "_label"))).setEscapeModelStrings(false));
                         } else if (entryValue.matches("https?://.+")) {
                             String entryLabel = entry.get(key + "_label");
                             if ("^".equals(entryLabel)) {
@@ -220,7 +226,7 @@ public class QueryResultList extends QueryResult {
                             } else {
                                 String display = hasLabel ? entryLabel : entryValue;
                                 if (Utils.looksLikeHtml(display)) {
-                                    display = withContextInHtmlLinks(Utils.sanitizeHtml(display));
+                                    display = cellHtml(display);
                                 } else if (hasLabel) {
                                     display = Strings.escapeMarkup(display).toString();
                                 }

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultPlainParagraph.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultPlainParagraph.java
@@ -122,7 +122,7 @@ public class QueryResultPlainParagraph extends QueryResult {
                 }
                 item.add(header);
                 String content = item.getModelObject().get("content");
-                item.add(new Label("content", content == null ? null : withContextInHtmlLinks(Utils.sanitizeHtml(content))).setEscapeModelStrings(false));
+                item.add(new Label("content", content == null ? null : cellHtml(content)).setEscapeModelStrings(false));
             }
         };
     }

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultTable.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultTable.java
@@ -319,7 +319,9 @@ public class QueryResultTable extends QueryResult {
                         for (int i = 0; i < parts.length; i++) {
                             String part = parts[i];
                             String rawLabel = (labels != null && i < labels.length && !labels[i].isBlank()) ? Utils.unescapeMultiValue(labels[i]) : null;
-                            if (part.matches("https?://.+")) {
+                            if (isPublishLink(part)) {
+                                components.add(new Label("component", publishButtonHtml(part, rawLabel)).setEscapeModelStrings(false));
+                            } else if (part.matches("https?://.+")) {
                                 if (rawLabel != null && rawLabel.equals(part)) {
                                     rawLabel = null;
                                 }
@@ -333,7 +335,7 @@ public class QueryResultTable extends QueryResult {
                                 } else {
                                     String display = label != null ? label : unescaped;
                                     if (Utils.looksLikeHtml(display)) {
-                                        components.add(new Label("component", withContextInHtmlLinks(Utils.sanitizeHtml(display)))
+                                        components.add(new Label("component", cellHtml(display))
                                                 .setEscapeModelStrings(false)
                                                 .add(new AttributeAppender("class", "cell-data-html")));
                                     } else {
@@ -356,7 +358,7 @@ public class QueryResultTable extends QueryResult {
                                 // Friendly relative time, matching single-value cells.
                                 components.add(new Label("component", Utils.friendlyDateHtml(display, display)).setEscapeModelStrings(false));
                             } else if (Utils.looksLikeHtml(display)) {
-                                components.add(new Label("component", withContextInHtmlLinks(Utils.sanitizeHtml(display)))
+                                components.add(new Label("component", cellHtml(display))
                                         .setEscapeModelStrings(false)
                                         .add(new AttributeAppender("class", "cell-data-html")));
                             } else {
@@ -372,6 +374,11 @@ public class QueryResultTable extends QueryResult {
                         String templateUrl = PublishPage.MOUNT_PATH + "?template=" + Utils.urlEncode(value) + "&template-version=latest" + templateLinkContextParam();
                         String html = "<a href=\"" + Strings.escapeMarkup(templateUrl) + "\">" + Strings.escapeMarkup(label) + "</a>";
                         cellItem.add(new Label(componentId, html).setEscapeModelStrings(false));
+                    } else if (isPublishLink(value)) {
+                        // A ready-made link to the publish form: an action the view offers,
+                        // shown as a button rather than as a link to content.
+                        String label = rowModel.getObject().get(key + "_label");
+                        cellItem.add(new Label(componentId, publishButtonHtml(value, label)).setEscapeModelStrings(false));
                     } else if (value.matches("https?://.+")) {
                         String label = rowModel.getObject().get(key + "_label");
                         cellItem.add(new NanodashLink(componentId, value, null, null, label, contextId));
@@ -380,7 +387,7 @@ public class QueryResultTable extends QueryResult {
                         if (litLabel != null && !litLabel.isBlank() && !litLabel.equals(value)) {
                             // Separate display label for a (non-IRI) literal value; the full
                             // literal is shown on hover via the standard styled tooltip.
-                            String labelHtml = Utils.looksLikeHtml(litLabel) ? withContextInHtmlLinks(Utils.sanitizeHtml(litLabel)) : Strings.escapeMarkup(litLabel).toString();
+                            String labelHtml = Utils.looksLikeHtml(litLabel) ? cellHtml(litLabel) : Strings.escapeMarkup(litLabel).toString();
                             String html = "<span class=\"tooltip\"><span class=\"tooltiptext tooltiptext-auto\">" + Strings.escapeMarkup(value) + "</span>" + labelHtml + "</span>";
                             cellItem.add(new Label(componentId, html).setEscapeModelStrings(false));
                         } else if (key.startsWith("pubkey")) {
@@ -391,7 +398,7 @@ public class QueryResultTable extends QueryResult {
                         } else {
                             Label cellLabel;
                             if (Utils.looksLikeHtml(value)) {
-                                cellLabel = (Label) new Label(componentId, withContextInHtmlLinks(Utils.sanitizeHtml(value)))
+                                cellLabel = (Label) new Label(componentId, cellHtml(value))
                                         .setEscapeModelStrings(false)
                                         .add(new AttributeAppender("class", "cell-data-html"));
                             } else {

--- a/src/test/java/com/knowledgepixels/nanodash/QueryResultPublishLinkTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/QueryResultPublishLinkTest.java
@@ -1,0 +1,55 @@
+package com.knowledgepixels.nanodash;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class QueryResultPublishLinkTest {
+
+    @Test
+    void publishLinksAreRecognized() {
+        assertTrue(QueryResult.isPublishLink("/publish"));
+        assertTrue(QueryResult.isPublishLink("/publish?template=https://example.com/t"));
+        // The sanitizer writes "=" as "&#61;", which only affects the parameters.
+        assertTrue(QueryResult.isPublishLink("/publish?template&#61;https://example.com/t"));
+    }
+
+    @Test
+    void otherLinksAreNotPublishLinks() {
+        assertFalse(QueryResult.isPublishLink(null));
+        assertFalse(QueryResult.isPublishLink("/query?id=https://example.com/q"));
+        assertFalse(QueryResult.isPublishLink("/publisher?id=https://example.com/p"));
+        assertFalse(QueryResult.isPublishLink("https://example.com/publish?template=x"));
+    }
+
+    @Test
+    void publishLinksBecomeButtons() {
+        String html = "<a href=\"/publish?template&#61;x\" rel=\"nofollow\">add a comment</a>";
+        assertEquals("<a class=\"smallbutton button light\" href=\"/publish?template&#61;x\" rel=\"nofollow\">add a comment</a>",
+                QueryResult.withPublishLinksAsButtons(html));
+    }
+
+    @Test
+    void otherLinksAreLeftAlone() {
+        String html = "see <a href=\"/query?id&#61;x\" rel=\"nofollow\">this query</a> and "
+                      + "<a href=\"https://example.com/\" rel=\"nofollow\">this page</a>";
+        assertEquals(html, QueryResult.withPublishLinksAsButtons(html));
+        assertNull(QueryResult.withPublishLinksAsButtons(null));
+    }
+
+    @Test
+    void everyPublishLinkInTheContentBecomesAButton() {
+        String html = "<a href=\"/publish?a\">one</a> and <a href=\"/publish?b\">two</a>";
+        String result = QueryResult.withPublishLinksAsButtons(html);
+        assertEquals(2, result.split("smallbutton button light", -1).length - 1);
+    }
+
+    @Test
+    void linksWithTheirOwnClassAreLeftAlone() {
+        String html = "<a class=\"source\" href=\"/publish?a\">one</a>";
+        assertEquals(html, QueryResult.withPublishLinksAsButtons(html));
+    }
+}


### PR DESCRIPTION
Closes #628.

Links to the publish form that come from view data are actions, not links to content, so they are now shown as small transparent buttons, reusing the existing secondary-button styling (`smallbutton button light`).

Both spellings that views use are covered:

- **Ready-made anchors in cell HTML** (`<a href="/publish?…">…</a>`): marked as buttons after sanitizing — the sanitizer strips any `class` the query itself carries, so the styling can only come from here.
- **Plain cell values that are a `/publish` path**: rendered as a button taking its label from the sibling `_label` / `_label_multi` column, as regular links do, falling back to a generic `publish…`. Wired into single-value and `_multi_val` cells of table and list views; paragraph views are covered by the HTML path.

The seven places that sanitized cell HTML now share one `cellHtml()` entry point that sanitizes, adds the navigation context, and marks publish links. The SVG path keeps context-only enrichment, since HTML button classes don't belong on SVG anchors.

### Not included

- `template_iri` columns still render as plain links (with the form icon in list views), although they too build a `/publish?template=…` URL: they read as content references rather than actions.
- Absolute publish URLs (a view building `~~SITEURL~~/publish?…`) are not recognized; only the app-relative form is.

### Verification

- Full test suite green (1147 tests), including 6 new tests in `QueryResultPublishLinkTest`.
- The button markup was rendered against the real `style.css` in a browser to check the look; not yet exercised against a deployed view that emits such links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)