### PR TITLE
feat: surface introduced-but-unapproved users as pending (#625)

### DIFF
--- a/docs/queries/get-view-displays-pending-arm.trig
+++ b/docs/queries/get-view-displays-pending-arm.trig
@@ -1,0 +1,198 @@
+@prefix this: <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
+@prefix sub: <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
+@prefix np: <http://www.nanopub.org/nschema#> .
+@prefix grlc: <https://w3id.org/kpxl/grlc/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix nt: <https://w3id.org/np/o/ntemplate/> .
+@prefix npx: <http://purl.org/nanopub/x/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix orcid: <https://orcid.org/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+sub:Head {
+  this: a np:Nanopublication;
+    np:hasAssertion sub:assertion;
+    np:hasProvenance sub:provenance;
+    np:hasPublicationInfo sub:pubinfo .
+}
+
+sub:assertion {
+  sub:get-view-displays a grlc:grlc-query;
+    dct:description "Returns the views to display for a given resource: both standalone view displays and the views contributed by assigned presets (issue #302), unioned and ordered by date so latest-wins override resolution holds across both. Filtered server-side to declarations signed by an admin or maintainer of the owning space, or by the affected user themselves (for an agent's own page). Each referenced view is resolved to its latest version by following the npx:supersedes chain: among the version tree's current heads (nanopubs that are themselves neither superseded nor validly retracted via npx:invalidates), the most recent is chosen, so ?view is the latest non-retracted view definition (no separate latest-version lookup needed by the client). Choosing a current head rather than the max-timestamp node makes resolution robust to backdated supersedes and to retracted versions. Preset-derived rows have an unbound ?display and carry the resolved ?view plus the assignment's activation mode. The view-version resolution is wrapped in a run-once sub-SELECT so it is evaluated once for the whole view set rather than once per referenced view. Space-governed versions (gen:governedBy, nanodash docs/views-and-presets-as-maintained-resources.md): a referenced version declaring gen:governedBy resolves to the newest version of its (kind, space) pair signed by a current member+ (admin/maintainer/member) of that space -- with the kind validated as a maintained resource of the space -- taking precedence over the supersedes-based head; without a valid governed candidate the pinned version stands. Federation footprint (2026-08-20): the query now runs on the repo/full endpoint, so the former SERVICE hops to repo/full (preset branch) and to the ResourceView type repo (view lookups, governed candidates) are plain local patterns; only the two lookups of materialized space state (authority gate, governed-signer validation) remain federated, to repo/spaces. The previous 5-SERVICE layout was the main amplifier of a connection-pool deadlock in the query service's loopback federation (an outer query holds a pooled connection while each SERVICE hop -- one per binding under a nested-loop join -- requests another from the same pool): a thread dump during a production wedge showed all 60 route connections held by result streamers of exactly these hops. Validated byte-for-byte identical to the previous version across resources covering standalone displays, preset assignments, governed views, an agent's own page, and rival space refs. Pending accounts (nanopub-query#195, nanodash#625): the self-signed arm additionally accepts npa:PendingAccountState rows -- mirrored by the query service from authoritative introductions of users who are not trust-approved yet -- so such a user's own page shows the view displays they signed themselves. The pending class is distinct from npa:AccountState, so no authority-granting join is widened: the admin/maintainer arm and the governed-version resolution keep requiring approved accounts.";
+    dct:license <http://www.apache.org/licenses/LICENSE-2.0>;
+    rdfs:label "Get view displays";
+    grlc:endpoint <https://w3id.org/np/l/nanopub-query-1.1/repo/full>;
+    grlc:sparql """prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix dct:  <http://purl.org/dc/terms/>
+prefix np:   <http://www.nanopub.org/nschema#>
+prefix npa:  <http://purl.org/nanopub/admin/>
+prefix npx:  <http://purl.org/nanopub/x/>
+prefix gen:  <https://w3id.org/kpxl/gen/terms/>
+
+select distinct ?display ?view (coalesce(?viewKindOptional, ?view) as ?viewKind)
+                ?label ?displayType ?displayMode ?np ?pubkey ?date where {
+  values ?_resource_multi_iri {}
+  service <https://w3id.org/np/l/nanopub-query-1.1/repo/spaces> {
+    graph npa:graph { npa:thisRepo npa:hasCurrentSpaceState ?stateG . }
+    {
+      # Authority gate (issue #130 / nanodash#510): a single mandatory hop through the
+      # governing space ref, which covers both a maintained resource and a space itself
+      # (the reflexive self-edge), keyed on the role tier materialized on the
+      # RoleInstantiation since #125. Replaces the old bare-IRI isMaintainedBy? hop and the
+      # dead RoleDeclaration maintainer join. Non-ref variant: any ref claiming the IRI, so
+      # authority merges across refs (the ref variant pins a single ?passedRef instead).
+      graph ?stateG {
+        ?_resource_multi_iri npa:hasGoverningSpaceRef ?spaceRef .
+        ?ri a gen:RoleInstantiation ; npa:forSpaceRef ?spaceRef ; npa:hasRoleType ?roleType ; npa:forAgent ?authAgent .
+        filter(?roleType = gen:AdminRole || ?roleType = gen:MaintainerRole)
+        ?authAcct a npa:AccountState ; npa:agent ?authAgent ; npa:pubkey ?pubkey .
+      }
+    } union {
+      graph ?stateG { ?selfAcct a npa:AccountState ; npa:agent ?_resource_multi_iri ; npa:pubkey ?pubkey . }
+    } union {
+      # Own page of an agent who is introduced but not trust-approved yet
+      # (nanopub-query#195, nanodash#625): npa:PendingAccountState rows are mirrored
+      # from authoritative introductions and carry a distinct class so that no
+      # authority join can resolve through them; this arm is display-only and scoped
+      # to the page's own agent, exactly like the AccountState self-arm above.
+      graph ?stateG { ?pendAcct a npa:PendingAccountState ; npa:agent ?_resource_multi_iri ; npa:pubkey ?pubkey . }
+    }
+  }
+  {
+    # branch (a): standalone view displays — LOCAL pattern on the endpoint repo
+    graph npa:graph {
+      ?np npx:hasNanopubType gen:ViewDisplay .
+      ?np npa:hasValidSignatureForPublicKeyHash ?pubkey .
+      filter not exists { ?npx npx:invalidates ?np ; npa:hasValidSignatureForPublicKeyHash ?pubkey . }
+      ?np dct:created ?date .
+      ?np npx:embeds ?display .
+      ?np np:hasAssertion ?a .
+      optional { ?np rdfs:label ?label }
+    }
+    graph ?a {
+      ?display gen:isDisplayOfView ?refView .
+      ?display gen:isDisplayFor   ?_resource_multi_iri .
+      optional { values ?displayType { gen:PartLevelViewDisplay gen:TopLevelViewDisplay } ?display a ?displayType . }
+      optional { values ?displayMode { gen:ActivatedViewDisplay gen:DeactivatedViewDisplay } ?display a ?displayMode . }
+    }
+  }
+  union
+  {
+    # branch (b): preset-supplied views — LOCAL since the endpoint moved to
+    # repo/full (the connection-pinning SERVICE hop this replaced was the main
+    # amplifier of the federation deadlock, eclipse-rdf4j/rdf4j federation +
+    # nanopub-query loopback route). Kept wrapped in a sub-SELECT so its
+    # bindings cannot collapse branch (a). ?display stays unbound.
+    select ?refView ?label ?displayType ?displayMode ?np ?pubkey ?date ?_resource_multi_iri {
+      {  # was: service repo/full — now local on the repo/full endpoint
+        graph npa:graph {
+          ?np npx:hasNanopubType gen:PresetAssignment .
+          ?np npa:hasValidSignatureForPublicKeyHash ?pubkey .
+          filter not exists { ?npx npx:invalidates ?np ; npa:hasValidSignatureForPublicKeyHash ?pubkey . }
+          ?np dct:created ?date .
+          ?np npx:embeds ?assignment .
+          ?np np:hasAssertion ?a .
+          optional { ?np rdfs:label ?label }
+        }
+        graph ?a {
+          ?assignment gen:isAssignmentFor      ?_resource_multi_iri .
+          ?assignment gen:isAssignmentOfPreset ?presetRef .
+          optional { values ?displayMode { gen:ActivatedPresetAssignment gen:DeactivatedPresetAssignment } ?assignment a ?displayMode . }
+        }
+        graph npa:graph { ?presetNp npx:embeds ?presetRef ; np:hasAssertion ?pa . }
+        graph ?pa {
+          ?presetRef a gen:Preset .
+          { ?presetRef gen:hasTopLevelView ?refView . bind(gen:TopLevelViewDisplay as ?displayType) }
+          union { ?presetRef gen:hasView ?refView . bind(gen:PartLevelViewDisplay as ?displayType) }
+        }
+      }
+    }
+  }
+  # Resolve each referenced view to its latest version: the current head of its
+  # supersedes version tree (a nanopub itself neither superseded nor validly
+  # retracted via npx:invalidates), most recent among heads on a fork. Now a
+  # LOCAL lookup (endpoint = repo/full; the ?ra type gate keeps it scoped to
+  # ResourceView nanopubs exactly as the former type-shard service did). Still
+  # wrapped in a run-once sub-SELECT so it is evaluated once for the whole view
+  # set rather than once per referenced view.
+  optional {
+    {  # was: service repo/type/ec6722… (ResourceView shard) — now local on the repo/full endpoint
+      select distinct ?refView ?latestView ?viewKindOptional ?pinKind ?pinSpace where {
+        graph npa:graph { ?rnp npx:embeds ?refView ; np:hasAssertion ?ra . }
+        graph ?ra { ?refView a gen:ResourceView . }
+        optional { graph ?ra { ?refView dct:isVersionOf ?pinKind ; gen:governedBy ?pinSpace . } }
+        optional {
+          ?vnp npx:embeds ?refView .
+          ?latestNp (npx:supersedes|^npx:supersedes)* ?vnp ; dct:created ?ldate ; npx:embeds ?latestView ; np:hasAssertion ?va ; npa:hasValidSignatureForPublicKeyHash ?invPk .
+          filter not exists { ?supNp npx:supersedes ?latestNp . }
+          filter not exists { ?invNp npx:invalidates ?latestNp ; npa:hasValidSignatureForPublicKeyHash ?invPk . }
+          filter not exists {
+            ?other (npx:supersedes|^npx:supersedes)* ?vnp ; dct:created ?odate ; npa:hasValidSignatureForPublicKeyHash ?invPk2 .
+            filter not exists { ?supNp2 npx:supersedes ?other . }
+            filter not exists { ?invNp2 npx:invalidates ?other ; npa:hasValidSignatureForPublicKeyHash ?invPk2 . }
+            filter(?odate > ?ldate)
+          }
+          graph ?va { ?latestView a gen:ResourceView . optional { ?latestView dct:isVersionOf ?viewKindOptional . } }
+        }
+      }
+    }
+  }
+    # Space-governed resolution (gen:governedBy; nanodash docs/views-and-presets-as-
+  # maintained-resources.md): a pinned version declaring a governing space resolves to
+  # the newest member+-signed version of its (kind, space) pair instead of the
+  # supersedes head; no valid candidate -> the pin stands.
+  optional {
+        { select ?pinKind ?pinSpace (iri(strafter(max(concat(str(?cDate), \">\", str(?cver))), \">\")) as ?governedLatest) where {
+            # Candidate versions — was a service on the ResourceView type shard, now
+            # local on the repo/full endpoint. The sub-select wrapper is LOAD-BEARING,
+            # not stylistic: on rdf4j 6.0.0, bindings produced by raw statement
+            # patterns are silently NOT joined into a subsequent SERVICE clause
+            # (empirically: identical bindings via VALUES join fine, via bare
+            # patterns yield zero rows, and any projecting sub-select restores the
+            # join — reproduced on two instances, 2026-08-20). Without this wrapper
+            # the spaces SERVICE below returns nothing and governed resolution
+            # silently falls back to the pin.
+            { select ?pinKind ?pinSpace ?cver ?cpk ?cDate where {
+              graph npa:graph {
+                ?cnp dct:created ?cDate ; npa:hasValidSignatureForPublicKeyHash ?cpk ; npx:embeds ?cver ; np:hasAssertion ?ca .
+                filter not exists { ?ci npx:invalidates ?cnp ; npa:hasValidSignatureForPublicKeyHash ?cpk . }
+              }
+              graph ?ca { ?cver dct:isVersionOf ?pinKind ; gen:governedBy ?pinSpace . }
+            } }
+            service <https://w3id.org/np/l/nanopub-query-1.1/repo/spaces> {
+              graph npa:graph { <http://purl.org/nanopub/admin/thisRepo> npa:hasCurrentSpaceState ?gsg . }
+              graph ?gsg {
+                ?pinKind npa:isMaintainedBy ?pinSpace ; npa:hasGoverningSpaceRef ?gref .
+                ?gri a gen:RoleInstantiation ; npa:forSpace ?pinSpace ; npa:forSpaceRef ?gref ; npa:hasRoleType ?gtier ; npa:forAgent ?gag .
+                filter(?gtier = gen:AdminRole || ?gtier = gen:MaintainerRole || ?gtier = gen:MemberRole)
+                ?gacct a npa:AccountState ; npa:agent ?gag ; npa:pubkey ?cpk .
+              }
+            }
+          } group by ?pinKind ?pinSpace }
+  }
+  bind(if(bound(?pinSpace), coalesce(?governedLatest, ?refView), coalesce(?latestView, ?refView)) as ?view)
+}
+order by desc(?date)""" .
+}
+
+sub:provenance {
+  sub:assertion prov:wasAttributedTo orcid:0000-0002-1267-0234 .
+}
+
+sub:pubinfo {
+  orcid:0000-0002-1267-0234 foaf:name "Tobias Kuhn" .
+  
+  this: dct:created "2026-08-24T18:34:02Z"^^xsd:dateTime;
+    dct:creator orcid:0000-0002-1267-0234;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    npx:embeds sub:get-view-displays;
+    npx:supersedes <https://w3id.org/np/RAWlJqJ5afOTN0AIDP3rnSCysQer9B4pmSC6QbzssTAyc>;
+    rdfs:label "Get view displays";
+    nt:wasCreatedFromProvenanceTemplate <https://w3id.org/np/RA7lSq6MuK_TIC6JMSHvLtee3lpLoZDOqLJCLXevnrPoU>;
+    nt:wasCreatedFromPubinfoTemplate <https://w3id.org/np/RA0J4vUn_dekg-U1kK3AOEt02p9mT2WO03uGxLDec1jLw>,
+      <https://w3id.org/np/RAoTD7udB2KtUuOuAe74tJi1t3VzK0DyWS7rYVAq1GRvw>, <https://w3id.org/np/RAukAcWHRDlkqxk7H2XNSegc1WnHI569INvNr-xdptDGI>;
+    nt:wasCreatedFromTemplate <https://w3id.org/np/RAEFAt-QcFK0ZhqfvlsmS10BnzGJA0xwOICZXkO-ai87k> .
+}
+

--- a/docs/queries/list-space-observers-ref-v7.trig
+++ b/docs/queries/list-space-observers-ref-v7.trig
@@ -1,0 +1,91 @@
+@prefix this: <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
+@prefix sub: <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
+@prefix np: <http://www.nanopub.org/nschema#> .
+@prefix grlc: <https://w3id.org/kpxl/grlc/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix npx: <http://purl.org/nanopub/x/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix orcid: <https://orcid.org/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+sub:Head {
+  this: a np:Nanopublication;
+    np:hasAssertion sub:assertion;
+    np:hasProvenance sub:provenance;
+    np:hasPublicationInfo sub:pubinfo .
+}
+
+sub:assertion {
+  sub:list-space-observers a grlc:grlc-query;
+    dct:description "Lists every observer-tier role association of a space ref (validated plus un-introduced self-declared, flagged via the headerless column). Excludes a member's observer association only when they hold a VALIDATED higher tier THROUGH THE SAME ROLE PROPERTY (npa:hasRoleType on a gen:RoleInstantiation in the current space state). BUGFIX over RAoW4pMA/RAZNHDFQ (nanodash#498): that version excluded the member whenever they held ANY validated higher-tier role, which hid an admin/maintainer/member from the observer list even for a separate, genuinely observer-tier role they hold (e.g. an admin who is also a planned attendant showed nowhere as an observer). Scoping the higher-tier check to the same role property restores the intended behaviour (every observer-tier association is listed) while keeping the #498 tier-collision fix: a property declared as observer globally but validated at a higher tier for this member in this ref is still excluded. Pending accounts (nanopub-query#195, nanodash#625): an association validated only through a pending account (the materialized gen:RoleInstantiation carries npa:trustStatus npa:seen) shows an hourglass in the same headerless flag column, so self-signed-up members awaiting approval are listed but visibly distinct. Flag semantics: empty = validated via an approved account; hourglass = validated via a pending (introduced but not yet approved) account; warning sign = not validated at all.";
+    dct:license <http://www.apache.org/licenses/LICENSE-2.0>;
+    rdfs:label "List space observers (ref-scoped, all observer-tier associations, with validation flag)";
+    grlc:endpoint <https://w3id.org/np/l/nanopub-query-1.1/repo/spaces>;
+    grlc:sparql """prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix dct: <http://purl.org/dc/terms/>
+prefix np: <http://www.nanopub.org/nschema#>
+prefix npa: <http://purl.org/nanopub/admin/>
+prefix npx: <http://purl.org/nanopub/x/>
+prefix gen: <https://w3id.org/kpxl/gen/terms/>
+prefix schema: <http://schema.org/>
+
+select ?member
+       (group_concat(distinct ?latestNp; separator=\" \") as ?role_assignments_multi_iri)
+       (group_concat(distinct ?roleLabel; separator=\"\\n\") as ?role_assignments_label_multi)
+       (if(max(?val) = 0, \"⚠️\", if(max(?pend) = 1, \"⏳\", \"\")) as ?unverified_noheader)
+where {
+  {
+    select ?member ?roleProp
+           (max(?val0) as ?val)
+           (max(?pend0) as ?pend)
+           (strafter(max(concat(coalesce(str(?dateNp),\"\"), \" \", str(?grantNp))), \" \") as ?latestNp)
+           (sample(?rl) as ?rlRaw)
+    where {
+      values ?_root_np_multi_iri {}
+      graph npa:spacesGraph { ?ref npa:rootNanopub ?_root_np_multi_iri ; npa:spaceIri ?spaceIri . }
+      graph npa:graph { npa:thisRepo npa:hasCurrentSpaceState ?g . }
+      graph npa:spacesGraph {
+        ?ri a gen:RoleInstantiation ; npa:forSpace ?inSpace ; npa:forAgent ?member ; npa:viaNanopub ?grantNp ;
+            (npa:regularProperty|npa:inverseProperty) ?roleProp .
+      }
+      filter( ?inSpace = ?spaceIri || exists { graph ?g { ?inSpace npa:sameAsSpace ?ref } } )
+      filter exists { graph npa:spacesGraph { ?rdf a npa:RoleDeclaration ; npa:hasRoleType gen:ObserverRole ; (gen:hasRegularProperty|gen:hasInverseProperty) ?roleProp } }
+      filter(?roleProp != gen:hasAdmin)
+      filter not exists { graph ?g { ?vriH a gen:RoleInstantiation ; npa:forSpaceRef ?ref ; npa:forAgent ?member ;
+          (npa:regularProperty|npa:inverseProperty) ?roleProp .
+        { ?vriH npa:hasRoleType gen:AdminRole } union { ?vriH npa:hasRoleType gen:MaintainerRole } union { ?vriH npa:hasRoleType gen:MemberRole } } }
+      filter not exists { graph npa:graph { ?invNp npx:invalidates ?grantNp ; npa:hasValidSignatureForPublicKeyHash ?invpk . ?grantNp npa:hasValidSignatureForPublicKeyHash ?invpk . } }
+      bind(if(exists { graph ?g { ?vri npa:forSpaceRef ?ref ; npa:forAgent ?member ; npa:viaNanopub ?grantNp } }, 1, 0) as ?val0)
+      bind(if(exists { graph ?g { ?vriP a gen:RoleInstantiation ; npa:forSpaceRef ?ref ; npa:forAgent ?member ; npa:viaNanopub ?grantNp ; npa:trustStatus npa:seen } }, 1, 0) as ?pend0)
+      optional { graph npa:graph { ?grantNp dct:created ?dateNp } }
+      optional {
+        graph ?g { ?raRole a gen:RoleAssignment ; npa:forSpaceRef ?ref ; gen:hasRole ?role . }
+        graph npa:spacesGraph { ?rd2 a npa:RoleDeclaration ; npa:role ?role ; (gen:hasRegularProperty|gen:hasInverseProperty) ?roleProp ; npa:viaNanopub ?roleNp . }
+        graph npa:graph { ?roleNp np:hasAssertion ?role_a . }
+        optional { graph ?role_a { ?role schema:name ?rl } }
+      }
+    }
+    group by ?member ?roleProp
+  }
+  bind(coalesce(?rlRaw, \"role\") as ?roleLabel)
+}
+group by ?member
+order by ?unverified_noheader ?member""" .
+}
+
+sub:provenance {
+  sub:assertion prov:wasAttributedTo orcid:0000-0002-1267-0234 .
+}
+
+sub:pubinfo {
+  orcid:0000-0002-1267-0234 foaf:name "Tobias Kuhn" .
+  
+  this: dct:created "2026-08-24T18:34:02Z"^^xsd:dateTime;
+    dct:creator orcid:0000-0002-1267-0234;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    npx:embeds sub:list-space-observers;
+    npx:supersedes <https://w3id.org/np/RAQylZL4shGjfhxcBiqoanuY2-cUJcVeWvpZDkfjP9_ko> .
+}
+

--- a/src/main/java/com/knowledgepixels/nanodash/QueryApiAccess.java
+++ b/src/main/java/com/knowledgepixels/nanodash/QueryApiAccess.java
@@ -109,7 +109,14 @@ public class QueryApiAccess {
     // amplifier of the rdf4j connection-pool deadlock behind the fleet-wide /api wedges
     // (nanopub-query, 2026-08-20 thread dump: 22 of 28 pool-blocked threads were this
     // query). Validated byte-identical across standalone/preset/governed/self-page cases.
-    public static final String GET_VIEW_DISPLAYS = "RAWlJqJ5afOTN0AIDP3rnSCysQer9B4pmSC6QbzssTAyc/get-view-displays";
+    // RA3ekD-2 (supersedes RAWlJqJ5) adds the pending-account self-arm (issue #625 /
+    // nanopub-query#195): the own-page branch of the authority gate additionally accepts
+    // npa:PendingAccountState rows (mirrored from authoritative introductions of users not
+    // trust-approved yet), so such a user's own page shows the view displays they signed
+    // themselves. Display-only: the pending class is distinct from npa:AccountState, so the
+    // admin/maintainer arm and the governed-version resolution keep requiring approved
+    // accounts. Validated byte-identical to RAWlJqJ5 across approved resources.
+    public static final String GET_VIEW_DISPLAYS = "RA3ekD-2utY7P0ZgAHSr4HRwugzNnYhxJbkeI-3EfYfww/get-view-displays";
     // Ref-scoped get-view-displays (the Content-tab renderer query): takes the space IRI (resource)
     // AND the ref's root nanopub (root_np) as two concrete params, gating the authorised signers on
     // that ref's admins/maintainers (npa:forSpaceRef) instead of the IRI merged across refs, so the
@@ -228,8 +235,13 @@ public class QueryApiAccess {
     // scoped to the SAME role property ((npa:regularProperty|npa:inverseProperty) ?roleProp on
     // ?vriH), so a higher tier held through a different property no longer suppresses the observer
     // association, while the #498 tier-collision fix (same property validated at a higher tier)
-    // is preserved.
-    public static final String LIST_SPACE_OBSERVERS_REF = "RAQylZL4shGjfhxcBiqoanuY2-cUJcVeWvpZDkfjP9_ko/list-space-observers";
+    // is preserved. RARcL1s1 (supersedes RAQylZL4) distinguishes pending accounts (issue #625 /
+    // nanopub-query#195): an association validated only through a pending account — the
+    // materialized RoleInstantiation carries npa:trustStatus npa:seen, produced by the
+    // PendingAccountState self-arm for observer-tier self-signups of introduced-but-unapproved
+    // users — shows ⏳ in the headerless flag column (empty = approved-validated, ⏳ =
+    // pending-validated, ⚠️ = not validated at all).
+    public static final String LIST_SPACE_OBSERVERS_REF = "RARcL1s1A1FitiH8LSm7qtOH0JIAmKepMA9F_pTG3sVmo/list-space-observers";
 
     // Ref-scoped non-approved role claims (root_np): agents holding a higher-tier role
     // instantiation (admin/maintainer/member) that is NOT in the validated state — a

--- a/src/main/java/com/knowledgepixels/nanodash/component/JustPublishedMessagePanel.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/JustPublishedMessagePanel.html
@@ -7,5 +7,9 @@
   <span class="titlebar-message-box titlebar-message-box-warning" wicket:id="introBox">
     &#9888; You haven't published an introduction yet — create one on <a wicket:id="profile-link">your About page</a>.
   </span>
+  <span class="titlebar-message-box titlebar-message-box-pending" wicket:id="pendingBox">
+    &#8987; Your account is pending: your contributions are marked as pending (&#8987;) until an approved
+    user approves your introduction — share it from <a wicket:id="about-link">your About page</a>.
+  </span>
 </span>
 </wicket:panel>

--- a/src/main/java/com/knowledgepixels/nanodash/component/JustPublishedMessagePanel.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/JustPublishedMessagePanel.html
@@ -8,8 +8,7 @@
     &#9888; You haven't published an introduction yet — create one on <a wicket:id="profile-link">your About page</a>.
   </span>
   <span class="titlebar-message-box titlebar-message-box-pending" wicket:id="pendingBox">
-    &#8987; Your account is pending: your contributions are marked as pending (&#8987;) until an approved
-    user approves your introduction — share it from <a wicket:id="about-link">your About page</a>.
+    &#8987; Your account is pending — share your introduction from <a wicket:id="about-link">your About page</a> so an approved user can approve it.
   </span>
 </span>
 </wicket:panel>

--- a/src/main/java/com/knowledgepixels/nanodash/component/JustPublishedMessagePanel.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/JustPublishedMessagePanel.java
@@ -21,15 +21,19 @@ import com.knowledgepixels.nanodash.page.ProfilePage;
 import com.knowledgepixels.nanodash.page.UserPage;
 
 /**
- * Title-bar message panel rendering up to two stacked boxes:
+ * Title-bar message panel rendering up to three stacked boxes:
  * <ul>
  *   <li>a blue "successfully published" confirmation box, shown only right after
  *       publishing (i.e. when the page carries a "just-published" parameter) and
- *       dismissable via a close button; and</li>
+ *       dismissable via a close button;</li>
  *   <li>a red "you haven't published an introduction yet" warning box, shown on
  *       <em>every</em> page (no close button) whenever a logged-in user with a
  *       local key has not yet published an introduction linking that key to their
- *       ORCID. It disappears only once such an introduction is published.</li>
+ *       ORCID. It disappears only once such an introduction is published; and</li>
+ *   <li>an amber "your account is pending approval" notice box, shown on
+ *       <em>every</em> page whenever the user has an introduction but no approved
+ *       key yet (issue #625): their self-signed contributions are marked as
+ *       pending (⏳) until an approved user approves their introduction.</li>
  * </ul>
  */
 public class JustPublishedMessagePanel extends Panel {
@@ -88,6 +92,23 @@ public class JustPublishedMessagePanel extends Panel {
         introBox.add(new ExternalLink("profile-link", introProfileUrl));
         add(introBox);
 
-        setVisible(justPublished || showIntroWarning);
+        // --- Pending-approval notice: the user has published an introduction, but no
+        // approved user has approved it yet, and they hold no approved key elsewhere
+        // either (issue #625). Until approval, their self-signed contributions count
+        // as pending: they show up marked ⏳ in role listings (e.g. the observers
+        // table) and on their own page, but stay hidden where approval is required.
+        // Shown on every page, like the intro warning; it disappears once the
+        // introduction is approved (via the periodic user-data refresh). Users with
+        // an approved key elsewhere are not in this pending state — their local-key
+        // situation is covered by the About-page recommendations instead. ---
+        boolean anyApprovedKey = session.getUserIri() != null
+                && !User.getPubkeyhashes(session.getUserIri(), true).isEmpty();
+        boolean showPendingNotice = canPublishIntro && hasLocalIntro && !anyApprovedKey;
+        WebMarkupContainer pendingBox = new WebMarkupContainer("pendingBox");
+        pendingBox.setVisible(showPendingNotice);
+        pendingBox.add(new ExternalLink("about-link", introProfileUrl));
+        add(pendingBox);
+
+        setVisible(justPublished || showIntroWarning || showPendingNotice);
     }
 }

--- a/src/main/java/com/knowledgepixels/nanodash/component/JustPublishedMessagePanel.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/JustPublishedMessagePanel.java
@@ -30,10 +30,10 @@ import com.knowledgepixels.nanodash.page.UserPage;
  *       <em>every</em> page (no close button) whenever a logged-in user with a
  *       local key has not yet published an introduction linking that key to their
  *       ORCID. It disappears only once such an introduction is published; and</li>
- *   <li>an amber "your account is pending approval" notice box, shown on
- *       <em>every</em> page whenever the user has an introduction but no approved
- *       key yet (issue #625): their self-signed contributions are marked as
- *       pending (⏳) until an approved user approves their introduction.</li>
+ *   <li>an amber "your account is pending" notice box, shown on <em>every</em>
+ *       page whenever the user has an introduction but no approved key yet
+ *       (issue #625), asking them to share their introduction so an approved
+ *       user can approve it.</li>
  * </ul>
  */
 public class JustPublishedMessagePanel extends Panel {

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -2102,6 +2102,12 @@ hr {
   border-color: #A0120840;
 }
 
+/* Amber variant for the "account pending approval" notice box (issue #625). */
+.titlebar-message-box-pending {
+  background: #B075001A;
+  border-color: #B0750040;
+}
+
 .titlebar-message-close {
   position: absolute;
   right: 8px;


### PR DESCRIPTION
Closes #625. Companion to knowledgepixels/nanopub-query#195 (`npa:PendingAccountState` materialization, deployed): introduced-but-unapproved users were invisible — their self-signed participation roles showed up nowhere, and view displays they published for their own profile never rendered.

## Changes

- **`get-view-displays` superseded** → `RA3ekD-2utY7…` (source: `docs/queries/get-view-displays-pending-arm.trig`): the authority gate's own-page arm additionally accepts `npa:PendingAccountState` rows, so an unapproved user's own page shows the view displays they signed themselves. Display-only — the pending class is distinct from `npa:AccountState`, so the admin/maintainer arm and governed-version resolution keep requiring approved accounts. Validated byte-identical to the previous head across approved resources.
- **`list-space-observers` superseded** → `RARcL1s1A1Fi…` (source: `docs/queries/list-space-observers-ref-v7.trig`): headerless flag column is now three-state — empty = approved-validated, ⏳ = pending-validated (`npa:trustStatus npa:seen` on the materialized instantiation), ⚠️ = not validated at all. Verified live on ko2025lecture9 (3 pending participants flagged) plus 8 other spaces with unchanged results.
- **Pending-approval notice**: third title-bar message box for users with an introduction but no approved key — asking them to share their introduction so an approved user can approve it. Users holding an approved key elsewhere are excluded (the About-page recommendations cover that case).

Both superseding queries are **published**; the `QueryApiAccess` constants pin the new heads, so this is safe to deploy any time.

## Verified

- Live: the three pending self-signed participants of `spaces/knowledgepixels/ko2025lecture9` appear ⏳-flagged in the published observers query; approved members unchanged.
- Regression: both new queries byte-identical (modulo `group_concat` ordering) to their predecessors on approved resources/spaces.
- Still pending render-verification on a deployed instance: the ⏳ column styling, the banner, and a pending user's own-page view display (no pending user has published one live yet; that path was validated on nanopub-query's local test instance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
