### PR TITLE
feat: never-evicting per-entry store behind the API cache

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -296,6 +296,11 @@
         <version>3.5.5</version>
         <configuration>
           <argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar} -Djava.awt.headless=true</argLine>
+          <environmentVariables>
+            <!-- Tests that start a WicketApplication must not read or write the developer's
+                 real API cache persistence (snapshot file and entry store) in ~/.nanopub. -->
+            <NANODASH_API_CACHE_FILE>none</NANODASH_API_CACHE_FILE>
+          </environmentVariables>
         </configuration>
       </plugin>
       <plugin>

--- a/src/main/java/com/knowledgepixels/nanodash/ApiCache.java
+++ b/src/main/java/com/knowledgepixels/nanodash/ApiCache.java
@@ -99,6 +99,44 @@ public class ApiCache {
     }
 
     /**
+     * Fills a memory miss from the per-entry store (see
+     * {@link ApiCachePersistence#loadEntry}): the stored response goes back into the
+     * in-memory cache with its <em>original</em> refresh timestamp, so the normal staleness
+     * logic takes over from there — the restored content is served while anything older than
+     * {@link #REFRESH_AGE_THRESHOLD_MS} re-fetches in the background. This is what makes
+     * memory eviction invisible to callers: the persistent tier never evicts, so content
+     * that once arrived stays available (however outdated) until a re-fetch replaces it.
+     * A timestamp from the future (a clock jump) is not adopted, leaving the entry to count
+     * as stale rather than as fresh indefinitely.
+     *
+     * @param cacheId the cache id (the query's URL string)
+     * @return the restored response, or null if the store has none
+     */
+    private static ApiResponse loadResponseFromStore(String cacheId) {
+        ApiCachePersistence.PersistedEntry entry = ApiCachePersistence.loadEntry(cacheId);
+        if (entry == null || !(entry.value instanceof ApiResponse response)) return null;
+        cachedResponses.put(cacheId, response);
+        if (entry.lastRefresh <= System.currentTimeMillis()) {
+            lastRefresh.putIfAbsent(cacheId, entry.lastRefresh);
+        }
+        return response;
+    }
+
+    /**
+     * The map counterpart of {@link #loadResponseFromStore(String)}.
+     */
+    @SuppressWarnings("unchecked")
+    private static Map<String, String> loadMapFromStore(String cacheId) {
+        ApiCachePersistence.PersistedEntry entry = ApiCachePersistence.loadEntry(cacheId);
+        if (entry == null || !(entry.value instanceof Map<?, ?> map)) return null;
+        cachedMaps.put(cacheId, (Map<String, String>) map);
+        if (entry.lastRefresh <= System.currentTimeMillis()) {
+            lastRefresh.putIfAbsent(cacheId, entry.lastRefresh);
+        }
+        return (Map<String, String>) map;
+    }
+
+    /**
      * Checks if a cache refresh is currently running for the given cache ID.
      *
      * @param cacheId The unique identifier for the cache.
@@ -168,14 +206,19 @@ public class ApiCache {
         }
         String cacheId = queryRef.getAsUrlString();
         logger.info("Updating cached API response for {}", cacheId);
+        long timeNow = System.currentTimeMillis();
         cachedResponses.put(cacheId, response);
-        lastRefresh.put(cacheId, System.currentTimeMillis());
+        lastRefresh.put(cacheId, timeNow);
+        ApiCachePersistence.storeEntry(cacheId, response, timeNow);
     }
 
     public static ApiResponse retrieveResponseSync(QueryRef queryRef, boolean forced) {
         long timeNow = System.currentTimeMillis();
         String cacheId = queryRef.getAsUrlString();
         logger.debug("Retrieving cached API response synchronously for {}", cacheId);
+        if (cachedResponses.getIfPresent(cacheId) == null) {
+            loadResponseFromStore(cacheId);
+        }
         boolean needsRefresh = true;
         if (cachedResponses.getIfPresent(cacheId) != null) {
             // lastRefresh can be missing for a cached entry (racing invalidation or
@@ -297,6 +340,9 @@ public class ApiCache {
             forcedRefresh.add(cacheId);
         }
         boolean forced = forcedRefresh.contains(cacheId);
+        if (cachedResponses.getIfPresent(cacheId) == null) {
+            loadResponseFromStore(cacheId);
+        }
         boolean isCached = false;
         boolean needsRefresh = true;
         if (cachedResponses.getIfPresent(cacheId) != null) {
@@ -366,8 +412,10 @@ public class ApiCache {
             map.put(resultEntry.get("key"), resultEntry.get("value"));
         }
         String cacheId = queryRef.getAsUrlString();
+        long timeNow = System.currentTimeMillis();
         cachedMaps.put(cacheId, map);
-        lastRefresh.put(cacheId, System.currentTimeMillis());
+        lastRefresh.put(cacheId, timeNow);
+        ApiCachePersistence.storeEntry(cacheId, (Serializable) map, timeNow);
     }
 
     /**
@@ -383,6 +431,9 @@ public class ApiCache {
         if (isForcedReload(cacheId)) {
             cachedMaps.invalidate(cacheId);
             lastRefresh.remove(cacheId);
+        }
+        if (cachedMaps.getIfPresent(cacheId) == null) {
+            loadMapFromStore(cacheId);
         }
         boolean isCached = false;
         boolean needsRefresh = true;
@@ -519,7 +570,9 @@ public class ApiCache {
 
     /**
      * Returns whatever response is cached for a query reference, however outdated, without
-     * triggering a refresh or any other side effect. Meant for showing the previous content
+     * triggering a refresh. A memory miss falls through to the per-entry store, which never
+     * evicts, so this finds any response that ever arrived for the query — restored quickly
+     * from a local file, never the network. Meant for showing the previous content
      * while a refresh is in flight (issue #599) — never as a substitute for the current data,
      * which is what {@link #retrieveResponseAsync(QueryRef)} and
      * {@link #retrieveResponseSync(QueryRef, boolean)} return.
@@ -528,7 +581,10 @@ public class ApiCache {
      * @return The cached response of any age, or null if nothing is cached.
      */
     public static ApiResponse retrieveStaleResponse(QueryRef queryRef) {
-        return cachedResponses.getIfPresent(queryRef.getAsUrlString());
+        String cacheId = queryRef.getAsUrlString();
+        ApiResponse response = cachedResponses.getIfPresent(cacheId);
+        if (response != null) return response;
+        return loadResponseFromStore(cacheId);
     }
 
     /**
@@ -621,6 +677,28 @@ public class ApiCache {
             count++;
         }
         return count;
+    }
+
+    /**
+     * Copies a restored snapshot's entries into the per-entry store, so content saved by a
+     * version from before the store existed is not lost to memory eviction again. Entries
+     * the store already has are left alone (its version is at least as new), and no age
+     * limit applies — unlike the in-memory import, the store keeps everything. Meant to run
+     * once at startup, right after the snapshot file is read.
+     *
+     * @param snapshot the restored snapshot
+     */
+    static void backfillEntryStore(Snapshot snapshot) {
+        for (Map.Entry<String, ApiResponse> e : snapshot.responses.entrySet()) {
+            Long t = snapshot.refreshTimes.get(e.getKey());
+            if (t == null || e.getValue() == null) continue;
+            ApiCachePersistence.storeEntryIfAbsent(e.getKey(), e.getValue(), t);
+        }
+        for (Map.Entry<String, Map<String, String>> e : snapshot.maps.entrySet()) {
+            Long t = snapshot.refreshTimes.get(e.getKey());
+            if (t == null || e.getValue() == null) continue;
+            ApiCachePersistence.storeEntryIfAbsent(e.getKey(), (Serializable) e.getValue(), t);
+        }
     }
 
     /**

--- a/src/main/java/com/knowledgepixels/nanodash/ApiCachePersistence.java
+++ b/src/main/java/com/knowledgepixels/nanodash/ApiCachePersistence.java
@@ -12,9 +12,12 @@ import java.io.FileOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -28,7 +31,17 @@ import java.util.concurrent.TimeUnit;
  * restored ones are served — instead of starting cold and re-fetching everything from the
  * query API and the registry at once.
  *
- * <p>The snapshot is a cache, not a store of record: a missing, corrupt, or (after a library
+ * <p>Next to the snapshot file sits a per-entry store (a directory of one small file per
+ * query response or map), from which the persistent tier never evicts: every successful
+ * fetch overwrites its entry, and nothing is ever aged out. The in-memory caches keep their
+ * bounded size and idle expiry; when a request misses there, {@link ApiCache} reads the
+ * entry back from this store with its original timestamp, so the stored content is shown
+ * right away while the usual staleness logic re-queries in the background. Without this
+ * tier, memory eviction used to propagate into the snapshot (which only captured what was
+ * still in memory), so rarely visited pages came back from a restart with a blank loading
+ * state instead of their previous content.</p>
+ *
+ * <p>Both tiers are caches, not stores of record: a missing, corrupt, or (after a library
  * upgrade) unreadable file only means starting cold, never failing startup. The default file
  * location is inside {@code ~/.nanopub}, which the standard Docker setup already mounts as a
  * volume, so deployments get persistence without any configuration.</p>
@@ -53,6 +66,10 @@ public class ApiCachePersistence {
 
     private static ScheduledExecutorService scheduler;
     private static File snapshotFile;
+
+    // Directory of the per-entry store; null while persistence is not (yet) initialized,
+    // which makes all entry-store operations no-ops.
+    private static volatile File entryStoreDir;
 
     /**
      * The root object written to the snapshot file: the query cache content together with
@@ -94,6 +111,7 @@ public class ApiCachePersistence {
             return;
         }
         snapshotFile = new File(path);
+        entryStoreDir = new File(path + ".d");
         load(snapshotFile);
         scheduler = Executors.newSingleThreadScheduledExecutor((r) -> {
             Thread t = new Thread(r, "nanodash-cache-persistence");
@@ -134,10 +152,12 @@ public class ApiCachePersistence {
                 int viewCount = state.views == null ? 0 : View.importViews(state.views);
                 logger.info("Restored {} cached query results, {} cached nanopubs, {} views and {} view resolutions from {}",
                         queryCount, npCount, viewCount, resolvedCount, file);
+                ApiCache.backfillEntryStore(state.queryCache);
             } else if (obj instanceof ApiCache.Snapshot snapshot) {
                 // A file from before the snapshot also carried the nanopub cache.
                 int count = ApiCache.importSnapshot(snapshot, MAX_SNAPSHOT_AGE_MS);
                 logger.info("Restored {} cached query results from {}", count, file);
+                ApiCache.backfillEntryStore(snapshot);
             } else {
                 logger.warn("Ignoring cache snapshot file {} with unexpected content", file);
             }
@@ -175,6 +195,127 @@ public class ApiCachePersistence {
             logger.debug("Saved {} cached query results and {} cached nanopubs to {}", snapshot.size(), nanopubs.size(), file);
         } catch (Exception ex) {
             logger.warn("Could not write cache snapshot file {}: {}", file, ex.toString());
+        }
+    }
+
+    /**
+     * One entry of the per-entry store: a query response or map together with the cache id
+     * it belongs to and when it was last refreshed. The cache id is stored inside the file
+     * (whose name is only a hash of it) so a read can verify it got the entry it asked for.
+     */
+    static class PersistedEntry implements Serializable {
+
+        private static final long serialVersionUID = 1L;
+
+        final String cacheId;
+        final long lastRefresh;
+        final Serializable value;
+
+        private PersistedEntry(String cacheId, Serializable value, long lastRefresh) {
+            this.cacheId = cacheId;
+            this.value = value;
+            this.lastRefresh = lastRefresh;
+        }
+
+    }
+
+    /**
+     * Points the per-entry store at the given directory (null disables it). Normally set by
+     * {@link #init()}; exposed for tests.
+     *
+     * @param dir the store directory, or null to disable the store
+     */
+    static void initEntryStore(File dir) {
+        entryStoreDir = dir;
+    }
+
+    /**
+     * Writes one cache entry to the per-entry store, replacing any previous version of it.
+     * Called for every successfully fetched query response or map, so the store always holds
+     * the latest content that ever arrived for each query — this tier never evicts. Written
+     * atomically (unique temporary file, then move), so concurrent writers and a crash
+     * mid-write can at worst leave the previous version in place. A no-op while persistence
+     * is disabled; any failure is logged and otherwise ignored.
+     *
+     * @param cacheId         the cache id (the query's URL string)
+     * @param value           the response or map to store
+     * @param lastRefreshTime when the content was fetched
+     */
+    static void storeEntry(String cacheId, Serializable value, long lastRefreshTime) {
+        File dir = entryStoreDir;
+        if (dir == null) return;
+        try {
+            dir.mkdirs();
+            File file = new File(dir, entryFileName(cacheId));
+            File tmpFile = new File(dir, file.getName() + ".tmp." + Thread.currentThread().threadId() + "." + System.nanoTime());
+            try (ObjectOutputStream out = new ObjectOutputStream(new BufferedOutputStream(new FileOutputStream(tmpFile)))) {
+                out.writeObject(new PersistedEntry(cacheId, value, lastRefreshTime));
+            }
+            try {
+                Files.move(tmpFile.toPath(), file.toPath(), StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+            } catch (AtomicMoveNotSupportedException ex) {
+                Files.move(tmpFile.toPath(), file.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            }
+        } catch (Exception ex) {
+            logger.warn("Could not write cache entry for {}: {}", cacheId, ex.toString());
+        }
+    }
+
+    /**
+     * Writes one cache entry to the per-entry store only if the store has none for that id
+     * yet. Used to backfill the store from a snapshot file at startup without overwriting
+     * entries the store may hold in a newer version.
+     *
+     * @param cacheId         the cache id (the query's URL string)
+     * @param value           the response or map to store
+     * @param lastRefreshTime when the content was fetched
+     */
+    static void storeEntryIfAbsent(String cacheId, Serializable value, long lastRefreshTime) {
+        File dir = entryStoreDir;
+        if (dir == null) return;
+        if (new File(dir, entryFileName(cacheId)).isFile()) return;
+        storeEntry(cacheId, value, lastRefreshTime);
+    }
+
+    /**
+     * Reads one cache entry back from the per-entry store, however old it may be — age is
+     * the caller's concern, this tier never evicts. An unreadable file (corrupt, written by
+     * an incompatible earlier version, or a hash collision) is deleted, since it can never
+     * be read again and its slot is rewritten on the next successful fetch anyway.
+     *
+     * @param cacheId the cache id (the query's URL string)
+     * @return the stored entry, or null if the store has none (or persistence is disabled)
+     */
+    static PersistedEntry loadEntry(String cacheId) {
+        File dir = entryStoreDir;
+        if (dir == null) return null;
+        File file = new File(dir, entryFileName(cacheId));
+        if (!file.isFile()) return null;
+        try (ObjectInputStream in = new ObjectInputStream(new BufferedInputStream(new FileInputStream(file)))) {
+            if (in.readObject() instanceof PersistedEntry entry && cacheId.equals(entry.cacheId)) {
+                return entry;
+            }
+        } catch (Exception ex) {
+            logger.warn("Could not read cache entry file {}: {}", file, ex.toString());
+        }
+        file.delete();
+        return null;
+    }
+
+    /**
+     * The store file name for a cache id: a hash, since cache ids are URL strings of
+     * arbitrary length and content.
+     */
+    private static String entryFileName(String cacheId) {
+        try {
+            byte[] hash = MessageDigest.getInstance("SHA-256").digest(cacheId.getBytes(StandardCharsets.UTF_8));
+            StringBuilder sb = new StringBuilder(hash.length * 2);
+            for (byte b : hash) {
+                sb.append(Character.forDigit((b >> 4) & 0xF, 16)).append(Character.forDigit(b & 0xF, 16));
+            }
+            return sb.append(".ser").toString();
+        } catch (NoSuchAlgorithmException ex) {
+            throw new RuntimeException(ex); // SHA-256 is guaranteed to exist
         }
     }
 

--- a/src/test/java/com/knowledgepixels/nanodash/ApiCachePersistenceTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/ApiCachePersistenceTest.java
@@ -1,11 +1,14 @@
 package com.knowledgepixels.nanodash;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.MockedStatic;
 import org.nanopub.extra.services.ApiResponse;
 import org.nanopub.extra.services.ApiResponseEntry;
+import org.nanopub.extra.services.QueryRef;
 
 import com.google.common.cache.Cache;
 
@@ -18,6 +21,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mockStatic;
 
 class ApiCachePersistenceTest {
 
@@ -41,6 +45,13 @@ class ApiCachePersistenceTest {
         Field f = Utils.class.getDeclaredField("nanopubs");
         f.setAccessible(true);
         ((Cache<?, ?>) f.get(null)).invalidateAll();
+        // The entry store is global too; tests that need it point it at their temp dir.
+        ApiCachePersistence.initEntryStore(null);
+    }
+
+    @AfterEach
+    void tearDown() {
+        ApiCachePersistence.initEntryStore(null);
     }
 
     private void resetMap(String fieldName) throws Exception {
@@ -214,6 +225,135 @@ class ApiCachePersistenceTest {
 
         ConcurrentMap<String, ApiResponse> cachedResponses = getMap("cachedResponses");
         assertSame(current, cachedResponses.get(RESPONSE_ID));
+    }
+
+    private File initEntryStore() {
+        File storeDir = new File(tempDir, "store");
+        ApiCachePersistence.initEntryStore(storeDir);
+        return storeDir;
+    }
+
+    @Test
+    @DisplayName("entry store should round-trip a response with its refresh timestamp")
+    void entryStoreRoundTrip() {
+        initEntryStore();
+        long refreshTime = System.currentTimeMillis() - 5000L;
+        ApiCachePersistence.storeEntry(RESPONSE_ID, makeResponse("stored"), refreshTime);
+
+        ApiCachePersistence.PersistedEntry entry = ApiCachePersistence.loadEntry(RESPONSE_ID);
+        assertNotNull(entry);
+        assertEquals(RESPONSE_ID, entry.cacheId);
+        assertEquals(refreshTime, entry.lastRefresh);
+        assertEquals("stored", ((ApiResponse) entry.value).getData().getFirst().get("thing"));
+    }
+
+    @Test
+    @DisplayName("entry store should be a no-op while not initialized")
+    void entryStoreDisabledWithoutInit() {
+        ApiCachePersistence.storeEntry(RESPONSE_ID, makeResponse("ignored"), System.currentTimeMillis());
+        assertNull(ApiCachePersistence.loadEntry(RESPONSE_ID));
+        assertFalse(new File(tempDir, "store").exists());
+    }
+
+    @Test
+    @DisplayName("retrieveStaleResponse should fall through to the entry store on a memory miss")
+    void staleResponseReadsThroughToStore() throws Exception {
+        initEntryStore();
+        QueryRef queryRef = new QueryRef(RESPONSE_ID);
+        String cacheId = queryRef.getAsUrlString();
+        long refreshTime = System.currentTimeMillis() - 3L * 24 * 60 * 60 * 1000; // way beyond memory expiry
+        ApiCachePersistence.storeEntry(cacheId, makeResponse("evicted-but-stored"), refreshTime);
+
+        ApiResponse result = ApiCache.retrieveStaleResponse(queryRef);
+
+        assertNotNull(result);
+        assertEquals("evicted-but-stored", result.getData().getFirst().get("thing"));
+        // The entry is back in memory with its original timestamp, so the normal
+        // staleness logic takes over from here.
+        assertNotNull(this.<String, ApiResponse>getMap("cachedResponses").get(cacheId));
+        assertEquals(refreshTime, this.<String, Long>getMap("lastRefresh").get(cacheId));
+    }
+
+    @Test
+    @DisplayName("retrieveResponseSync should serve a stored entry without calling the API")
+    void syncReadsThroughToStoreWithoutApiCall() {
+        initEntryStore();
+        QueryRef queryRef = new QueryRef(RESPONSE_ID);
+        String cacheId = queryRef.getAsUrlString();
+        // Fresh enough that no background refresh is due, so the call is fully deterministic.
+        ApiCachePersistence.storeEntry(cacheId, makeResponse("from-store"), System.currentTimeMillis() - 5000L);
+
+        try (MockedStatic<QueryApiAccess> queryApiAccess = mockStatic(QueryApiAccess.class)) {
+            ApiResponse result = ApiCache.retrieveResponseSync(queryRef, false);
+
+            assertNotNull(result);
+            assertEquals("from-store", result.getData().getFirst().get("thing"));
+            queryApiAccess.verifyNoInteractions();
+        }
+    }
+
+    @Test
+    @DisplayName("retrieveMap should serve a stored map without calling the API")
+    void mapReadsThroughToStoreWithoutApiCall() {
+        initEntryStore();
+        QueryRef queryRef = new QueryRef(MAP_ID);
+        String cacheId = queryRef.getAsUrlString();
+        HashMap<String, String> map = new HashMap<>();
+        map.put("key1", "value1");
+        ApiCachePersistence.storeEntry(cacheId, map, System.currentTimeMillis() - 5000L);
+
+        try (MockedStatic<QueryApiAccess> queryApiAccess = mockStatic(QueryApiAccess.class)) {
+            Map<String, String> result = ApiCache.retrieveMap(queryRef);
+
+            assertEquals(map, result);
+            queryApiAccess.verifyNoInteractions();
+        }
+    }
+
+    @Test
+    @DisplayName("storeEntryIfAbsent should not overwrite an existing entry")
+    void storeEntryIfAbsentKeepsExisting() {
+        initEntryStore();
+        ApiCachePersistence.storeEntry(RESPONSE_ID, makeResponse("existing"), 1000L);
+        ApiCachePersistence.storeEntryIfAbsent(RESPONSE_ID, makeResponse("newcomer"), 2000L);
+
+        ApiCachePersistence.PersistedEntry entry = ApiCachePersistence.loadEntry(RESPONSE_ID);
+        assertEquals("existing", ((ApiResponse) entry.value).getData().getFirst().get("thing"));
+    }
+
+    @Test
+    @DisplayName("loadEntry should delete an unreadable entry file and report a miss")
+    void corruptEntryFileIsDeletedOnRead() throws Exception {
+        File storeDir = initEntryStore();
+        ApiCachePersistence.storeEntry(RESPONSE_ID, makeResponse("soon-corrupt"), System.currentTimeMillis());
+        File[] files = storeDir.listFiles();
+        assertEquals(1, files.length);
+        Files.write(files[0].toPath(), new byte[] {1, 2, 3, 4, 5});
+
+        assertNull(ApiCachePersistence.loadEntry(RESPONSE_ID));
+        assertFalse(files[0].isFile(), "the useless file should be gone");
+    }
+
+    @Test
+    @DisplayName("load should backfill the entry store from the snapshot file")
+    void loadBackfillsEntryStore() throws Exception {
+        putCachedResponse(RESPONSE_ID, makeResponse("snapshot-only"), 5000L);
+        Map<String, String> map = new HashMap<>();
+        map.put("key1", "value1");
+        putCachedMap(MAP_ID, map, 5000L);
+        File file = new File(tempDir, "cache.ser");
+        ApiCachePersistence.save(file);
+
+        setUp();
+        initEntryStore();
+        ApiCachePersistence.load(file);
+
+        ApiCachePersistence.PersistedEntry responseEntry = ApiCachePersistence.loadEntry(RESPONSE_ID);
+        assertNotNull(responseEntry);
+        assertEquals("snapshot-only", ((ApiResponse) responseEntry.value).getData().getFirst().get("thing"));
+        ApiCachePersistence.PersistedEntry mapEntry = ApiCachePersistence.loadEntry(MAP_ID);
+        assertNotNull(mapEntry);
+        assertEquals(map, mapEntry.value);
     }
 
 }


### PR DESCRIPTION
Follow-up to #570. The persistent cache only captured what was still in the in-memory caches at save time, so their 24h idle expiry propagated into the snapshot: space and maintained-resource pages not visited for a day of runtime came back from a restart with a blank loading state instead of their previous content (user pages mostly escaped this because their few pages are visited often and their cache keys are stable).

**What this adds**

- **Per-entry store**: a directory next to the snapshot file (`<apiCacheFile>.d/`, default `~/.nanopub/nanodash-api-cache.ser.d/`) with one small file per query response or map, named by a SHA-256 of the cache id. Every successful fetch overwrites its entry (atomic tmp+move). This tier **never evicts** — content that once arrived stays available until a re-fetch replaces it.
- **Read-through on memory miss**: `retrieveStaleResponse`, `retrieveResponseSync`, `retrieveResponseAsync`, and `retrieveMap` fall through to the store and re-insert the entry with its *original* timestamp, so the existing stale-while-revalidate logic serves the stored content immediately while re-querying in the background. No display-layer changes needed.
- **Backfill at startup**: the store is populated from the snapshot file, so content saved by versions from before the store existed carries over.
- The in-memory caches keep their bounded size and 24h idle expiry; the 5-min snapshot file stays as the bulk warm-boot path (and remains the only persistence for nanopubs and views).
- **Test isolation**: surefire now sets `NANODASH_API_CACHE_FILE=none` — tests starting a `WicketApplication` were reading and writing the developer's real snapshot in `~/.nanopub`, which would become permanent pollution with a never-evicting store.

**Verified**

- Full test suite passes (1184 tests, 8 new: store round-trip, read-through without API calls, backfill on load, corrupt-file deletion, if-absent semantics, disabled-store no-ops).
- E2E on an isolated instance: with the snapshot file deleted and only the store present, space, maintained-resource, and user pages all rendered their full content with no spinners, while background refreshes updated the served entries and rewrote their store files.

**Trade-off**: the store grows monotonically (a few KB per distinct query+params ever issued); housekeeping can be layered on later without touching the read/write paths. Not addressed here: the multi-ref representative-root flip still makes a space page cold once per flip, since the new `root_np` cache key has never been fetched — possible follow-up is a seed fallback to other known ref roots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)