### PR TITLE
feat: profile pictures for spaces and maintained resources, with SVG support (#632, #634)

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/QueryApiAccess.java
+++ b/src/main/java/com/knowledgepixels/nanodash/QueryApiAccess.java
@@ -32,6 +32,12 @@ public class QueryApiAccess {
     public static final String GET_LATEST_VERSION_OF_NP = "RAiRsB2YywxjsBMkVRTREJBooXhf2ZOHoUs5lxciEl37I/get-latest-version-of-np";
     public static final String GET_ALL_USER_INTROS = "RAjHh6P11QFUaoPiMRBavdAnTq4YMJW4PB85oVFSBfYjU/get-all-user-intros";
     public static final String GET_ALL_USER_PROFILE_PICS = "RAtcodMPmTrmBvdOqwYIrNNFDO74f8B_xo0qsOcKlCwTA/get-all-user-profile-pics";
+    // Profile pictures of spaces and maintained resources (issue #632), declared as
+    // schema:image on the resource IRI. Unlike the user pictures above -- self-declared and
+    // read from a subject-agnostic query -- these are gated on the declaring nanopub being
+    // signed by a current admin of the governing space ref, so a third party cannot set a
+    // space's picture. Ordered newest first; the first row wins.
+    public static final String GET_RESOURCE_PROFILE_PICTURE = "RALK8_WQPtAbMUv2IvHeZyUU1WjD77V4a3hb0KsiZI0tI/get-resource-profile-picture";
     public static final String GET_ALL_USER_DEFAULT_LICENSE = "RA-_IwzReR2_HfTLz4YcNM6Mh3Vt16y0RUS12tpJTN9FI/get-all-user-default-license";
     public static final String GET_SUGGESTED_TEMPLATES_TO_GET_STARTED = "RA-tlMmQA7iT2wR2aS3PlONrepX7vdXbkzeWluea7AECg/get-suggested-templates-to-get-started";
     public static final String GET_MONTHLY_TYPE_OVERVIEW_BY_PUBKEYS = "RAhI-C2KsqS_IvnxwyBrbMFsoj65dhLWE_CBo_KtcVEVA/get-monthly-type-overview-by-pubkeys";

--- a/src/main/java/com/knowledgepixels/nanodash/Utils.java
+++ b/src/main/java/com/knowledgepixels/nanodash/Utils.java
@@ -1286,9 +1286,40 @@ public class Utils {
         return s.isEmpty() ? null : s;
     }
 
-    private static final String PLAIN_LITERAL_PATTERN = "^\"(([^\\\\\\\"]|\\\\\\\\|\\\\\")*)\"";
-    private static final String LANGTAG_LITERAL_PATTERN = "^\"(([^\\\\\\\"]|\\\\\\\\|\\\\\")*)\"@([0-9a-zA-Z-]{2,})$";
-    private static final String DATATYPE_LITERAL_PATTERN = "^\"(([^\\\\\\\"]|\\\\\\\\|\\\\\")*)\"\\^\\^<([^ ><\"^]+)>";
+    // The part after the quoted string: a language tag, or a datatype IRI. The quoted
+    // string itself is scanned rather than matched (see scanQuotedString): expressed as a
+    // regex it costs one stack frame per character, so a literal of a few thousand
+    // characters -- e.g. a profile picture given as SVG markup, issue #634 -- overflowed
+    // the stack and turned publish-form validation into a 500.
+    private static final Pattern LANGTAG_SUFFIX = Pattern.compile("^@([0-9a-zA-Z-]{2,})$");
+    private static final Pattern DATATYPE_SUFFIX = Pattern.compile("^\\^\\^<([^ ><\"^]+)>$");
+
+    /**
+     * Scans a leading quoted string, in which a backslash may escape a backslash or a
+     * quote, and returns the index just past its closing quote.
+     *
+     * @param s the string to scan
+     * @return the index just past the closing quote, or -1 if the string does not start
+     * with a well-formed quoted string
+     */
+    private static int scanQuotedString(String s) {
+        if (s.isEmpty() || s.charAt(0) != '"') return -1;
+        int i = 1;
+        while (i < s.length()) {
+            char c = s.charAt(i);
+            if (c == '\\') {
+                if (i + 1 >= s.length()) return -1;
+                char next = s.charAt(i + 1);
+                if (next != '\\' && next != '"') return -1;
+                i += 2;
+            } else if (c == '"') {
+                return i + 1;
+            } else {
+                i++;
+            }
+        }
+        return -1;
+    }
 
     /**
      * Checks whether string is valid literal serialization.
@@ -1297,14 +1328,12 @@ public class Utils {
      * @return true if valid
      */
     public static boolean isValidLiteralSerialization(String literalString) {
-        if (literalString.matches(PLAIN_LITERAL_PATTERN)) {
-            return true;
-        } else if (literalString.matches(LANGTAG_LITERAL_PATTERN)) {
-            return true;
-        } else if (literalString.matches(DATATYPE_LITERAL_PATTERN)) {
-            return true;
-        }
-        return false;
+        int end = scanQuotedString(literalString);
+        if (end < 0) return false;
+        String suffix = literalString.substring(end);
+        return suffix.isEmpty()
+                || LANGTAG_SUFFIX.matcher(suffix).matches()
+                || DATATYPE_SUFFIX.matcher(suffix).matches();
     }
 
     /**
@@ -1330,14 +1359,15 @@ public class Utils {
      * @return The parse Literal object
      */
     public static Literal getParsedLiteral(String serializedLiteral) {
-        if (serializedLiteral.matches(PLAIN_LITERAL_PATTERN)) {
-            return vf.createLiteral(getUnescapedLiteralString(serializedLiteral.replaceFirst(PLAIN_LITERAL_PATTERN, "$1")));
-        } else if (serializedLiteral.matches(LANGTAG_LITERAL_PATTERN)) {
-            String langtag = serializedLiteral.replaceFirst(LANGTAG_LITERAL_PATTERN, "$3");
-            return vf.createLiteral(getUnescapedLiteralString(serializedLiteral.replaceFirst(LANGTAG_LITERAL_PATTERN, "$1")), langtag);
-        } else if (serializedLiteral.matches(DATATYPE_LITERAL_PATTERN)) {
-            IRI datatype = vf.createIRI(serializedLiteral.replaceFirst(DATATYPE_LITERAL_PATTERN, "$3"));
-            return vf.createLiteral(getUnescapedLiteralString(serializedLiteral.replaceFirst(DATATYPE_LITERAL_PATTERN, "$1")), datatype);
+        int end = scanQuotedString(serializedLiteral);
+        if (end >= 0) {
+            String value = getUnescapedLiteralString(serializedLiteral.substring(1, end - 1));
+            String suffix = serializedLiteral.substring(end);
+            if (suffix.isEmpty()) return vf.createLiteral(value);
+            Matcher langtag = LANGTAG_SUFFIX.matcher(suffix);
+            if (langtag.matches()) return vf.createLiteral(value, langtag.group(1));
+            Matcher datatype = DATATYPE_SUFFIX.matcher(suffix);
+            if (datatype.matches()) return vf.createLiteral(value, vf.createIRI(datatype.group(1)));
         }
         throw new IllegalArgumentException("Not a valid literal serialization: " + serializedLiteral);
     }
@@ -1349,7 +1379,7 @@ public class Utils {
      * @return escaped string
      */
     public static String getEscapedLiteralString(String unescapedString) {
-        return unescapedString.replaceAll("\\\\", "\\\\\\\\").replaceAll("\"", "\\\"");
+        return unescapedString.replace("\\", "\\\\").replace("\"", "\\\"");
     }
 
     /**

--- a/src/main/java/com/knowledgepixels/nanodash/Utils.java
+++ b/src/main/java/com/knowledgepixels/nanodash/Utils.java
@@ -657,13 +657,63 @@ public class Utils {
             "d", "points", "dx", "dy", "transform",
             "fill", "fill-opacity", "fill-rule",
             "stroke", "stroke-width", "stroke-opacity", "stroke-linecap",
-            "stroke-linejoin", "stroke-dasharray", "opacity",
+            "stroke-linejoin", "stroke-dasharray", "stroke-dashoffset",
+            "stroke-miterlimit", "clip-rule", "opacity",
             "font-family", "font-size", "font-weight", "font-style",
             "text-anchor", "dominant-baseline", "text-decoration",
             "marker-start", "marker-mid", "marker-end",
             "markerwidth", "markerWidth", "markerheight", "markerHeight",
             "refx", "refX", "refy", "refY", "orient", "markerunits", "markerUnits",
             "id"};
+
+    // Drawing tools export SVG with the paint in a style attribute
+    // (style="fill:rgb(120,184,134);") rather than in presentation attributes. The
+    // sanitizer allows no style attribute -- it is the one attribute whose value can pull
+    // in external resources -- so those declarations used to be dropped, and every shape
+    // fell back to the SVG default fill: an all-black figure. They are therefore rewritten
+    // into the equivalent presentation attributes first, which the existing allow-list
+    // then validates like any other: nothing new is allowed through, and a declaration
+    // whose property is not on the list (or whose value could reference something, i.e.
+    // contains a function call other than a colour) is dropped as before.
+    private static final Set<String> STYLE_PROPERTIES_AS_ATTRIBUTES = Set.of(
+            "fill", "fill-opacity", "fill-rule",
+            "stroke", "stroke-width", "stroke-opacity", "stroke-linecap",
+            "stroke-linejoin", "stroke-dasharray", "stroke-dashoffset",
+            "stroke-miterlimit", "clip-rule", "opacity",
+            "font-family", "font-size", "font-weight", "font-style",
+            "text-anchor", "dominant-baseline", "text-decoration");
+
+    // A style attribute on any element, with either quoting style.
+    private static final Pattern STYLE_ATTRIBUTE = Pattern.compile(
+            "\\sstyle\\s*=\\s*(\"[^\"]*\"|'[^']*')", Pattern.CASE_INSENSITIVE);
+
+    // A value safe to move into a presentation attribute: no function call other than the
+    // colour functions, so url(...) and expression(...) can never survive.
+    private static final Pattern SAFE_STYLE_VALUE = Pattern.compile(
+            "(?:[-#%.,0-9a-zA-Z_ ]|(?:rgb|rgba|hsl|hsla)\\([-0-9%.,\\s]*\\))+");
+
+    private static String styleToPresentationAttributes(String raw) {
+        if (raw == null || !raw.contains("style")) return raw;
+        Matcher m = STYLE_ATTRIBUTE.matcher(raw);
+        StringBuilder sb = new StringBuilder();
+        while (m.find()) {
+            String quoted = m.group(1);
+            String declarations = quoted.substring(1, quoted.length() - 1);
+            StringBuilder attributes = new StringBuilder();
+            for (String declaration : declarations.split(";")) {
+                int colon = declaration.indexOf(':');
+                if (colon < 0) continue;
+                String property = declaration.substring(0, colon).trim().toLowerCase();
+                String value = declaration.substring(colon + 1).trim();
+                if (!STYLE_PROPERTIES_AS_ATTRIBUTES.contains(property)) continue;
+                if (value.isEmpty() || !SAFE_STYLE_VALUE.matcher(value).matches()) continue;
+                attributes.append(' ').append(property).append("=\"").append(value).append('"');
+            }
+            m.appendReplacement(sb, Matcher.quoteReplacement(attributes.toString()));
+        }
+        m.appendTail(sb);
+        return sb.toString();
+    }
 
     private static String[] concat(String[] values, String... more) {
         String[] result = Arrays.copyOf(values, values.length + more.length);
@@ -702,7 +752,7 @@ public class Utils {
      * @return sanitized HTML string
      */
     public static String sanitizeHtml(String rawHtml) {
-        return htmlSanitizePolicy.sanitize(normalizeSelfClosedSvgTags(rawHtml));
+        return htmlSanitizePolicy.sanitize(styleToPresentationAttributes(normalizeSelfClosedSvgTags(rawHtml)));
     }
 
     private static final PolicyFactory svgSanitizePolicy = allowSvgSubset(new HtmlPolicyBuilder()
@@ -739,7 +789,7 @@ public class Utils {
      * @return sanitized SVG markup
      */
     public static String sanitizeSvg(String rawSvg) {
-        return svgSanitizePolicy.sanitize(normalizeSelfClosedSvgTags(rawSvg));
+        return svgSanitizePolicy.sanitize(styleToPresentationAttributes(normalizeSelfClosedSvgTags(rawSvg)));
     }
 
     // A whole inline SVG figure, dropped wherever HTML is reduced to text: its

--- a/src/main/java/com/knowledgepixels/nanodash/component/AgentChoiceItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/AgentChoiceItem.java
@@ -10,6 +10,7 @@ import com.knowledgepixels.nanodash.page.ProfilePage;
 import com.knowledgepixels.nanodash.template.Template;
 import com.knowledgepixels.nanodash.template.TemplateContext;
 import com.knowledgepixels.nanodash.template.UnificationException;
+import com.knowledgepixels.nanodash.domain.ProfilePicture;
 import org.apache.wicket.Component;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.form.OnChangeAjaxBehavior;
@@ -208,9 +209,9 @@ public class AgentChoiceItem extends AbstractContextComponent {
                 } else {
                     selectedIri = NanodashSession.get().getUserIri();
                 }
-                IRI profilePicIri = (selectedIri != null) ? User.getProfilePicture(selectedIri) : null;
-                if (profilePicIri != null) {
-                    tag.put("src", profilePicIri.stringValue());
+                ProfilePicture profilePicture = (selectedIri != null) ? User.getProfilePicture(selectedIri) : null;
+                if (profilePicture != null) {
+                    tag.put("src", profilePicture.getSrc());
                 } else if (selectedIri != null && IndividualAgent.isSoftware(selectedIri)) {
                     tag.put("src", urlFor(new ContextRelativeResourceReference("images/bot-icon.svg", false), null).toString());
                 } else {

--- a/src/main/java/com/knowledgepixels/nanodash/component/ItemListElement.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/ItemListElement.java
@@ -3,6 +3,7 @@ package com.knowledgepixels.nanodash.component;
 import com.knowledgepixels.nanodash.domain.IndividualAgent;
 import com.knowledgepixels.nanodash.domain.User;
 import com.knowledgepixels.nanodash.page.UserPage;
+import com.knowledgepixels.nanodash.domain.ProfilePicture;
 import org.apache.wicket.Component;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.WebPage;
@@ -36,10 +37,10 @@ public class ItemListElement extends Panel {
         super(markupId);
 
         IRI userIri = getUserIri(pageClass, parameters);
-        IRI profilePicIri = (userIri != null) ? User.getProfilePicture(userIri) : null;
+        ProfilePicture profilePicture = (userIri != null) ? User.getProfilePicture(userIri) : null;
 
-        if (profilePicIri != null) {
-            ExternalImage profilePic = new ExternalImage("user-icon", profilePicIri.stringValue());
+        if (profilePicture != null) {
+            ExternalImage profilePic = new ExternalImage("user-icon", profilePicture.getSrc());
             add(profilePic);
         } else {
             Component userIcon;

--- a/src/main/java/com/knowledgepixels/nanodash/component/ProfileItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/ProfileItem.java
@@ -4,6 +4,7 @@ import com.knowledgepixels.nanodash.NanodashPreferences;
 import com.knowledgepixels.nanodash.NanodashSession;
 import com.knowledgepixels.nanodash.domain.User;
 import com.knowledgepixels.nanodash.page.*;
+import com.knowledgepixels.nanodash.domain.ProfilePicture;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.image.ExternalImage;
@@ -50,9 +51,9 @@ public class ProfileItem extends Panel {
         } else {
             if (userId != null) {
                 BookmarkablePageLink<ProfilePage> l = new BookmarkablePageLink<ProfilePage>("profilelink", UserPage.class, new PageParameters().set("id", userId.stringValue()));
-                IRI profilePictureIri = User.getProfilePicture(userId);
-                if (profilePictureIri != null) {
-                    l.add(new ExternalImage("profileimage", profilePictureIri.stringValue()));
+                ProfilePicture profilePicture = User.getProfilePicture(userId);
+                if (profilePicture != null) {
+                    l.add(new ExternalImage("profileimage", profilePicture.getSrc()));
                 } else {
                     l.add(new Image("profileimage", new ContextRelativeResourceReference("images/user-icon.svg", false)));
                 }

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultItemList.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultItemList.java
@@ -6,6 +6,7 @@ import com.knowledgepixels.nanodash.domain.IndividualAgent;
 import com.knowledgepixels.nanodash.domain.User;
 import com.knowledgepixels.nanodash.page.PublishPage;
 import com.knowledgepixels.nanodash.page.UserPage;
+import com.knowledgepixels.nanodash.domain.ProfilePicture;
 import org.apache.wicket.Component;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.markup.html.navigation.paging.AjaxPagingNavigator;
@@ -126,11 +127,11 @@ public class QueryResultItemList extends QueryResult {
 
             if (key.endsWith("user_iri")) {
                 IRI userIri = Utils.vf.createIRI(value);
-                IRI profilePicIri = User.getProfilePicture(userIri);
+                ProfilePicture profilePicture = User.getProfilePicture(userIri);
                 String imgSrc;
                 String iconClass;
-                if (profilePicIri != null) {
-                    imgSrc = Strings.escapeMarkup(profilePicIri.stringValue()).toString();
+                if (profilePicture != null) {
+                    imgSrc = Strings.escapeMarkup(profilePicture.getSrc()).toString();
                     iconClass = "user-icon";
                 } else if (IndividualAgent.isSoftware(userIri)) {
                     imgSrc = RequestCycle.get().urlFor(new ContextRelativeResourceReference("images/bot-icon.svg", false), null).toString();

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultList.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultList.java
@@ -5,6 +5,7 @@ import com.knowledgepixels.nanodash.component.menu.EntryActionMenu;
 import com.knowledgepixels.nanodash.domain.IndividualAgent;
 import com.knowledgepixels.nanodash.domain.User;
 import com.knowledgepixels.nanodash.page.*;
+import com.knowledgepixels.nanodash.domain.ProfilePicture;
 import org.apache.wicket.Component;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.markup.html.navigation.paging.AjaxPagingNavigator;
@@ -106,10 +107,10 @@ public class QueryResultList extends QueryResult {
                     if (entryValue != null && !entryValue.isBlank()) {
                         if (key.endsWith("user_iri")) {
                             IRI userIri = Utils.vf.createIRI(entryValue);
-                            IRI profilePicIri = User.getProfilePicture(userIri);
+                            ProfilePicture profilePicture = User.getProfilePicture(userIri);
                             String imgSrc;
-                            if (profilePicIri != null) {
-                                imgSrc = Strings.escapeMarkup(profilePicIri.stringValue()).toString();
+                            if (profilePicture != null) {
+                                imgSrc = Strings.escapeMarkup(profilePicture.getSrc()).toString();
                             } else if (IndividualAgent.isSoftware(userIri)) {
                                 imgSrc = RequestCycle.get().urlFor(new ContextRelativeResourceReference("images/bot-icon.svg", false), null).toString();
                             } else {

--- a/src/main/java/com/knowledgepixels/nanodash/domain/AbstractResourceWithProfile.java
+++ b/src/main/java/com/knowledgepixels/nanodash/domain/AbstractResourceWithProfile.java
@@ -9,6 +9,7 @@ import com.knowledgepixels.nanodash.ViewDisplay;
 import com.knowledgepixels.nanodash.repository.SpaceRepository;
 import com.knowledgepixels.nanodash.vocabulary.KPXL_TERMS;
 import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.util.Values;
 import org.nanopub.Nanopub;
 import org.nanopub.extra.services.ApiResponse;
 import org.nanopub.extra.services.ApiResponseEntry;
@@ -53,6 +54,10 @@ public abstract class AbstractResourceWithProfile implements Serializable, Resou
      */
     protected static class ResourceWithProfile implements Serializable {
         List<ViewDisplay> viewDisplays = new ArrayList<>();
+        // The admin-declared profile picture (issue #632), fetched together with the view
+        // displays so that rendering never waits on it and a publication's forced refresh
+        // picks up a new picture along with the rest of the structure.
+        IRI profilePicture;
     }
 
     /**
@@ -152,6 +157,7 @@ public abstract class AbstractResourceWithProfile implements Serializable, Resou
                     // standalone displays correctly, in either direction.
                     seedFromCacheIfPossible();
                     newData.viewDisplays.addAll(buildViewDisplays(viewDisplaysQueryRef()));
+                    newData.profilePicture = fetchProfilePicture();
                     data = newData;
                     dataInitialized = true;
                     // A forceRefresh that came in while this fetch was already running has
@@ -202,6 +208,7 @@ public abstract class AbstractResourceWithProfile implements Serializable, Resou
         if (cachedResponse == null) return;
         ResourceWithProfile seeded = new ResourceWithProfile();
         seeded.viewDisplays.addAll(buildViewDisplays(cachedResponse, vdQuery));
+        seeded.profilePicture = firstPicture(ApiCache.retrieveStaleResponse(profilePictureQueryRef()));
         data = seeded;
         dataInitialized = true;
     }
@@ -458,6 +465,49 @@ public abstract class AbstractResourceWithProfile implements Serializable, Resou
      * @return the ref's root nanopub, or null
      */
     protected String getViewDisplayRefRoot() {
+        return null;
+    }
+
+    /**
+     * The profile picture of this resource, declared as {@code schema:image} with the
+     * resource IRI as subject (issue #632). Only declarations signed by a current admin of
+     * the governing space count — a space's picture is not something an unrelated agent can
+     * set, unlike a user's self-declared one (see
+     * {@link QueryApiAccess#GET_RESOURCE_PROFILE_PICTURE}). Read from the asynchronously
+     * updated data, so this never blocks the render; a resource without a declared picture
+     * simply shows none (there is no fallback icon).
+     *
+     * @return the picture's IRI, or null if none is declared
+     */
+    public IRI getProfilePicture() {
+        triggerDataUpdate();
+        return data.profilePicture;
+    }
+
+    private QueryRef profilePictureQueryRef() {
+        return new QueryRef(QueryApiAccess.GET_RESOURCE_PROFILE_PICTURE, "resource", id);
+    }
+
+    private IRI fetchProfilePicture() {
+        return firstPicture(ApiCache.retrieveResponseSync(profilePictureQueryRef(), true));
+    }
+
+    /**
+     * The newest usable picture of a get-resource-profile-picture response (the query
+     * orders newest first), skipping rows whose value is not a usable IRI — the declaring
+     * triple does not constrain the object, so a literal or a malformed URL is possible.
+     */
+    private IRI firstPicture(ApiResponse response) {
+        if (response == null) return null;
+        for (ApiResponseEntry r : response.getData()) {
+            String url = r.get("imageUrl");
+            if (url == null || url.isEmpty()) continue;
+            try {
+                return Values.iri(url);
+            } catch (IllegalArgumentException ex) {
+                logger.warn("Ignoring malformed profile picture {} for resource {}", url, id);
+            }
+        }
         return null;
     }
 

--- a/src/main/java/com/knowledgepixels/nanodash/domain/AbstractResourceWithProfile.java
+++ b/src/main/java/com/knowledgepixels/nanodash/domain/AbstractResourceWithProfile.java
@@ -57,7 +57,7 @@ public abstract class AbstractResourceWithProfile implements Serializable, Resou
         // The admin-declared profile picture (issue #632), fetched together with the view
         // displays so that rendering never waits on it and a publication's forced refresh
         // picks up a new picture along with the rest of the structure.
-        IRI profilePicture;
+        ProfilePicture profilePicture;
     }
 
     /**
@@ -477,9 +477,9 @@ public abstract class AbstractResourceWithProfile implements Serializable, Resou
      * updated data, so this never blocks the render; a resource without a declared picture
      * simply shows none (there is no fallback icon).
      *
-     * @return the picture's IRI, or null if none is declared
+     * @return the picture, or null if none is declared
      */
-    public IRI getProfilePicture() {
+    public ProfilePicture getProfilePicture() {
         triggerDataUpdate();
         return data.profilePicture;
     }
@@ -488,24 +488,23 @@ public abstract class AbstractResourceWithProfile implements Serializable, Resou
         return new QueryRef(QueryApiAccess.GET_RESOURCE_PROFILE_PICTURE, "resource", id);
     }
 
-    private IRI fetchProfilePicture() {
+    private ProfilePicture fetchProfilePicture() {
         return firstPicture(ApiCache.retrieveResponseSync(profilePictureQueryRef(), true));
     }
 
     /**
-     * The newest usable picture of a get-resource-profile-picture response (the query
-     * orders newest first), skipping rows whose value is not a usable IRI — the declaring
-     * triple does not constrain the object, so a literal or a malformed URL is possible.
+     * The newest usable picture of a get-resource-profile-picture response (the query orders
+     * newest first), skipping values that are neither an image link nor usable SVG markup —
+     * the declaring triple is unconstrained, so anything can turn up there.
      */
-    private IRI firstPicture(ApiResponse response) {
+    private ProfilePicture firstPicture(ApiResponse response) {
         if (response == null) return null;
         for (ApiResponseEntry r : response.getData()) {
-            String url = r.get("imageUrl");
-            if (url == null || url.isEmpty()) continue;
-            try {
-                return Values.iri(url);
-            } catch (IllegalArgumentException ex) {
-                logger.warn("Ignoring malformed profile picture {} for resource {}", url, id);
+            ProfilePicture picture = ProfilePicture.of(r.get("imageUrl"));
+            if (picture != null) return picture;
+            String value = r.get("imageUrl");
+            if (value != null && !value.isEmpty()) {
+                logger.warn("Ignoring unusable profile picture value for resource {}", id);
             }
         }
         return null;

--- a/src/main/java/com/knowledgepixels/nanodash/domain/IndividualAgent.java
+++ b/src/main/java/com/knowledgepixels/nanodash/domain/IndividualAgent.java
@@ -119,7 +119,7 @@ public class IndividualAgent extends AbstractResourceWithProfile {
      * for spaces and maintained resources (issue #632).
      */
     @Override
-    public IRI getProfilePicture() {
+    public ProfilePicture getProfilePicture() {
         return User.getProfilePicture(Utils.vf.createIRI(getId()));
     }
 

--- a/src/main/java/com/knowledgepixels/nanodash/domain/IndividualAgent.java
+++ b/src/main/java/com/knowledgepixels/nanodash/domain/IndividualAgent.java
@@ -113,4 +113,14 @@ public class IndividualAgent extends AbstractResourceWithProfile {
         return getId();
     }
 
+    /**
+     * A user's profile picture is self-declared, so it comes from the user data (loaded once
+     * for all users) rather than from the admin-gated per-resource query the base class uses
+     * for spaces and maintained resources (issue #632).
+     */
+    @Override
+    public IRI getProfilePicture() {
+        return User.getProfilePicture(Utils.vf.createIRI(getId()));
+    }
+
 }

--- a/src/main/java/com/knowledgepixels/nanodash/domain/ProfilePicture.java
+++ b/src/main/java/com/knowledgepixels/nanodash/domain/ProfilePicture.java
@@ -1,0 +1,95 @@
+package com.knowledgepixels.nanodash.domain;
+
+import com.knowledgepixels.nanodash.Utils;
+import org.eclipse.rdf4j.model.util.Values;
+
+import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.regex.Pattern;
+
+/**
+ * A profile picture of a user, space, or maintained resource, declared as
+ * {@code schema:image}. The object of that triple can be either a link to an image file or
+ * a literal holding the SVG markup itself (issue #634); both end up here as a ready-to-use
+ * image source, so that every place showing a picture stays a plain {@code <img>} — with
+ * the tilted-square mask on user icons, the object-fit rules on resource pictures, and the
+ * sizing in list rows all working unchanged for either kind.
+ * <p>
+ * SVG markup is reduced to the same static subset as an SVG view's output before being
+ * embedded ({@link Utils#sanitizeSvg}), and it travels as a {@code data:} URI rather than
+ * as inline markup: inside an {@code <img>} an SVG document cannot script or fetch anything
+ * regardless, so the picture of one resource can never reach into the page showing it.
+ */
+public class ProfilePicture implements Serializable {
+
+    private static final Pattern SVG_ROOT = Pattern.compile("<svg\\b", Pattern.CASE_INSENSITIVE);
+    private static final String SVG_NAMESPACE = "http://www.w3.org/2000/svg";
+
+    private final String src;
+    private final boolean svg;
+
+    private ProfilePicture(String src, boolean svg) {
+        this.src = src;
+        this.svg = svg;
+    }
+
+    /**
+     * Builds a picture from the value of a {@code schema:image} triple, which the declaring
+     * templates do not constrain: an IRI pointing at an image file, or a literal holding SVG
+     * markup. Anything else (a plain literal, a malformed IRI, SVG markup of which nothing
+     * survives sanitizing) yields null, so callers can treat "no usable picture" and "none
+     * declared" alike.
+     *
+     * @param value the raw value of the triple
+     * @return the picture, or null if the value is not usable as one
+     */
+    public static ProfilePicture of(String value) {
+        if (value == null) return null;
+        String trimmed = value.trim();
+        if (trimmed.isEmpty()) return null;
+        if (trimmed.startsWith("<") && SVG_ROOT.matcher(trimmed).find()) {
+            String sanitized = Utils.sanitizeSvg(trimmed);
+            if (!SVG_ROOT.matcher(sanitized).find()) return null;
+            // An <img> loads its SVG as XML, where the namespace declaration is not optional
+            // (an author writing markup for inline use may well have left it out).
+            if (!sanitized.contains("xmlns")) {
+                sanitized = SVG_ROOT.matcher(sanitized)
+                        .replaceFirst("<svg xmlns=\"" + SVG_NAMESPACE + "\"");
+            }
+            String encoded = Base64.getEncoder().encodeToString(sanitized.getBytes(StandardCharsets.UTF_8));
+            return new ProfilePicture("data:image/svg+xml;base64," + encoded, true);
+        }
+        try {
+            Values.iri(trimmed);
+        } catch (IllegalArgumentException ex) {
+            return null;
+        }
+        return new ProfilePicture(trimmed, false);
+    }
+
+    /**
+     * The value to use as an {@code <img>} source: the declared URL, or a {@code data:} URI
+     * carrying the sanitized SVG.
+     *
+     * @return the image source
+     */
+    public String getSrc() {
+        return src;
+    }
+
+    /**
+     * Whether the picture was declared as SVG markup rather than as a link.
+     *
+     * @return true for an SVG literal
+     */
+    public boolean isSvg() {
+        return svg;
+    }
+
+    @Override
+    public String toString() {
+        return src;
+    }
+
+}

--- a/src/main/java/com/knowledgepixels/nanodash/domain/User.java
+++ b/src/main/java/com/knowledgepixels/nanodash/domain/User.java
@@ -201,9 +201,9 @@ public class User {
      * Retrieves the profile picture IRI for a user based on their IRI.
      *
      * @param userIri The IRI of the user.
-     * @return The IRI of the user's profile picture, or null if not set.
+     * @return The user's profile picture, or null if not set.
      */
-    public static IRI getProfilePicture(IRI userIri) {
+    public static ProfilePicture getProfilePicture(IRI userIri) {
         return getUserData().getProfilePicture(userIri);
     }
 

--- a/src/main/java/com/knowledgepixels/nanodash/domain/UserData.java
+++ b/src/main/java/com/knowledgepixels/nanodash/domain/UserData.java
@@ -45,7 +45,7 @@ public class UserData implements Serializable {
     private Set<IRI> approvedIntros = new HashSet<>();
     private HashMap<IRI, String> idNameMap = new HashMap<>();
     private HashMap<IRI, List<IntroNanopub>> introNanopubLists = new HashMap<>();
-    private final HashMap<IRI, IRI> profilePictures = new HashMap<>();
+    private final HashMap<IRI, ProfilePicture> profilePictures = new HashMap<>();
     private final HashMap<IRI, IRI> defaultLicense = new HashMap<>();
 
     /**
@@ -128,7 +128,11 @@ public class UserData implements Serializable {
         }
 
         for (ApiResponseEntry entry : ApiCache.retrieveResponseSync(new QueryRef(QueryApiAccess.GET_ALL_USER_PROFILE_PICS), forced).getData()) {
-            profilePictures.put(Values.iri(entry.get("user")), Values.iri(entry.get("imageUrl")));
+            // The value can be a link or SVG markup (issue #634), and nothing stops a user
+            // from declaring something unusable as either — hence the null check rather
+            // than a bare parse, which would abort the whole user-data load.
+            ProfilePicture picture = ProfilePicture.of(entry.get("imageUrl"));
+            if (picture != null) profilePictures.put(Values.iri(entry.get("user")), picture);
         }
 
         for (ApiResponseEntry entry : ApiCache.retrieveResponseSync(new QueryRef(QueryApiAccess.GET_ALL_USER_DEFAULT_LICENSE), forced).getData()) {
@@ -603,12 +607,16 @@ public class UserData implements Serializable {
     }
 
     /**
-     * Retrieves the profile picture IRI for a user based on their IRI.
+     * Retrieves the profile picture IRI for a user based on their IRI. Users declare their
+     * own picture, and the underlying query accepts any signer, so this is for user IRIs
+     * only: spaces and maintained resources go through the admin-gated per-resource query
+     * instead (issue #632, see
+     * {@link com.knowledgepixels.nanodash.domain.AbstractResourceWithProfile#getProfilePicture()}).
      *
      * @param userIri the IRI of the user for whom to retrieve the profile picture
      * @return the IRI of the user's profile picture if found, or null if not found
      */
-    public IRI getProfilePicture(IRI userIri) {
+    public ProfilePicture getProfilePicture(IRI userIri) {
         return profilePictures.get(userIri);
     }
 

--- a/src/main/java/com/knowledgepixels/nanodash/page/MaintainedResourcePage.html
+++ b/src/main/java/com/knowledgepixels/nanodash/page/MaintainedResourcePage.html
@@ -13,6 +13,7 @@
 
   <div class="row-section">
     <div class="col-12 header">
+      <img class="resource-profile-pic" wicket:id="profilepic"/>
       <h2><span wicket:id="resourcename">Resource ABC</span><span class="title-suffix" wicket:id="titlesuffix"></span><span
           class="title-actions" wicket:id="titlemenu"></span></h2>
       <p><span wicket:id="id"></span></p>

--- a/src/main/java/com/knowledgepixels/nanodash/page/MaintainedResourcePage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/MaintainedResourcePage.java
@@ -9,6 +9,7 @@ import com.knowledgepixels.nanodash.domain.AbstractResourceWithProfile;
 import com.knowledgepixels.nanodash.domain.MaintainedResource;
 import com.knowledgepixels.nanodash.domain.Space;
 import com.knowledgepixels.nanodash.repository.MaintainedResourceRepository;
+import com.knowledgepixels.nanodash.domain.ProfilePicture;
 import org.apache.wicket.Component;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.extensions.ajax.markup.html.AjaxLazyLoadPanel;
@@ -93,9 +94,9 @@ public class MaintainedResourcePage extends NanodashPage {
         // Optional profile picture, left of the title/URI block (issue #632). Shown
         // plainly, i.e. without the tilted-square mask that user icons get, and simply
         // omitted when the resource declares none.
-        IRI profilePicture = resource.getProfilePicture();
+        ProfilePicture profilePicture = resource.getProfilePicture();
         add(profilePicture != null
-                ? new ExternalImage("profilepic", profilePicture.stringValue())
+                ? new ExternalImage("profilepic", profilePicture.getSrc())
                 : new WebMarkupContainer("profilepic").setVisible(false));
         add(new Label("resourcename", resource.getLabel()));
         add(new Label("titlesuffix", ResourceTabs.titleSuffix(activeTab)));

--- a/src/main/java/com/knowledgepixels/nanodash/page/MaintainedResourcePage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/MaintainedResourcePage.java
@@ -14,11 +14,13 @@ import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.extensions.ajax.markup.html.AjaxLazyLoadPanel;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.image.ExternalImage;
 import org.apache.wicket.markup.html.panel.EmptyPanel;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.LoadableDetachableModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
+import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.util.Values;
 
 import java.util.List;
@@ -88,6 +90,13 @@ public class MaintainedResourcePage extends NanodashPage {
         ).setTabs(new ResourceTabs("tabs", "resource", resource.getId(), activeTab)));
 
         add(new Label("pagetitle", resource.getLabel() + " (resource) | nanodash"));
+        // Optional profile picture, left of the title/URI block (issue #632). Shown
+        // plainly, i.e. without the tilted-square mask that user icons get, and simply
+        // omitted when the resource declares none.
+        IRI profilePicture = resource.getProfilePicture();
+        add(profilePicture != null
+                ? new ExternalImage("profilepic", profilePicture.stringValue())
+                : new WebMarkupContainer("profilepic").setVisible(false));
         add(new Label("resourcename", resource.getLabel()));
         add(new Label("titlesuffix", ResourceTabs.titleSuffix(activeTab)));
         add(PageTitleMenu.forResource("titlemenu", resource));

--- a/src/main/java/com/knowledgepixels/nanodash/page/SpacePage.html
+++ b/src/main/java/com/knowledgepixels/nanodash/page/SpacePage.html
@@ -13,6 +13,7 @@
 
   <div class="row-section">
     <div class="col-12 header">
+      <img class="resource-profile-pic" wicket:id="profilepic"/>
       <h2><span wicket:id="spacename">Space ABC</span><span class="title-suffix" wicket:id="titlesuffix"></span><span
           class="title-actions" wicket:id="titlemenu"></span></h2>
       <p><span wicket:id="id"></span></p>

--- a/src/main/java/com/knowledgepixels/nanodash/page/SpacePage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/SpacePage.java
@@ -16,11 +16,13 @@ import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.extensions.ajax.markup.html.AjaxLazyLoadPanel;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.image.ExternalImage;
 import org.apache.wicket.markup.html.panel.EmptyPanel;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.LoadableDetachableModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
+import org.eclipse.rdf4j.model.IRI;
 
 import java.util.List;
 import java.util.Optional;
@@ -106,6 +108,13 @@ public class SpacePage extends NanodashPage {
         }
 
         add(new Label("pagetitle", space.getLabel() + " (space) | nanodash"));
+        // Optional profile picture, left of the title/URI block (issue #632). Shown
+        // plainly, i.e. without the tilted-square mask that user icons get, and simply
+        // omitted when the space declares none.
+        IRI profilePicture = space.getProfilePicture();
+        add(profilePicture != null
+                ? new ExternalImage("profilepic", profilePicture.stringValue())
+                : new WebMarkupContainer("profilepic").setVisible(false));
         add(new Label("spacename", space.getLabel()));
         add(new Label("titlesuffix", ResourceTabs.titleSuffix(activeTab)));
         // Calendar submenus for (event-containing) event spaces, plus configuration

--- a/src/main/java/com/knowledgepixels/nanodash/page/SpacePage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/SpacePage.java
@@ -10,6 +10,7 @@ import com.knowledgepixels.nanodash.domain.MaintainedResource;
 import com.knowledgepixels.nanodash.domain.Space;
 import com.knowledgepixels.nanodash.repository.MaintainedResourceRepository;
 import com.knowledgepixels.nanodash.repository.SpaceRepository;
+import com.knowledgepixels.nanodash.domain.ProfilePicture;
 import org.apache.wicket.Component;
 import org.apache.wicket.RestartResponseException;
 import org.apache.wicket.ajax.AjaxRequestTarget;
@@ -111,9 +112,9 @@ public class SpacePage extends NanodashPage {
         // Optional profile picture, left of the title/URI block (issue #632). Shown
         // plainly, i.e. without the tilted-square mask that user icons get, and simply
         // omitted when the space declares none.
-        IRI profilePicture = space.getProfilePicture();
+        ProfilePicture profilePicture = space.getProfilePicture();
         add(profilePicture != null
-                ? new ExternalImage("profilepic", profilePicture.stringValue())
+                ? new ExternalImage("profilepic", profilePicture.getSrc())
                 : new WebMarkupContainer("profilepic").setVisible(false));
         add(new Label("spacename", space.getLabel()));
         add(new Label("titlesuffix", ResourceTabs.titleSuffix(activeTab)));

--- a/src/main/java/com/knowledgepixels/nanodash/page/UserPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/UserPage.java
@@ -7,6 +7,7 @@ import com.knowledgepixels.nanodash.ViewDisplay;
 import com.knowledgepixels.nanodash.component.*;
 import com.knowledgepixels.nanodash.domain.IndividualAgent;
 import com.knowledgepixels.nanodash.domain.User;
+import com.knowledgepixels.nanodash.domain.ProfilePicture;
 import org.apache.wicket.Component;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.extensions.ajax.markup.html.AjaxLazyLoadPanel;
@@ -82,9 +83,9 @@ public class UserPage extends NanodashPage {
         add(new TitleBar("titlebar", this)
                 .setTabs(new ResourceTabs("tabs", "user", userIriString, activeTab)));
 
-        IRI profilePictureIri = User.getProfilePicture(userIri);
-        if (profilePictureIri != null) {
-            ExternalImage userIcon = new ExternalImage("userIcon", profilePictureIri);
+        ProfilePicture profilePicture = User.getProfilePicture(userIri);
+        if (profilePicture != null) {
+            ExternalImage userIcon = new ExternalImage("userIcon", profilePicture.getSrc());
             add(userIcon);
         } else {
             boolean isSoftware = IndividualAgent.isSoftware(userIri);

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -677,6 +677,20 @@ img.thirdparty {
   -webkit-mask-size: contain;
 }
 
+/* Profile pictures of spaces and maintained resources (issue #632): unlike user
+   icons these are shown plainly, without the tilted-square mask, above the title and
+   main URI and flush with them on the left. object-fit: contain keeps wide logos
+   uncropped; with no picture the header is exactly as it was before. */
+.resource-profile-pic {
+  display: block;
+  height: 4.2em;
+  width: auto;
+  max-width: 12em;
+  object-fit: contain;
+  object-position: left;
+  margin: 0 0 0.4em 0;
+}
+
 .api-icon {
   display: inline-block;
   background-image: url("images/api-icon.svg");

--- a/src/test/java/com/knowledgepixels/nanodash/LiteralSerializationTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/LiteralSerializationTest.java
@@ -1,0 +1,73 @@
+package com.knowledgepixels.nanodash;
+
+import org.eclipse.rdf4j.model.Literal;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Serialization and parsing of the literal form used by the publish form's value fields
+ * (nt:ValuePlaceholder). The long-literal cases guard the stack overflow that a
+ * regex-based implementation caused for SVG-sized values (issue #634).
+ */
+class LiteralSerializationTest {
+
+    private static String longSvgLiteral() {
+        StringBuilder sb = new StringBuilder("\"<svg xmlns=\\\"http://www.w3.org/2000/svg\\\" viewBox=\\\"0 0 1029 478\\\">");
+        for (int i = 0; i < 400; i++) {
+            sb.append("<path d=\\\"M0.074,-0L0.074,-0.657L0.285,-0.657Z\\\" style=\\\"fill:rgb(63,63,63);\\\"/>");
+        }
+        return sb.append("</svg>\"").toString();
+    }
+
+    @Test
+    void plainLiteralRoundTrips() {
+        Literal l = Utils.getParsedLiteral("\"hello\"");
+        assertEquals("hello", l.stringValue());
+        assertTrue(Utils.isValidLiteralSerialization("\"hello\""));
+    }
+
+    @Test
+    void languageTaggedAndTypedLiteralsRoundTrip() {
+        assertEquals("de", Utils.getParsedLiteral("\"Haus\"@de").getLanguage().orElse(null));
+        Literal typed = Utils.getParsedLiteral("\"42\"^^<http://www.w3.org/2001/XMLSchema#integer>");
+        assertEquals("42", typed.stringValue());
+        assertEquals("http://www.w3.org/2001/XMLSchema#integer", typed.getDatatype().stringValue());
+    }
+
+    @Test
+    void escapedQuotesAndBackslashesRoundTrip() {
+        String value = "a \" b \\ c";
+        String serialized = "\"" + Utils.getEscapedLiteralString(value) + "\"";
+        // The escaping must survive validation — an unescaped inner quote would end the
+        // literal early and make the rest unparseable.
+        assertTrue(Utils.isValidLiteralSerialization(serialized), serialized);
+        assertEquals(value, Utils.getParsedLiteral(serialized).stringValue());
+    }
+
+    @Test
+    void longSvgLiteralIsValidatedWithoutOverflowing() {
+        String serialized = longSvgLiteral();
+        assertTrue(serialized.length() > 20_000);
+        assertTrue(Utils.isValidLiteralSerialization(serialized));
+        assertTrue(Utils.getParsedLiteral(serialized).stringValue().startsWith("<svg "));
+    }
+
+    @Test
+    void longSvgLiteralWithLanguageTagAndDatatypeIsValidated() {
+        String body = longSvgLiteral();
+        assertTrue(Utils.isValidLiteralSerialization(body + "@en"));
+        assertTrue(Utils.isValidLiteralSerialization(body + "^^<http://www.w3.org/2001/XMLSchema#string>"));
+    }
+
+    @Test
+    void malformedSerializationsAreRejected() {
+        assertFalse(Utils.isValidLiteralSerialization("no quotes"));
+        assertFalse(Utils.isValidLiteralSerialization("\"unterminated"));
+        assertFalse(Utils.isValidLiteralSerialization("\"inner \" quote\""));
+        assertFalse(Utils.isValidLiteralSerialization("\"text\" trailing"));
+        assertFalse(Utils.isValidLiteralSerialization("\"bad escape \\n\""));
+        assertThrows(IllegalArgumentException.class, () -> Utils.getParsedLiteral("no quotes"));
+    }
+
+}

--- a/src/test/java/com/knowledgepixels/nanodash/ProfilePictureTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/ProfilePictureTest.java
@@ -1,0 +1,71 @@
+package com.knowledgepixels.nanodash;
+
+import com.knowledgepixels.nanodash.domain.ProfilePicture;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ProfilePictureTest {
+
+    private static String decodeSvg(ProfilePicture picture) {
+        String prefix = "data:image/svg+xml;base64,";
+        assertTrue(picture.getSrc().startsWith(prefix), picture.getSrc());
+        return new String(Base64.getDecoder().decode(picture.getSrc().substring(prefix.length())),
+                StandardCharsets.UTF_8);
+    }
+
+    @Test
+    void linkIsUsedAsIs() {
+        ProfilePicture picture = ProfilePicture.of("https://example.com/logo.png");
+        assertNotNull(picture);
+        assertFalse(picture.isSvg());
+        assertEquals("https://example.com/logo.png", picture.getSrc());
+    }
+
+    @Test
+    void surroundingWhitespaceIsIgnored() {
+        assertEquals("https://example.com/logo.png",
+                ProfilePicture.of("  https://example.com/logo.png\n").getSrc());
+    }
+
+    @Test
+    void svgLiteralBecomesDataUri() {
+        ProfilePicture picture = ProfilePicture.of(
+                "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 10 10\"><rect width=\"10\" height=\"10\" fill=\"red\"/></svg>");
+        assertNotNull(picture);
+        assertTrue(picture.isSvg());
+        String svg = decodeSvg(picture);
+        assertTrue(svg.contains("<rect"), svg);
+        assertTrue(svg.contains("</rect>"), svg);  // self-closed tags are expanded
+        assertTrue(svg.contains("viewBox"), svg);
+    }
+
+    @Test
+    void missingNamespaceIsAdded() {
+        // Without it the browser refuses to render the data: URI as an image.
+        String svg = decodeSvg(ProfilePicture.of("<svg viewBox=\"0 0 10 10\"><circle cx=\"5\" cy=\"5\" r=\"4\"/></svg>"));
+        assertTrue(svg.contains("xmlns=\"http://www.w3.org/2000/svg\""), svg);
+    }
+
+    @Test
+    void scriptingIsStrippedFromSvg() {
+        String svg = decodeSvg(ProfilePicture.of(
+                "<svg xmlns=\"http://www.w3.org/2000/svg\"><script>alert(1)</script>"
+                        + "<rect width=\"10\" height=\"10\" onload=\"alert(2)\"/></svg>"));
+        assertFalse(svg.contains("script"), svg);
+        assertFalse(svg.contains("alert"), svg);
+        assertFalse(svg.contains("onload"), svg);
+    }
+
+    @Test
+    void unusableValuesYieldNull() {
+        assertNull(ProfilePicture.of(null));
+        assertNull(ProfilePicture.of("   "));
+        assertNull(ProfilePicture.of("just a label"));
+        assertNull(ProfilePicture.of("<p>not an image</p>"));
+    }
+
+}

--- a/src/test/java/com/knowledgepixels/nanodash/SvgStyleSanitizationTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/SvgStyleSanitizationTest.java
@@ -1,0 +1,76 @@
+package com.knowledgepixels.nanodash;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Sanitizing SVG whose paint sits in style attributes, as drawing tools export it. The
+ * sanitizer allows no style attribute, so the safe declarations are rewritten into the
+ * equivalent presentation attributes first — without them every shape falls back to the
+ * SVG default fill and the figure renders all black.
+ */
+class SvgStyleSanitizationTest {
+
+    @Test
+    void styleFillBecomesPresentationAttribute() {
+        String out = Utils.sanitizeSvg("<svg viewBox=\"0 0 10 10\"><rect width=\"10\" height=\"10\" style=\"fill:rgb(120,184,134);\"/></svg>");
+        assertTrue(out.contains("fill=\"rgb(120,184,134)\""), out);
+        assertFalse(out.contains("style"), out);
+    }
+
+    @Test
+    void severalDeclarationsAreConverted() {
+        String out = Utils.sanitizeSvg("<svg style=\"fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;\"><path d=\"M0,0\" style=\"fill:#3f3f3f;fill-opacity:0.5\"/></svg>");
+        assertTrue(out.contains("fill-rule=\"evenodd\""), out);
+        assertTrue(out.contains("clip-rule=\"evenodd\""), out);
+        assertTrue(out.contains("stroke-linejoin=\"round\""), out);
+        assertTrue(out.contains("stroke-miterlimit=\"2\""), out);
+        assertTrue(out.contains("fill=\"#3f3f3f\""), out);
+        assertTrue(out.contains("fill-opacity=\"0.5\""), out);
+    }
+
+    @Test
+    void singleQuotedStyleIsConverted() {
+        String out = Utils.sanitizeSvg("<svg viewBox='0 0 10 10'><circle cx='5' cy='5' r='4' style='fill:red'/></svg>");
+        assertTrue(out.contains("fill=\"red\""), out);
+    }
+
+    @Test
+    void referencesAndFunctionsAreDropped() {
+        String out = Utils.sanitizeSvg("<svg><rect width=\"10\" height=\"10\" style=\"fill:url(#evil);stroke:expression(alert(1));opacity:0.5\"/></svg>");
+        assertFalse(out.contains("url("), out);
+        assertFalse(out.contains("expression"), out);
+        // The safe declaration in the same attribute still survives.
+        assertTrue(out.contains("opacity=\"0.5\""), out);
+    }
+
+    @Test
+    void unlistedPropertiesAreDropped() {
+        String out = Utils.sanitizeSvg("<svg><rect width=\"10\" height=\"10\" style=\"position:absolute;behavior:url(x.htc);fill:blue\"/></svg>");
+        assertFalse(out.contains("position"), out);
+        assertFalse(out.contains("behavior"), out);
+        assertTrue(out.contains("fill=\"blue\""), out);
+    }
+
+    @Test
+    void presentationAttributesStillWork() {
+        String out = Utils.sanitizeSvg("<svg><circle cx=\"5\" cy=\"5\" r=\"4\" fill=\"#ffd400\"/></svg>");
+        assertTrue(out.contains("fill=\"#ffd400\""), out);
+    }
+
+    @Test
+    void styleInHtmlDoesNotSurviveAsStyling() {
+        String out = Utils.sanitizeHtml("<p style=\"fill:red;position:absolute\">text</p>");
+        assertFalse(out.contains("style"), out);
+        assertFalse(out.contains("position"), out);
+        assertTrue(out.contains("text"), out);
+    }
+
+    @Test
+    void inlineSvgInHtmlKeepsItsPaint() {
+        String out = Utils.sanitizeHtml("<p>see <svg viewBox=\"0 0 10 10\"><rect width=\"10\" height=\"10\" style=\"fill:green\"/></svg></p>");
+        assertTrue(out.contains("fill=\"green\""), out);
+    }
+
+}

--- a/src/test/java/com/knowledgepixels/nanodash/UtilsTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/UtilsTest.java
@@ -752,7 +752,10 @@ class UtilsTest {
     void getEscapedLiteralStringEscapesQuotesCorrectly() {
         String input = "This is a \"quote\"";
         String result = Utils.getEscapedLiteralString(Utils.getUnescapedLiteralString(input));
-        assertEquals("This is a \"quote\"", result);
+        // Quotes must come back escaped, like the backslashes below: an unescaped inner
+        // quote ends the serialized literal early, so a value containing one (e.g. SVG
+        // markup, issue #634) could not be round-tripped through a value field.
+        assertEquals("This is a \\\"quote\\\"", result);
     }
 
     @Test


### PR DESCRIPTION
Closes #632, closes #634.

## Profile pictures for spaces and maintained resources (#632)

A space or maintained resource that declares `schema:image` on its own IRI shows that picture above its title and main URI, plainly — no tilted-square mask like user icons get. With no picture declared, the header renders exactly as before.

Only declarations **signed by a current admin of the governing space** count. The new query [`RALK8_WQ…/get-resource-profile-picture`](https://w3id.org/np/RALK8_WQPtAbMUv2IvHeZyUU1WjD77V4a3hb0KsiZI0tI) follows the shape of `get-view-displays-unresolved`: it runs on `repo/full` and makes one federated hop to `repo/spaces` for the authority gate (`npa:hasGoverningSpaceRef` → admin `RoleInstantiation` → `npa:AccountState`), reflexive for a space itself and pointing at the maintainer space for a maintained resource. Candidates are found subject-first, so that hop only ever sees a handful of rows. The maintainer tier is deliberately *not* accepted, and the gate is not pinned to a single ref — for an identifier with rival claimants, an admin of any claiming ref can declare a picture.

The picture is fetched inside the resource's existing asynchronous data update, next to the view displays, so rendering never waits on it and a post-publish forced refresh picks up a new picture with the rest of the structure.

Per the issue, there is no About-page option to set one yet: a picture is declared by publishing the triple.

## SVG markup as a profile picture (#634)

A `schema:image` value may be a literal holding the SVG itself rather than a link — for users as well as for spaces and maintained resources.

`ProfilePicture` is the one place that interprets the value: SVG markup goes through `Utils.sanitizeSvg`, gets an `xmlns` injected when the author left it out (an `<img>` parses SVG as XML and fails without one), and travels on as a `data:` URI. Every picture site stays a plain `<img>`, so the mask on user icons, `object-fit` on resource pictures and list-row sizing keep working for either kind of value — and inside an `<img>` an SVG document can neither script nor fetch, so a picture cannot reach into the page showing it.

Setting one through the UI needs a template whose field accepts a literal. The live one is URL-only and cannot be superseded from another account (latest-version resolution joins on the same pubkey), so this is published instead:

- template [`RAz5tNdG…/template`](https://w3id.org/np/RAz5tNdG4uiRWPcSLkHIPM5SFboQES51mrTEq3w2hAqfs) — one statement with an `nt:ValuePlaceholder` ("image URL, or SVG markup in quotes"), space-governed by `https://w3id.org/spaces/knowledgepixels/nanodash` so its members can edit it collaboratively
- kind registration [`RA6owO2C…`](https://w3id.org/np/RA6owO2Cao1Wld1fBjYMYiMK0VZ3uYe6sR3Noc9BiMcpI) — `<kind> a gen:MaintainedResource ; gen:isMaintainedBy <…/nanodash>`
- profile view [`RATPxXJT…`](https://w3id.org/np/RATPxXJTidw9yClX9YmrzEkF69MhcXhvcnzTYQ6uesYNc) — the "update profile image..." action points at the template's embedded IRI

No code change is needed for governed float: the action URL carries `template-version=latest`, and `TemplateData.getLatestTemplateId` routes governed pins through `get-latest-governed-version`.

## Two bugs found on the way

**Long literals overflowed the stack.** `isValidLiteralSerialization` / `getParsedLiteral` used patterns shaped `^"(([^\\"]|\\\\|\\")*)"…` — an alternation inside a greedy star, which Java's regex engine evaluates with one stack frame per character. A ~15 KB SVG pasted into a value field threw `StackOverflowError` in the publish form's validator, i.e. a 500. The quoted part is now scanned linearly.

**`getEscapedLiteralString` never escaped quotes.** `replaceAll("\"", "\\\\\"")` passes `\"` as a *replacement* string, where the backslash is an escape, so it emitted a bare quote and any value containing one round-tripped into an unparseable serialization. Now uses `String.replace`. `UtilsTest.getEscapedLiteralStringEscapesQuotesCorrectly` had codified that bug (it asserted the input came back unchanged, while its backslash sibling asserted real escaping), so its expectation is corrected here.

**SVG exported by drawing tools rendered all black.** Serif/Affinity-style exports put every paint in `style="fill:rgb(…)"`, and the sanitizer allows no `style` attribute — so the declarations were dropped and every shape fell back to the SVG default fill. Safe declarations are now rewritten into the equivalent presentation attributes before sanitizing, so the existing allow-list validates them like any other attribute: the property must be one of the paint/text ones, and the value may contain no function call other than `rgb/rgba/hsl/hsla(…)`, so `url(…)` and `expression(…)` cannot survive. This also fixes inline SVG in cells, lists and paragraphs, not just profile pictures.

## Verification

Driven against a local instance on a separate port (dev server untouched, nothing published from it):

- space and maintained-resource pages with no picture (header unchanged), with a linked image, and with a wide logo
- an admin-signed declaration on `test/group` renders; the authority join was validated against live data with a stand-in predicate before publishing, a bogus-role variant returns 0 rows, and the two non-space subjects in the network that do carry `schema:image` are correctly rejected
- an SVG literal renders in the user-page header and the session icon, mask intact
- the new template loads through its embedded IRI, a quoted SVG reaches the signed preview as a literal, a URL as an IRI, and a 28 KB literal no longer 500s

23 new unit tests (`ProfilePictureTest`, `LiteralSerializationTest`, `SvgStyleSanitizationTest`); full suite green at 1176.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
