### PR TITLE
feat: give the error page a way onward

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/GrlcQuery.java
+++ b/src/main/java/com/knowledgepixels/nanodash/GrlcQuery.java
@@ -1,6 +1,7 @@
 package com.knowledgepixels.nanodash;
 
 import com.knowledgepixels.nanodash.component.QueryParamField;
+import com.knowledgepixels.nanodash.page.ErrorPage;
 import org.eclipse.rdf4j.query.MalformedQueryException;
 import org.nanopub.extra.services.QueryRef;
 import org.nanopub.extra.services.QueryTemplate;
@@ -76,7 +77,7 @@ public class GrlcQuery extends QueryTemplate {
      */
     public static GrlcQuery load(String id) {
         if (id == null || id.isBlank()) {
-            throw new QueryLoadException("No query was given to show or run.");
+            throw new QueryLoadException("No query was given to show or run.", ErrorPage.Kind.REQUEST);
         }
         GrlcQuery cached = instanceMap.getIfPresent(id);
         if (cached != null) return cached;
@@ -86,7 +87,7 @@ public class GrlcQuery extends QueryTemplate {
         } catch (Exception ex) {
             // Logged in full here, because what is shown to the user is only the gist of it.
             logger.warn("Could not load query: {}", id, ex);
-            throw new QueryLoadException(explainLoadFailure(id, ex), ex);
+            throw new QueryLoadException(explainLoadFailure(id, ex), kindOfLoadFailure(id), ex);
         }
         // Cached under the normalized ID, so that the different ways of referring to the same
         // query (URI, ID, containing nanopublication) share one instance.
@@ -114,14 +115,28 @@ public class GrlcQuery extends QueryTemplate {
         if (sparqlFailure != null) {
             String detail = SparqlSyntax.summarize(sparqlFailure.getMessage());
             String characterHint = SparqlSyntax.explainOffendingCharacter(sparqlFailure.getMessage());
+            // Who can fix this — the query's author, not the reader — is left to the error
+            // page, which says that for every error of this kind (#616).
             return "The SPARQL code of the query '" + id + "' is not valid, so the query can't be shown or run."
                     + (detail == null ? "" : " The SPARQL parser reports: " + detail)
-                    + (characterHint == null ? "" : " " + characterHint)
-                    + " This is a problem with the published query itself, which only a corrected version of it can fix.";
+                    + (characterHint == null ? "" : " " + characterHint);
         }
         String detail = ex.getMessage();
         if (detail == null || detail.isBlank()) detail = ex.getClass().getSimpleName();
         return "The query '" + id + "' couldn't be loaded: " + detail;
+    }
+
+    /**
+     * Whose problem a failed load is: the asking user's when the ID doesn't hold an artifact
+     * code at all, so that nothing could have been fetched for it, and the query author's
+     * otherwise — the nanopublication that was asked for is then the thing at fault, whether
+     * its SPARQL doesn't parse, it holds no query, or it isn't to be had.
+     *
+     * @param id the query ID or URI that was asked for
+     * @return the kind of error to answer with
+     */
+    private static ErrorPage.Kind kindOfLoadFailure(String id) {
+        return ARTIFACT_CODE_PATTERN.matcher(id).find() ? ErrorPage.Kind.CONTENT : ErrorPage.Kind.REQUEST;
     }
 
     /**

--- a/src/main/java/com/knowledgepixels/nanodash/QueryLoadException.java
+++ b/src/main/java/com/knowledgepixels/nanodash/QueryLoadException.java
@@ -1,26 +1,33 @@
 package com.knowledgepixels.nanodash;
 
+import com.knowledgepixels.nanodash.page.ErrorPage;
+
 /**
  * Thrown when a query cannot be loaded: its identifier doesn't denote a query, the
  * nanopublication holding it can't be retrieved, or the SPARQL code it carries is not
  * valid.
  * <p>
  * The message is written for the user rather than for the log, because it ends up on the
- * {@link com.knowledgepixels.nanodash.page.ErrorPage} that a request for a query that
- * can't be loaded is answered with. It should therefore say what is wrong with the query
- * in plain words, instead of exposing internals.
+ * {@link ErrorPage} that a request for a query that can't be loaded is answered with. It
+ * should therefore say what is wrong with the query in plain words, instead of exposing
+ * internals. The {@link #getKind() kind} says whose problem it is, which that page turns
+ * into what it tells the user to do about it.
  *
  * @see GrlcQuery#load(String)
  */
 public class QueryLoadException extends RuntimeException {
 
+    private final ErrorPage.Kind kind;
+
     /**
      * Constructs a new QueryLoadException with the given user-facing message.
      *
      * @param message explains, in plain words, why the query couldn't be loaded
+     * @param kind    whose problem this is: the asking user's, the query author's, or Nanodash's
      */
-    public QueryLoadException(String message) {
+    public QueryLoadException(String message, ErrorPage.Kind kind) {
         super(message);
+        this.kind = kind;
     }
 
     /**
@@ -28,10 +35,21 @@ public class QueryLoadException extends RuntimeException {
      * underlying failure.
      *
      * @param message explains, in plain words, why the query couldn't be loaded
+     * @param kind    whose problem this is: the asking user's, the query author's, or Nanodash's
      * @param cause   the failure this message was derived from, kept for the log
      */
-    public QueryLoadException(String message, Throwable cause) {
+    public QueryLoadException(String message, ErrorPage.Kind kind, Throwable cause) {
         super(message, cause);
+        this.kind = kind;
+    }
+
+    /**
+     * Whose problem this is, and with that what the user can do about it.
+     *
+     * @return the kind of error
+     */
+    public ErrorPage.Kind getKind() {
+        return kind;
     }
 
 }

--- a/src/main/java/com/knowledgepixels/nanodash/page/ErrorPage.html
+++ b/src/main/java/com/knowledgepixels/nanodash/page/ErrorPage.html
@@ -5,15 +5,24 @@
     <link rel="stylesheet" href="../../../../../webapp/style.css?for-local-testing-only" type="text/css" media="screen" title="Stylesheet" />
 </wicket:remove>
   <wicket:head>
-    <title>Error | nanodash</title>
+    <title wicket:id="pagetitle">Error | nanodash</title>
   </wicket:head>
 </head>
 <body>
 <wicket:extend>
   <div class="row-section">
     <div class="col-12">
-      <h2>An error has happened... :(</h2>
-      <div wicket:id="message" class="message"></div>
+      <h2 wicket:id="heading"></h2>
+      <div class="message">
+        <p wicket:id="message"></p>
+        <wicket:enclosure child="address"><p><code wicket:id="address"></code></p></wicket:enclosure>
+        <p wicket:id="responsibility"></p>
+      </div>
+      <p>
+        <a class="button" href="." wicket:id="back-link">back to where you were</a>
+        <a class="button" href="." wicket:id="home-link">to the homepage</a>
+        <a class="button" href="." wicket:id="report-link">report this problem</a>
+      </p>
     </div>
   </div>
 </wicket:extend>

--- a/src/main/java/com/knowledgepixels/nanodash/page/ErrorPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/ErrorPage.java
@@ -1,12 +1,30 @@
 package com.knowledgepixels.nanodash.page;
 
+import com.knowledgepixels.nanodash.Utils;
+import com.knowledgepixels.nanodash.WicketApplication;
 import com.knowledgepixels.nanodash.component.TitleBar;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.link.BookmarkablePageLink;
+import org.apache.wicket.markup.html.link.ExternalLink;
+import org.apache.wicket.request.Request;
 import org.apache.wicket.request.http.WebResponse;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Locale;
+
 /**
- * ErrorPage is a Wicket page that serves as a generic error page.
+ * The page shown when a request can't be answered and there is no more fitting page for
+ * the outcome. Besides saying what went wrong, it says whose problem it is — that differs
+ * per error, and with it what the user can do about it — and offers a way onward: back to
+ * the page they came from, home, and, for the errors that are Nanodash's own, a way to
+ * report them.
+ *
+ * @see Kind
  */
 public class ErrorPage extends NanodashPage {
 
@@ -23,12 +41,162 @@ public class ErrorPage extends NanodashPage {
     public static final String MESSAGE_PARAM = "message";
 
     /**
+     * Page parameter holding the {@link Kind} of error, by lower-case name. Callers that
+     * know what kind of problem they ran into set it; without it the page assumes the
+     * error is Nanodash's own, since an unforeseen one usually is.
+     */
+    public static final String KIND_PARAM = "kind";
+
+    /**
+     * Where the errors that are Nanodash's own get reported.
+     */
+    private static final String ISSUE_TRACKER_URL = "https://github.com/knowledgepixels/nanodash/issues/new";
+
+    /**
+     * 422, for content that was understood but can't be worked with. Not among the
+     * constants of {@link HttpServletResponse}.
+     */
+    private static final int SC_UNPROCESSABLE_CONTENT = 422;
+
+    /**
+     * What kind of problem an error is, which is to say who can act on it: the user, the
+     * author of the thing that was asked for, or Nanodash itself. It determines what the
+     * page says around the {@link #MESSAGE_PARAM details of the error}, whether it offers
+     * a way to report it, and the HTTP status it is answered with, so that clients other
+     * than browsers can tell these apart too.
+     */
+    public enum Kind {
+
+        /**
+         * Something in the address is wrong: a mistyped identifier, a missing parameter.
+         * The user, or whoever wrote the link, can correct it.
+         */
+        REQUEST(HttpServletResponse.SC_BAD_REQUEST, "\u2753", "That request can't be answered",
+                "Something in the address that led here isn't right. If you typed or edited it, correcting it is" +
+                " what puts this straight; if you followed a link, it is the link that is at fault rather than" +
+                " what it points at."),
+
+        /**
+         * There is no page at the address that was asked for. Reached through the
+         * container's 404 handling rather than from within the application.
+         */
+        NOT_FOUND(HttpServletResponse.SC_NOT_FOUND, "\uD83D\uDD0D", "There is no page at this address",
+                "The address that led here doesn't match any page of Nanodash. It may be mistyped, or it may be" +
+                " out of date, from a time when it led somewhere."),
+
+        /**
+         * What was asked for exists but can't be used as published — an invalid query,
+         * for instance. Only its author can put it right, by publishing a corrected
+         * version; nanopublications can't be changed after the fact.
+         */
+        CONTENT(SC_UNPROCESSABLE_CONTENT, "\uD83D\uDCC4", "That can't be shown as it was published",
+                "The problem is in the published nanopublication itself, which nothing on this end can change:" +
+                " only its author can put it right, by publishing a corrected version of it."),
+
+        /**
+         * Nanodash malfunctioned. Ours to fix, and worth reporting, since the alternative
+         * is that it dead-ends at a stack trace in the server log.
+         */
+        MALFUNCTION(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "\uD83D\uDCA5", "Something went wrong here",
+                "This one is on Nanodash rather than on you or on what you asked for. Reporting it is what gets" +
+                " it looked at; the server log alone doesn't say what you were trying to do.");
+
+        private final int httpStatus;
+        private final String emoji;
+        private final String heading;
+        private final String responsibility;
+
+        Kind(int httpStatus, String emoji, String heading, String responsibility) {
+            this.httpStatus = httpStatus;
+            this.emoji = emoji;
+            this.heading = heading;
+            this.responsibility = responsibility;
+        }
+
+        /**
+         * The HTTP status this kind of error is answered with.
+         *
+         * @return the status code
+         */
+        public int getHttpStatus() {
+            return httpStatus;
+        }
+
+        /**
+         * The pictogram shown beside the heading, as the sibling error pages have one.
+         *
+         * @return the emoji
+         */
+        public String getEmoji() {
+            return emoji;
+        }
+
+        /**
+         * The headline of the page, naming the situation.
+         *
+         * @return the heading
+         */
+        public String getHeading() {
+            return heading;
+        }
+
+        /**
+         * What the page says about who can act on this kind of error, and how.
+         *
+         * @return the explanation
+         */
+        public String getResponsibility() {
+            return responsibility;
+        }
+
+        /**
+         * The value this kind is passed as in the {@link #KIND_PARAM} page parameter.
+         *
+         * @return the parameter value
+         */
+        public String getParamValue() {
+            return name().toLowerCase(Locale.ROOT);
+        }
+
+        /**
+         * The kind denoted by the given {@link #getParamValue() parameter value}.
+         *
+         * @param value the parameter value, in any case
+         * @return the kind, or null if the value denotes none
+         */
+        public static Kind byParamValue(String value) {
+            if (value == null || value.isBlank()) return null;
+            for (Kind kind : values()) {
+                if (kind.name().equalsIgnoreCase(value.trim())) return kind;
+            }
+            return null;
+        }
+
+        /**
+         * The kind that fits an HTTP status the servlet container has already settled on,
+         * for the errors that reach this page through the container's error handling
+         * rather than from within the application.
+         *
+         * @param status the status code the container answered with
+         * @return the matching kind
+         */
+        public static Kind byHttpStatus(int status) {
+            if (status == HttpServletResponse.SC_NOT_FOUND) return NOT_FOUND;
+            if (status >= 400 && status < 500) return REQUEST;
+            return MALFUNCTION;
+        }
+
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override
     public String getMountPath() {
         return MOUNT_PATH;
     }
+
+    private final Kind kind;
 
     /**
      * Default constructor for ErrorPage.
@@ -39,16 +207,139 @@ public class ErrorPage extends NanodashPage {
     public ErrorPage(final PageParameters parameters) {
         super(parameters);
         add(new TitleBar("titlebar", this));
+
+        HttpServletRequest containerRequest = getContainerRequest();
+        kind = resolveKind(parameters, containerRequest);
         String message = parameters.get(MESSAGE_PARAM).toString("");
+        String address = getFailingAddress(containerRequest);
+        String backUrl = getBackUrl(containerRequest);
+
+        add(new Label("pagetitle", kind.getHeading() + " | nanodash"));
+        add(new Label("heading", kind.getEmoji() + " " + kind.getHeading()));
         add(new Label("message", message).setVisible(!message.isBlank()));
+        add(new Label("responsibility", kind.getResponsibility()));
+        // The address is worth spelling out where it is the whole of the problem; elsewhere
+        // the message says what was wrong with what was asked for.
+        add(new Label("address", address).setVisible(kind == Kind.NOT_FOUND && address != null));
+
+        add(new ExternalLink("back-link", backUrl).setVisible(backUrl != null));
+        add(new BookmarkablePageLink<Void>("home-link", HomePage.class));
+        add(new ExternalLink("report-link", getReportUrl(message, address, backUrl))
+                .setVisible(kind == Kind.MALFUNCTION));
+    }
+
+    /**
+     * The kind of error to answer with: what the caller said it is, or else what the
+     * container's error handling implies, or else — for an error nobody foresaw — one of
+     * Nanodash's own.
+     */
+    private static Kind resolveKind(PageParameters parameters, HttpServletRequest request) {
+        Kind named = Kind.byParamValue(parameters.get(KIND_PARAM).toString(""));
+        if (named != null) return named;
+        Integer containerStatus = getContainerErrorStatus(request);
+        if (containerStatus != null) return Kind.byHttpStatus(containerStatus);
+        return Kind.MALFUNCTION;
+    }
+
+    private HttpServletRequest getContainerRequest() {
+        Request request = getRequest();
+        if (request != null && request.getContainerRequest() instanceof HttpServletRequest containerRequest) {
+            return containerRequest;
+        }
+        return null;
+    }
+
+    /**
+     * The status the servlet container settled on before dispatching to this page, for the
+     * errors (a 404 on an address that maps to no page, an exception that got as far as
+     * the container) that arrive through {@code web.xml}'s error-page mapping. Null when
+     * this page was reached from within the application instead.
+     */
+    private static Integer getContainerErrorStatus(HttpServletRequest request) {
+        if (request == null) return null;
+        Object status = request.getAttribute(RequestDispatcher.ERROR_STATUS_CODE);
+        if (status instanceof Integer code) return code;
+        if (status == null) return null;
+        try {
+            return Integer.valueOf(status.toString());
+        } catch (NumberFormatException ex) {
+            return null;
+        }
+    }
+
+    /**
+     * The address the failed request was for: the one the container was dispatching for
+     * where it dispatched, and the current one otherwise (a page that forwards here does
+     * so within the request, so the address stays the one that was asked for).
+     */
+    private static String getFailingAddress(HttpServletRequest request) {
+        if (request == null) return null;
+        Object errorUri = request.getAttribute(RequestDispatcher.ERROR_REQUEST_URI);
+        if (errorUri != null && !errorUri.toString().isBlank()) return errorUri.toString();
+        StringBuffer url = request.getRequestURL();
+        if (url == null) return null;
+        String query = request.getQueryString();
+        return query == null || query.isBlank() ? url.toString() : url + "?" + query;
+    }
+
+    /**
+     * Where the user was before they landed here, so that an error isn't a dead end.
+     * Only this instance's own pages qualify: an off-site referrer is not where the user
+     * was working, and the error page itself is no way back either.
+     */
+    private static String getBackUrl(HttpServletRequest request) {
+        if (request == null) return null;
+        String referrer = request.getHeader("Referer");
+        if (referrer == null || referrer.isBlank()) return null;
+        URI uri;
+        try {
+            uri = new URI(referrer);
+        } catch (URISyntaxException ex) {
+            return null;
+        }
+        if (uri.getScheme() == null || uri.getHost() == null) return null;
+        String scheme = uri.getScheme().toLowerCase(Locale.ROOT);
+        if (!scheme.equals("http") && !scheme.equals("https")) return null;
+        if (!uri.getHost().equalsIgnoreCase(request.getServerName())) return null;
+        String path = uri.getPath() == null ? "" : uri.getPath();
+        String contextPath = request.getContextPath();
+        if (contextPath != null && !contextPath.isEmpty() && path.startsWith(contextPath)) {
+            path = path.substring(contextPath.length());
+        }
+        if (path.equals(MOUNT_PATH) || path.startsWith(MOUNT_PATH + "/")) return null;
+        return referrer;
+    }
+
+    /**
+     * A pre-filled issue on the tracker, so that reporting a malfunction takes no more
+     * than following a link and pressing a button, and arrives with what is needed to
+     * place it: what the user saw, where, and which version said it.
+     */
+    private static String getReportUrl(String message, String address, String cameFrom) {
+        String title = message.isBlank()
+                ? "Something went wrong in Nanodash"
+                : "Error: " + Utils.truncateLabel(message);
+        StringBuilder body = new StringBuilder();
+        body.append("What Nanodash said:\n\n> ")
+                .append(message.isBlank() ? "(no details were given)" : message)
+                .append("\n\n");
+        body.append("What I was doing:\n\n(please describe)\n\n");
+        if (address != null) body.append("Address: ").append(address).append("\n");
+        if (cameFrom != null) body.append("Came from: ").append(cameFrom).append("\n");
+        body.append("Nanodash version: ").append(WicketApplication.getThisVersion()).append("\n");
+        return ISSUE_TRACKER_URL + "?title=" + Utils.urlEncode(title) + "&body=" + Utils.urlEncode(body.toString());
     }
 
     /**
      * {@inheritDoc}
+     * <p>
+     * Answers with the HTTP status that matches the {@link Kind} of error, so that
+     * clients other than browsers can tell these apart too.
      */
     @Override
     protected void configureResponse(WebResponse response) {
         super.configureResponse(response);
+        response.setStatus(kind.getHttpStatus());
     }
 
     /**

--- a/src/main/java/com/knowledgepixels/nanodash/page/NanopubNotFoundPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/NanopubNotFoundPage.java
@@ -60,8 +60,11 @@ public class NanopubNotFoundPage extends NanodashPage {
     public static void forwardFor(NanopubLookup lookup) {
         switch (lookup.getStatus()) {
             case FOUND -> throw new IllegalArgumentException("Nanopublication was found, nothing to forward to");
-            case INVALID_ID -> throw new RestartResponseException(ErrorPage.class,
-                    new PageParameters().set(ErrorPage.MESSAGE_PARAM, lookup.getErrorMessage()));
+            // A malformed identifier is the asking user's to correct, so the error page is
+            // told as much and says so (#616).
+            case INVALID_ID -> throw new RestartResponseException(ErrorPage.class, new PageParameters()
+                    .set(ErrorPage.MESSAGE_PARAM, lookup.getErrorMessage())
+                    .set(ErrorPage.KIND_PARAM, ErrorPage.Kind.REQUEST.getParamValue()));
             default -> {
                 PageParameters params = new PageParameters().set(ID_PARAM, lookup.getId());
                 if (lookup.getStatus() == NanopubLookup.Status.TIMEOUT) {

--- a/src/main/java/com/knowledgepixels/nanodash/page/QueryPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/QueryPage.java
@@ -92,8 +92,9 @@ public class QueryPage extends NanodashPage {
         try {
             q = GrlcQuery.load(id);
         } catch (QueryLoadException ex) {
-            throw new RestartResponseException(ErrorPage.class,
-                    new PageParameters().set(ErrorPage.MESSAGE_PARAM, ex.getMessage()));
+            throw new RestartResponseException(ErrorPage.class, new PageParameters()
+                    .set(ErrorPage.MESSAGE_PARAM, ex.getMessage())
+                    .set(ErrorPage.KIND_PARAM, ex.getKind().getParamValue()));
         }
         if (!q.getQueryId().equals(id)) {
             throw new RestartResponseException(getClass(), parameters.set("id", q.getQueryId()));

--- a/src/test/java/com/knowledgepixels/nanodash/GrlcQueryTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/GrlcQueryTest.java
@@ -1,6 +1,7 @@
 package com.knowledgepixels.nanodash;
 
 import com.knowledgepixels.nanodash.component.QueryParamField;
+import com.knowledgepixels.nanodash.page.ErrorPage;
 import com.knowledgepixels.nanodash.utils.TestUtils;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
@@ -107,6 +108,8 @@ class GrlcQueryTest {
 
             QueryLoadException ex = assertThrows(QueryLoadException.class, () -> GrlcQuery.load(NANOPUB_URI));
             assertTrue(ex.getMessage().contains("SPARQL code"), ex.getMessage());
+            // Only the query's author can put this right, and the error page says so (#616).
+            assertEquals(ErrorPage.Kind.CONTENT, ex.getKind());
             // The offending character is invisible, so naming it is the only way the author of
             // the query can find it.
             assertTrue(ex.getMessage().contains("U+00A0"), ex.getMessage());
@@ -139,15 +142,18 @@ class GrlcQueryTest {
         }
     }
 
+    // Asking without saying for what, or with an ID that holds no artifact code, is a
+    // request the asker can correct — unlike a query that is there but unusable (#616).
     @Test
     void loadThrowsForMissingId() {
-        assertThrows(QueryLoadException.class, () -> GrlcQuery.load(null));
-        assertThrows(QueryLoadException.class, () -> GrlcQuery.load("  "));
+        assertEquals(ErrorPage.Kind.REQUEST, assertThrows(QueryLoadException.class, () -> GrlcQuery.load(null)).getKind());
+        assertEquals(ErrorPage.Kind.REQUEST, assertThrows(QueryLoadException.class, () -> GrlcQuery.load("  ")).getKind());
     }
 
     @Test
     void loadThrowsForIdThatIsNotAQueryId() {
-        assertThrows(QueryLoadException.class, () -> GrlcQuery.load("https://example.com/not-a-query"));
+        QueryLoadException ex = assertThrows(QueryLoadException.class, () -> GrlcQuery.load("https://example.com/not-a-query"));
+        assertEquals(ErrorPage.Kind.REQUEST, ex.getKind());
     }
 
     /**

--- a/src/test/java/com/knowledgepixels/nanodash/page/ErrorPageTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/page/ErrorPageTest.java
@@ -1,10 +1,15 @@
 package com.knowledgepixels.nanodash.page;
 
 import com.knowledgepixels.nanodash.WicketApplication;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.http.HttpServletResponse;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
 import org.apache.wicket.util.tester.WicketTester;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ErrorPageTest {
 
@@ -15,19 +20,117 @@ class ErrorPageTest {
         tester = new WicketTester(new WicketApplication());
     }
 
+    private String renderedPage() {
+        return tester.getLastResponse().getDocument();
+    }
+
+    private PageParameters params(ErrorPage.Kind kind, String message) {
+        PageParameters params = new PageParameters().add(ErrorPage.KIND_PARAM, kind.getParamValue());
+        if (message != null) params.add(ErrorPage.MESSAGE_PARAM, message);
+        return params;
+    }
+
+    // An error nobody foresaw is Nanodash's own until something says otherwise, so it is
+    // answered as one: a server error, with a way to report it (#616).
     @Test
     void rendersWithoutMessage() {
         tester.startPage(ErrorPage.class);
         tester.assertRenderedPage(ErrorPage.class);
+        tester.assertContains("Something went wrong here");
+        assertEquals(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, tester.getLastResponse().getStatus());
+        assertTrue(renderedPage().contains("https://github.com/knowledgepixels/nanodash/issues/new"), renderedPage());
     }
 
     // Details about what went wrong are shown to the user, so that e.g. a mistyped
     // nanopublication identifier can be told apart from a malfunction (#270).
     @Test
     void rendersGivenMessage() {
-        tester.startPage(ErrorPage.class, new PageParameters().add(ErrorPage.MESSAGE_PARAM, "'x' is not a valid nanopublication identifier."));
+        tester.startPage(ErrorPage.class, params(ErrorPage.Kind.REQUEST, "'x' is not a valid nanopublication identifier."));
         tester.assertRenderedPage(ErrorPage.class);
         tester.assertContains("is not a valid nanopublication identifier");
+    }
+
+    // Every error page says who can act on the problem, which differs per kind, and answers
+    // with the HTTP status that matches it (#616).
+    @Test
+    void aMistypedAddressIsTheUsersToCorrect() {
+        tester.startPage(ErrorPage.class, params(ErrorPage.Kind.REQUEST, "'x' is not a valid nanopublication identifier."));
+        tester.assertContains("If you typed or edited it");
+        assertEquals(HttpServletResponse.SC_BAD_REQUEST, tester.getLastResponse().getStatus());
+        // Nothing to report here: this one isn't Nanodash's to fix.
+        tester.assertInvisible("report-link");
+    }
+
+    @Test
+    void anInvalidPublishedQueryIsItsAuthorsToCorrect() {
+        tester.startPage(ErrorPage.class, params(ErrorPage.Kind.CONTENT, "The SPARQL code of the query is not valid."));
+        tester.assertContains("only its author can put it right");
+        tester.assertInvisible("report-link");
+        assertEquals(422, tester.getLastResponse().getStatus());
+    }
+
+    @Test
+    void aMalfunctionIsOursToFixAndCanBeReported() {
+        tester.startPage(ErrorPage.class, params(ErrorPage.Kind.MALFUNCTION, "Something unexpected happened."));
+        tester.assertContains("on Nanodash rather than on you");
+        assertEquals(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, tester.getLastResponse().getStatus());
+        assertTrue(renderedPage().contains("Something+unexpected+happened"), renderedPage());
+    }
+
+    // Every error page offers a way onward, whatever kind it is (#616).
+    @Test
+    void alwaysLinksHome() {
+        for (ErrorPage.Kind kind : ErrorPage.Kind.values()) {
+            tester.startPage(ErrorPage.class, params(kind, null));
+            tester.assertRenderedPage(ErrorPage.class);
+            tester.assertVisible("home-link");
+        }
+    }
+
+    // The container's own error handling forwards here (see web.xml); the status it settled
+    // on says what kind of error it is, and is answered with unchanged (#616).
+    @Test
+    void takesOverTheContainersErrorStatus() {
+        tester.getRequest().setAttribute(RequestDispatcher.ERROR_STATUS_CODE, HttpServletResponse.SC_NOT_FOUND);
+        tester.getRequest().setAttribute(RequestDispatcher.ERROR_REQUEST_URI, "/no-such-page");
+        tester.startPage(ErrorPage.class);
+        tester.assertRenderedPage(ErrorPage.class);
+        tester.assertContains("no page at this address");
+        tester.assertContains("/no-such-page");
+        assertEquals(HttpServletResponse.SC_NOT_FOUND, tester.getLastResponse().getStatus());
+    }
+
+    // Where the user came from is a way back, so the error page isn't a dead end (#616).
+    @Test
+    void linksBackToTheReferringPage() {
+        String referrer = "http://localhost/np/RAFl3dEaZocvP1BAyakcX_cXhFiRQ6uO8K6qMA_3p3j_t";
+        tester.getRequest().setHeader("Referer", referrer);
+        tester.startPage(ErrorPage.class, params(ErrorPage.Kind.REQUEST, null));
+        tester.assertVisible("back-link");
+        assertTrue(renderedPage().contains("href=\"" + referrer + "\""), renderedPage());
+    }
+
+    // Off-site is not where the user was working, and following the referrer there would
+    // take them further away rather than back.
+    @Test
+    void doesNotLinkBackOffSite() {
+        tester.getRequest().setHeader("Referer", "https://example.org/somewhere");
+        tester.startPage(ErrorPage.class, params(ErrorPage.Kind.REQUEST, null));
+        tester.assertInvisible("back-link");
+    }
+
+    // An error page is no way back either; offering one would just loop.
+    @Test
+    void doesNotLinkBackToAnErrorPage() {
+        tester.getRequest().setHeader("Referer", "http://localhost" + ErrorPage.MOUNT_PATH + "/500");
+        tester.startPage(ErrorPage.class, params(ErrorPage.Kind.REQUEST, null));
+        tester.assertInvisible("back-link");
+    }
+
+    @Test
+    void withoutAReferrerThereIsNoWayBack() {
+        tester.startPage(ErrorPage.class, params(ErrorPage.Kind.REQUEST, null));
+        tester.assertInvisible("back-link");
     }
 
 }

--- a/src/test/java/com/knowledgepixels/nanodash/page/NanopubNotFoundPageTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/page/NanopubNotFoundPageTest.java
@@ -85,6 +85,9 @@ class NanopubNotFoundPageTest {
         RestartResponseException ex = assertThrows(RestartResponseException.class, () -> NanopubNotFoundPage.forwardFor(lookup));
         assertEquals(ErrorPage.class, TestUtils.forwardedPageClass(ex));
         assertTrue(TestUtils.forwardedPageParameters(ex).get(ErrorPage.MESSAGE_PARAM).toString().contains(malformedId));
+        // It is the asking user's to correct, which the error page needs to be told (#616).
+        assertEquals(ErrorPage.Kind.REQUEST.getParamValue(),
+                TestUtils.forwardedPageParameters(ex).get(ErrorPage.KIND_PARAM).toString());
     }
 
     @Test

--- a/src/test/java/com/knowledgepixels/nanodash/page/QueryPageTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/page/QueryPageTest.java
@@ -69,6 +69,10 @@ class QueryPageTest {
             assertEquals(ErrorPage.class, TestUtils.forwardedPageClass(ex));
             String message = TestUtils.forwardedPageParameters(ex).get(ErrorPage.MESSAGE_PARAM).toString();
             assertTrue(message.contains("NO-BREAK SPACE"), message);
+            // Only the query's author can publish a corrected version, and the error page
+            // is told as much so it can say so (#616).
+            assertEquals(ErrorPage.Kind.CONTENT.getParamValue(),
+                    TestUtils.forwardedPageParameters(ex).get(ErrorPage.KIND_PARAM).toString());
         }
     }
 
@@ -79,6 +83,9 @@ class QueryPageTest {
         RestartResponseException ex = assertThrows(RestartResponseException.class,
                 () -> new QueryPage(new PageParameters()));
         assertEquals(ErrorPage.class, TestUtils.forwardedPageClass(ex));
+        // Nothing was published wrongly here; the request itself is what can be corrected (#616).
+        assertEquals(ErrorPage.Kind.REQUEST.getParamValue(),
+                TestUtils.forwardedPageParameters(ex).get(ErrorPage.KIND_PARAM).toString());
     }
 
 }


### PR DESCRIPTION
Closes #616.

`ErrorPage` said what went wrong and nothing else — no link home, no way back to what the user was doing, no hint of who could act on it. Compare `NanopubNotFoundPage`, which explains the situation, offers a retry and a link home, and answers with a fitting HTTP status.

## The shape of the error, not just its details

A new `ErrorPage.Kind`, set through a `kind` page parameter next to the existing `message`, says whose problem it is. It decides what the page tells the user to do, whether it offers a way to report the problem, and the status it is answered with:

| Kind | What the page says | Status |
| --- | --- | --- |
| `REQUEST` | The address is wrong; you — or whoever wrote the link — can correct it | 400 |
| `NOT_FOUND` | There is no page at this address (which it spells out) | 404 |
| `CONTENT` | The published nanopublication is at fault; only its author can put it right, by publishing a corrected version | 422 |
| `MALFUNCTION` | This one is on Nanodash, and here is how to report it | 500 |

`configureResponse()` answers with the matching status the way `NanopubNotFoundPage` does, so non-browser clients can tell these apart too. Without a kind, the page falls back to the status the servlet container settled on — that is how `web.xml`'s `/error/404` and `/error/500` arrive — and to `MALFUNCTION` otherwise, since an error nobody foresaw usually is one.

## A way onward

- A link home on every error page.
- A link back to where the user was, built from the `Referer` and accepted only for this instance's own pages — an off-site referrer is not where they were working — and never for an error page itself, which would only loop.
- For the errors that are ours, a pre-filled issue on the tracker carrying what the user saw, the failing address, where they came from, and the Nanodash version, so a malfunction doesn't dead-end at a stack trace in the server log.

## Callers say what they ran into

- `NanopubNotFoundPage.forwardFor()` marks a malformed identifier as the asking user's to correct.
- `GrlcQuery` classifies a failed load — the asking user's when the ID holds no artifact code at all, so nothing could have been fetched for it, and the query author's otherwise — and passes it through `QueryLoadException.getKind()` to `QueryPage`.
- The "which only a corrected version of it can fix" sentence moves out of the SPARQL message and into the page, where it now covers every error of that kind rather than just that one.

## Tests

11 tests in `ErrorPageTest` cover the per-kind wording and status, the report link's presence and contents, the back-link's accept and reject cases, and the container-status takeover. Kind assertions were added to `GrlcQueryTest`, `QueryPageTest`, and `NanopubNotFoundPageTest`. Full suite green: 1134 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)