### PR TITLE
feat(SourceNanopub): update nanopub element with additional data for RDFa parsers

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/component/SourceNanopub.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/SourceNanopub.html
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:wicket="http://wicket.apache.org">
+
 <body>
-<wicket:panel>
-  <a wicket:id="np" class="source">^</a>
-</wicket:panel>
+  <wicket:panel>
+    <a wicket:id="np" class="source" rel="cite-as" vocab="https://www.w3.org/ns/iana/link-relations/relation#">^</a>
+  </wicket:panel>
 </body>
+
 </html>


### PR DESCRIPTION
This pull request makes a small change to the `SourceNanopub.html` component. The update adds semantic HTML attributes to the source link to improve metadata and interoperability.

- Added `rel="cite-as"` and `vocab="https://www.w3.org/ns/iana/link-relations/relation#"` attributes to the `<a>` tag with `wicket:id="np"` to enhance citation semantics.